### PR TITLE
Fix distributed

### DIFF
--- a/src/grid.hpp
+++ b/src/grid.hpp
@@ -346,6 +346,7 @@ public:
 #endif
 	space_vector get_cell_center(integer i, integer j, integer k);
 	gravity_boundary_type get_gravity_boundary(const geo::direction& dir, bool is_local);
+	neighbor_gravity_type fill_received_array(neighbor_gravity_type raw_input);
     void allocate();
     void reconstruct();
     void store();

--- a/src/grid.hpp
+++ b/src/grid.hpp
@@ -347,6 +347,8 @@ public:
 	space_vector get_cell_center(integer i, integer j, integer k);
 	gravity_boundary_type get_gravity_boundary(const geo::direction& dir, bool is_local);
 	neighbor_gravity_type fill_received_array(neighbor_gravity_type raw_input);
+
+    const std::vector<boundary_interaction_type>& get_ilist_n_bnd(const geo::direction &dir);
     void allocate();
     void reconstruct();
     void store();

--- a/src/grid_fmm.cpp
+++ b/src/grid_fmm.cpp
@@ -1808,3 +1808,8 @@ neighbor_gravity_type grid::fill_received_array(neighbor_gravity_type raw_input)
     }
     return filled_array;
 }
+
+const std::vector<boundary_interaction_type>& grid::get_ilist_n_bnd(const geo::direction &dir)
+{
+    return ilist_n_bnd[dir];
+}

--- a/src/grid_fmm.cpp
+++ b/src/grid_fmm.cpp
@@ -1732,38 +1732,38 @@ gravity_boundary_type grid::get_gravity_boundary(const geo::direction& dir, bool
     auto& mon = *mon_ptr;
     if (!is_local) {
         data.allocate();
-        constexpr size_t blocksize = INX * INX * INX;
-        if (is_leaf) {
-            data.m->reserve(blocksize);
-            for (auto i = 0; i < blocksize; ++i) {
-                data.m->push_back(mon[i]);
-            }
-        } else {
-            data.M->reserve(blocksize);
-            data.x->reserve(blocksize);
-            for (auto i = 0; i < blocksize; ++i) {
-                data.M->push_back(M[i]);
-                data.x->push_back((*(com_ptr[0]))[i]);
-            }
-        }
-        // integer iter = 0;
-        // const std::vector<boundary_interaction_type>& list = ilist_n_bnd[dir.flip()];
+        // constexpr size_t blocksize = INX * INX * INX;
         // if (is_leaf) {
-        //     data.m->reserve(list.size());
-        //     for (auto i : list) {
-        //         const integer iii = i.second;
-        //         data.m->push_back(mon[iii]);
+        //     data.m->reserve(blocksize);
+        //     for (auto i = 0; i < blocksize; ++i) {
+        //         data.m->push_back(mon[i]);
         //     }
         // } else {
-        //     data.M->reserve(list.size());
-        //     data.x->reserve(list.size());
-        //     for (auto i : list) {
-        //         const integer iii = i.second;
-        //         const integer top = M[iii].size();
-        //         data.M->push_back(M[iii]);
-        //         data.x->push_back((*(com_ptr[0]))[iii]);
+        //     data.M->reserve(blocksize);
+        //     data.x->reserve(blocksize);
+        //     for (auto i = 0; i < blocksize; ++i) {
+        //         data.M->push_back(M[i]);
+        //         data.x->push_back((*(com_ptr[0]))[i]);
         //     }
         // }
+        integer iter = 0;
+        const std::vector<boundary_interaction_type>& list = ilist_n_bnd[dir.flip()];
+        if (is_leaf) {
+            data.m->reserve(list.size());
+            for (auto i : list) {
+                const integer iii = i.second;
+                data.m->push_back(mon[iii]);
+            }
+        } else {
+            data.M->reserve(list.size());
+            data.x->reserve(list.size());
+            for (auto i : list) {
+                const integer iii = i.second;
+                const integer top = M[iii].size();
+                data.M->push_back(M[iii]);
+                data.x->push_back((*(com_ptr[0]))[iii]);
+            }
+        }
     } else {
         if (is_leaf) {
             data.m = mon_ptr;
@@ -1774,4 +1774,37 @@ gravity_boundary_type grid::get_gravity_boundary(const geo::direction& dir, bool
     }
     PROF_END;
     return data;
+}
+
+neighbor_gravity_type grid::fill_received_array(neighbor_gravity_type raw_input) {
+    const std::vector<boundary_interaction_type>& list = ilist_n_bnd[raw_input.direction];
+    neighbor_gravity_type filled_array;
+    filled_array.data.allocate();
+    constexpr size_t blocksize = INX * INX * INX;
+    filled_array.direction = raw_input.direction;
+    filled_array.is_monopole = raw_input.is_monopole;
+    if (raw_input.is_monopole) {
+        // fill with unimportant data
+        filled_array.data.m->resize(blocksize);
+        // Overwrite data that matters
+        int counter = 0;
+        for (auto i : list) {
+            const integer iii = i.second;
+            filled_array.data.m->at(iii) = raw_input.data.m->at(counter);
+            counter++;
+        }
+     } else {
+        // fill with unimportant data
+        filled_array.data.M->resize(blocksize);
+        filled_array.data.x->resize(blocksize);
+        // Overwrite data that matters
+        int counter = 0;
+        for (auto i : list) {
+            const integer iii = i.second;
+            filled_array.data.M->at(iii) = raw_input.data.M->at(counter);
+            filled_array.data.x->at(iii) = raw_input.data.x->at(counter);
+            counter++;
+        }
+    }
+    return filled_array;
 }

--- a/src/grid_fmm.cpp
+++ b/src/grid_fmm.cpp
@@ -1733,37 +1733,34 @@ gravity_boundary_type grid::get_gravity_boundary(const geo::direction& dir, bool
     if (!is_local) {
         data.allocate();
         constexpr size_t blocksize = INX * INX * INX;
+        const std::vector<boundary_interaction_type>& list = ilist_n_bnd[dir.flip()];
         if (is_leaf) {
+            integer counter = 0;
             data.m->reserve(blocksize);
-            for (auto i = 0; i < blocksize; ++i) {
-                data.m->push_back(mon[i]);
+            for (auto i : list) {
+                counter++;
+                const integer iii = i.second;
+                data.m->push_back(mon[iii]);
+            }
+            for (auto i = counter; i < blocksize; ++i) {
+                data.m->push_back(0.0);
             }
         } else {
+            integer counter = 0;
             data.M->reserve(blocksize);
             data.x->reserve(blocksize);
-            for (auto i = 0; i < blocksize; ++i) {
-                data.M->push_back(M[i]);
-                data.x->push_back((*(com_ptr[0]))[i]);
+            for (auto i : list) {
+                const integer iii = i.second;
+                const integer top = M[iii].size();
+                counter++;
+                data.M->push_back(M[iii]);
+                data.x->push_back((*(com_ptr[0]))[iii]);
+            }
+            for (auto i = counter; i < blocksize; ++i) {
+                data.M->push_back(expansion());
+                data.x->push_back(space_vector());
             }
         }
-        // integer iter = 0;
-        // const std::vector<boundary_interaction_type>& list = ilist_n_bnd[dir.flip()];
-        // if (is_leaf) {
-        //     data.m->reserve(list.size());
-        //     for (auto i : list) {
-        //         const integer iii = i.second;
-        //         data.m->push_back(mon[iii]);
-        //     }
-        // } else {
-        //     data.M->reserve(list.size());
-        //     data.x->reserve(list.size());
-        //     for (auto i : list) {
-        //         const integer iii = i.second;
-        //         const integer top = M[iii].size();
-        //         data.M->push_back(M[iii]);
-        //         data.x->push_back((*(com_ptr[0]))[iii]);
-        //     }
-        // }
     } else {
         if (is_leaf) {
             data.m = mon_ptr;

--- a/src/grid_fmm.cpp
+++ b/src/grid_fmm.cpp
@@ -1732,24 +1732,38 @@ gravity_boundary_type grid::get_gravity_boundary(const geo::direction& dir, bool
     auto& mon = *mon_ptr;
     if (!is_local) {
         data.allocate();
-        integer iter = 0;
-        const std::vector<boundary_interaction_type>& list = ilist_n_bnd[dir.flip()];
+        constexpr size_t blocksize = INX * INX * INX;
         if (is_leaf) {
-            data.m->reserve(list.size());
-            for (auto i : list) {
-                const integer iii = i.second;
-                data.m->push_back(mon[iii]);
+            data.m->reserve(blocksize);
+            for (auto i = 0; i < blocksize; ++i) {
+                data.m->push_back(mon[i]);
             }
         } else {
-            data.M->reserve(list.size());
-            data.x->reserve(list.size());
-            for (auto i : list) {
-                const integer iii = i.second;
-                const integer top = M[iii].size();
-                data.M->push_back(M[iii]);
-                data.x->push_back((*(com_ptr[0]))[iii]);
+            data.M->reserve(blocksize);
+            data.x->reserve(blocksize);
+            for (auto i = 0; i < blocksize; ++i) {
+                data.M->push_back(M[i]);
+                data.x->push_back((*(com_ptr[0]))[i]);
             }
         }
+        // integer iter = 0;
+        // const std::vector<boundary_interaction_type>& list = ilist_n_bnd[dir.flip()];
+        // if (is_leaf) {
+        //     data.m->reserve(list.size());
+        //     for (auto i : list) {
+        //         const integer iii = i.second;
+        //         data.m->push_back(mon[iii]);
+        //     }
+        // } else {
+        //     data.M->reserve(list.size());
+        //     data.x->reserve(list.size());
+        //     for (auto i : list) {
+        //         const integer iii = i.second;
+        //         const integer top = M[iii].size();
+        //         data.M->push_back(M[iii]);
+        //         data.x->push_back((*(com_ptr[0]))[iii]);
+        //     }
+        // }
     } else {
         if (is_leaf) {
             data.m = mon_ptr;

--- a/src/grid_fmm.cpp
+++ b/src/grid_fmm.cpp
@@ -1733,34 +1733,37 @@ gravity_boundary_type grid::get_gravity_boundary(const geo::direction& dir, bool
     if (!is_local) {
         data.allocate();
         constexpr size_t blocksize = INX * INX * INX;
-        const std::vector<boundary_interaction_type>& list = ilist_n_bnd[dir.flip()];
         if (is_leaf) {
-            integer counter = 0;
             data.m->reserve(blocksize);
-            for (auto i : list) {
-                counter++;
-                const integer iii = i.second;
-                data.m->push_back(mon[iii]);
-            }
-            for (auto i = counter; i < blocksize; ++i) {
-                data.m->push_back(0.0);
+            for (auto i = 0; i < blocksize; ++i) {
+                data.m->push_back(mon[i]);
             }
         } else {
-            integer counter = 0;
             data.M->reserve(blocksize);
             data.x->reserve(blocksize);
-            for (auto i : list) {
-                const integer iii = i.second;
-                const integer top = M[iii].size();
-                counter++;
-                data.M->push_back(M[iii]);
-                data.x->push_back((*(com_ptr[0]))[iii]);
-            }
-            for (auto i = counter; i < blocksize; ++i) {
-                data.M->push_back(expansion());
-                data.x->push_back(space_vector());
+            for (auto i = 0; i < blocksize; ++i) {
+                data.M->push_back(M[i]);
+                data.x->push_back((*(com_ptr[0]))[i]);
             }
         }
+        // integer iter = 0;
+        // const std::vector<boundary_interaction_type>& list = ilist_n_bnd[dir.flip()];
+        // if (is_leaf) {
+        //     data.m->reserve(list.size());
+        //     for (auto i : list) {
+        //         const integer iii = i.second;
+        //         data.m->push_back(mon[iii]);
+        //     }
+        // } else {
+        //     data.M->reserve(list.size());
+        //     data.x->reserve(list.size());
+        //     for (auto i : list) {
+        //         const integer iii = i.second;
+        //         const integer top = M[iii].size();
+        //         data.M->push_back(M[iii]);
+        //         data.x->push_back((*(com_ptr[0]))[iii]);
+        //     }
+        // }
     } else {
         if (is_leaf) {
             data.m = mon_ptr;

--- a/src/interaction_types.hpp
+++ b/src/interaction_types.hpp
@@ -149,7 +149,7 @@ struct boundary_interaction_type
 Vc_DECLARE_ALLOCATOR(boundary_interaction_type)
 
 enum interaction_kernel_type {
-    OLD = 0,
-    SOA_CPU,
+    SOA_CPU = 0,
+    OLD,
     SOA_CUDA
 };

--- a/src/monopole_interactions/calculate_stencil.cpp
+++ b/src/monopole_interactions/calculate_stencil.cpp
@@ -72,7 +72,7 @@ namespace fmm {
                         superimposed_stencil.push_back(stencil_element);
                     }
                 }
-                std::cout << "Stencil size: " << stencils[i].size() << std::endl;
+                // std::cout << "Stencil size: " << stencils[i].size() << std::endl;
             }
             // std::cout << "superimposed_stencil.size(): " << superimposed_stencil.size() <<
             // std::endl;

--- a/src/multipole_interactions/calculate_stencil.cpp
+++ b/src/multipole_interactions/calculate_stencil.cpp
@@ -84,7 +84,7 @@ namespace fmm {
                             stencils[i].stencil_phase_indicator[element_index]);
                     }
                 }
-                std::cout << "Stencil size: " << stencils[i].stencil_elements.size() << std::endl;
+                // std::cout << "Stencil size: " << stencils[i].stencil_elements.size() << std::endl;
             }
             return superimposed_stencil;
         }

--- a/src/multipole_interactions/multipole_interaction_interface.cpp
+++ b/src/multipole_interactions/multipole_interaction_interface.cpp
@@ -14,7 +14,7 @@ namespace octotiger {
 namespace fmm {
     namespace multipole_interactions {
 
-    two_phase_stencil multipole_interaction_interface::stencil;
+        two_phase_stencil multipole_interaction_interface::stencil;
         multipole_interaction_interface::multipole_interaction_interface(void)
           : neighbor_empty_multipole(27)
           , neighbor_empty_monopole(27)
@@ -75,16 +75,20 @@ namespace fmm {
                             local_expansions_SoA.set_AoS_value(std::move(expansion()), flat_index);
                             center_of_masses_SoA.set_AoS_value(
                                 std::move(space_vector()), flat_index);
-                    local_monopoles.at(flat_index) = 0.0;
+                            local_monopoles.at(flat_index) = 0.0;
                         });
                         neighbor_empty_multipole[dir.flat_index_with_center()] = true;
                     } else {
                         std::vector<multipole>& neighbor_M_ptr = *(neighbor.data.M);
                         std::vector<space_vector>& neighbor_com0 = *(neighbor.data.x);
-                        iterate_inner_cells_padding(
-                            dir, [this, neighbor_M_ptr, neighbor_com0](const multiindex<>& i,
-                                     const size_t flat_index, const multiindex<>& i_unpadded,
-                                     const size_t flat_index_unpadded) {
+                        const bool fullsizes = neighbor_M_ptr.size() == INNER_CELLS &&
+                            neighbor_com0.size() == INNER_CELLS;
+                        if (fullsizes) {
+                            iterate_inner_cells_padding(dir, [this, neighbor_M_ptr, neighbor_com0](
+                                                                 const multiindex<>& i,
+                                                                 const size_t flat_index,
+                                                                 const multiindex<>& i_unpadded,
+                                                                 const size_t flat_index_unpadded) {
                                 // local_expansions.at(flat_index) =
                                 //     neighbor_M_ptr.at(flat_index_unpadded);
                                 // center_of_masses.at(flat_index) =
@@ -93,9 +97,30 @@ namespace fmm {
                                     std::move(neighbor_M_ptr.at(flat_index_unpadded)), flat_index);
                                 center_of_masses_SoA.set_AoS_value(
                                     std::move(neighbor_com0.at(flat_index_unpadded)), flat_index);
-                    local_monopoles.at(flat_index) = 0.0;
+                                local_monopoles.at(flat_index) = 0.0;
 
                             });
+                        } else {
+                            auto list = grid_ptr->get_ilist_n_bnd(dir);
+                            size_t counter = 0;
+                            for (auto i : list) {
+                                const integer iii = i.second;
+                                const multiindex<> offset =
+                                    flat_index_to_multiindex_not_padded(iii);
+                                const multiindex<> m(offset.x + INNER_CELLS_PADDING_DEPTH +
+                                        dir[0] * INNER_CELLS_PADDING_DEPTH,
+                                    offset.y + INNER_CELLS_PADDING_DEPTH +
+                                        dir[1] * INNER_CELLS_PADDING_DEPTH,
+                                    offset.z + INNER_CELLS_PADDING_DEPTH +
+                                        dir[2] * INNER_CELLS_PADDING_DEPTH);
+                                const size_t flat_index = to_flat_index_padded(m);
+                                local_expansions_SoA.set_AoS_value(
+                                    std::move(neighbor_M_ptr.at(counter)), flat_index);
+                                center_of_masses_SoA.set_AoS_value(
+                                    std::move(neighbor_com0.at(counter)), flat_index);
+                                counter++;
+                            }
+                        }
                     }
                 } else {
                     neighbor_empty_multipole[dir.flat_index_with_center()] = true;
@@ -111,7 +136,7 @@ namespace fmm {
                             local_expansions_SoA.set_AoS_value(std::move(expansion()), flat_index);
                             center_of_masses_SoA.set_AoS_value(
                                 std::move(space_vector()), flat_index);
-                    local_monopoles.at(flat_index) = 0.0;
+                            local_monopoles.at(flat_index) = 0.0;
 
                         });
                         neighbor_empty_monopole[dir.flat_index_with_center()] = true;
@@ -119,30 +144,60 @@ namespace fmm {
                     } else {
                         // Get multipole data into our input structure
                         std::vector<real>& neighbor_mons = *(neighbor.data.m);
-                        std::vector<space_vector>& neighbor_com0 = *(neighbor.data.x);
-                        iterate_inner_cells_padding(
-                            dir, [this, neighbor_mons, xbase, dx](const multiindex<>& i,
-                                     const size_t flat_index, const multiindex<>& i_unpadded,
-                                     const size_t flat_index_unpadded) {
-                                // local_expansions.at(flat_index) = 0.0;
-                                // center_of_masses.at(flat_index) = 0.0;
+                        const bool fullsizes = neighbor_mons.size() == INNER_CELLS;
+                        if (fullsizes) {
+                            iterate_inner_cells_padding(
+                                dir, [this, neighbor_mons, xbase, dx](const multiindex<>& i,
+                                         const size_t flat_index, const multiindex<>& i_unpadded,
+                                         const size_t flat_index_unpadded) {
+                                    // local_expansions.at(flat_index) = 0.0;
+                                    // center_of_masses.at(flat_index) = 0.0;
 
-                                space_vector e;
-                                e[0] = (i.x) * dx + xbase[0] -
-                                INNER_CELLS_PER_DIRECTION * dx;
-                                e[1] = (i.y) * dx + xbase[1] -
-                                INNER_CELLS_PER_DIRECTION * dx;
-                                e[2] = (i.z) * dx + xbase[2] -
-                                INNER_CELLS_PER_DIRECTION * dx;
-                                center_of_masses_SoA.set_AoS_value(
-                                    std::move(e), flat_index);
-                                // local_monopoles.at(flat_index) =
-                                // neighbor_mons.at(flat_index_unpadded);
-                            local_expansions_SoA.set_AoS_value(std::move(expansion()), flat_index);
-                                // local_expansions_SoA.set_value(
-                                //     std::move(neighbor_mons.at(flat_index_unpadded)), flat_index);
-                    local_monopoles.at(flat_index) = neighbor_mons.at(flat_index_unpadded);
-                            });
+                                    space_vector e;
+                                    e[0] = (i.x) * dx + xbase[0] - INNER_CELLS_PER_DIRECTION * dx;
+                                    e[1] = (i.y) * dx + xbase[1] - INNER_CELLS_PER_DIRECTION * dx;
+                                    e[2] = (i.z) * dx + xbase[2] - INNER_CELLS_PER_DIRECTION * dx;
+                                    center_of_masses_SoA.set_AoS_value(std::move(e), flat_index);
+                                    // local_monopoles.at(flat_index) =
+                                    // neighbor_mons.at(flat_index_unpadded);
+                                    local_expansions_SoA.set_AoS_value(
+                                        std::move(expansion()), flat_index);
+                                    // local_expansions_SoA.set_value(
+                                    //     std::move(neighbor_mons.at(flat_index_unpadded)),
+                                    //     flat_index);
+                                    local_monopoles.at(flat_index) =
+                                        neighbor_mons.at(flat_index_unpadded);
+                                });
+                        } else {
+                            auto list = grid_ptr->get_ilist_n_bnd(dir);
+                            size_t counter = 0;
+                            for (auto i : list) {
+                                const integer iii = i.second;
+                                const multiindex<> offset =
+                                    flat_index_to_multiindex_not_padded(iii);
+                                const multiindex<> m(offset.x + INNER_CELLS_PADDING_DEPTH +
+                                        dir[0] * INNER_CELLS_PADDING_DEPTH,
+                                    offset.y + INNER_CELLS_PADDING_DEPTH +
+                                        dir[1] * INNER_CELLS_PADDING_DEPTH,
+                                    offset.z + INNER_CELLS_PADDING_DEPTH +
+                                        dir[2] * INNER_CELLS_PADDING_DEPTH);
+                                const size_t flat_index = to_flat_index_padded(m);
+                                local_monopoles.at(flat_index) = neighbor_mons.at(counter);
+                                counter++;
+                            }
+                            iterate_inner_cells_padding(
+                                dir, [this, neighbor_mons, xbase, dx](const multiindex<>& i,
+                                         const size_t flat_index, const multiindex<>& i_unpadded,
+                                         const size_t flat_index_unpadded) {
+                                    space_vector e;
+                                    e[0] = (i.x) * dx + xbase[0] - INNER_CELLS_PER_DIRECTION * dx;
+                                    e[1] = (i.y) * dx + xbase[1] - INNER_CELLS_PER_DIRECTION * dx;
+                                    e[2] = (i.z) * dx + xbase[2] - INNER_CELLS_PER_DIRECTION * dx;
+                                    center_of_masses_SoA.set_AoS_value(std::move(e), flat_index);
+                                    local_expansions_SoA.set_AoS_value(
+                                        std::move(expansion()), flat_index);
+                                });
+                        }
                         monopole_neighbors_exist = true;
                         x_skip[z][y][x] = false;
                     }
@@ -168,7 +223,8 @@ namespace fmm {
                 }
             }
 
-            // std::fill(std::begin(potential_expansions), std::end(potential_expansions), ZERO);
+            // std::fill(std::begin(potential_expansions), std::end(potential_expansions),
+            // ZERO);
 
             // std::cout << "local_expansions:" << std::endl;
             // this->print_local_expansions();
@@ -190,13 +246,14 @@ namespace fmm {
                 // if (monopole_neighbors_exist) {
                 //     mixed_interactions_kernel.apply_stencil(local_monopoles,
                 //     local_expansions_SoA,
-                //         center_of_masses_SoA, potential_expansions_SoA, angular_corrections_SoA,
+                //         center_of_masses_SoA, potential_expansions_SoA,
+                //         angular_corrections_SoA,
                 //         stencil_mixed_interactions, type, dX, xBase, x_skip, y_skip, z_skip);
                 // }
                 m2m_kernel kernel(neighbor_empty_multipole);
                 kernel.apply_stencil(local_expansions_SoA, center_of_masses_SoA,
-                                     potential_expansions_SoA, angular_corrections_SoA, local_monopoles,
-                    stencil, type);
+                    potential_expansions_SoA, angular_corrections_SoA, local_monopoles, stencil,
+                    type);
 
                 if (type == RHO) {
                     angular_corrections_SoA.to_non_SoA(grid_ptr->get_L_c());
@@ -211,8 +268,8 @@ namespace fmm {
                     angular_corrections_SoA;
                 m2m_kernel kernel(neighbor_empty_multipole);
                 kernel.apply_stencil(local_expansions_SoA, center_of_masses_SoA,
-                                     potential_expansions_SoA, angular_corrections_SoA, local_monopoles,
-                    stencil, type);
+                    potential_expansions_SoA, angular_corrections_SoA, local_monopoles, stencil,
+                    type);
 
                 std::vector<expansion>& L = grid_ptr->get_L();
                 std::vector<space_vector>& L_c = grid_ptr->get_L_c();
@@ -236,14 +293,16 @@ namespace fmm {
                 struct_of_array_data<space_vector, real, 3, INNER_CELLS, SOA_PADDING>
                     angular_corrections_SoA;
                 // if (monopole_neighbors_exist) {
-                //     mixed_interactions_kernel.apply_stencil(local_monopoles, local_expansions_SoA,
-                //         center_of_masses_SoA, potential_expansions_SoA, angular_corrections_SoA,
+                //     mixed_interactions_kernel.apply_stencil(local_monopoles,
+                //     local_expansions_SoA,
+                //         center_of_masses_SoA, potential_expansions_SoA,
+                //         angular_corrections_SoA,
                 //         stencil_mixed_interactions, type, dX, xBase, x_skip, y_skip, z_skip);
                 // }
                 m2m_kernel kernel(neighbor_empty_multipole);
                 kernel.apply_stencil(local_expansions_SoA, center_of_masses_SoA,
-                                     potential_expansions_SoA, angular_corrections_SoA, local_monopoles,
-                    stencil, type);
+                    potential_expansions_SoA, angular_corrections_SoA, local_monopoles, stencil,
+                    type);
 
                 std::vector<expansion>& L = grid_ptr->get_L();
                 std::vector<space_vector>& L_c = grid_ptr->get_L_c();

--- a/src/node_server.cpp
+++ b/src/node_server.cpp
@@ -661,10 +661,12 @@ void node_server::compute_fmm(gsolve_type type, bool energy_account, bool aonly)
      // now that all boundary information has been processed, signal all non-empty neighbors
      // note that this was done before during boundary calculations
      for (auto const& dir : geo::direction::full_set()) {
+		if (!neighbors[dir].empty()) {
          neighbor_gravity_type &neighbor_data = all_neighbor_interaction_data[dir];
          if (neighbor_data.data.local_semaphore != nullptr) {
              neighbor_data.data.local_semaphore->signal();
          }
+        }
      }
      /***************************************************************************/
 

--- a/src/node_server.cpp
+++ b/src/node_server.cpp
@@ -587,14 +587,7 @@ void node_server::compute_fmm(gsolve_type type, bool energy_account, bool aonly)
     std::vector<neighbor_gravity_type> all_neighbor_interaction_data;
     for (geo::direction const& dir : geo::direction::full_set()) {
         if (!neighbors[dir].empty()) {
-            const bool is_local = neighbors[dir].is_local();
-            if (!is_local) {
-                const auto filled_array_neighbor =
-                        grid_ptr->fill_received_array(neighbor_gravity_channels[dir].get_future(gcycle).get());
-                all_neighbor_interaction_data.push_back(std::move(filled_array_neighbor));
-            } else {
-                all_neighbor_interaction_data.push_back(neighbor_gravity_channels[dir].get_future(gcycle).get());
-            }
+            all_neighbor_interaction_data.push_back(neighbor_gravity_channels[dir].get_future(gcycle).get());
         } else {
             all_neighbor_interaction_data.emplace_back();
         }
@@ -634,17 +627,17 @@ void node_server::compute_fmm(gsolve_type type, bool energy_account, bool aonly)
             std::array<real, NDIM> Xbase = {grid_ptr->get_X()[0][hindex(H_BW, H_BW, H_BW)],
                                           grid_ptr->get_X()[1][hindex(H_BW, H_BW, H_BW)],
                                           grid_ptr->get_X()[2][hindex(H_BW, H_BW, H_BW)]};
+            m2m_interactor.set_grid_ptr(grid_ptr);
             m2m_interactor.update_input(
                 mon_ptr, M_ptr, com_ptr, all_neighbor_interaction_data, type, grid_ptr->get_dx(), Xbase);
-            m2m_interactor.set_grid_ptr(grid_ptr);
             m2m_interactor.compute_interactions(opts.m2m_kernel_type,
                                                 opts.m2p_kernel_type,
                                                 is_direction_empty,
                                                 all_neighbor_interaction_data);
         } else {
+            p2m_interactor.set_grid_ptr(grid_ptr);
             p2m_interactor.update_input(mon_ptr, M_ptr, com_ptr, all_neighbor_interaction_data,
                 type, grid_ptr->get_dx());
-            p2m_interactor.set_grid_ptr(grid_ptr);
             p2m_interactor.compute_interactions(opts.p2p_kernel_type,
                                                 opts.p2m_kernel_type,
                                                 is_direction_empty,

--- a/src/node_server.cpp
+++ b/src/node_server.cpp
@@ -589,9 +589,8 @@ void node_server::compute_fmm(gsolve_type type, bool energy_account, bool aonly)
         if (!neighbors[dir].empty()) {
             const bool is_local = neighbors[dir].is_local();
             if (!is_local) {
-                auto raw_neighbor = neighbor_gravity_channels[dir].get_future(gcycle).get();
-                auto filled_array_neighbor =
-                        grid_ptr->fill_received_array(raw_neighbor);
+                const auto filled_array_neighbor =
+                        grid_ptr->fill_received_array(neighbor_gravity_channels[dir].get_future(gcycle).get());
                 all_neighbor_interaction_data.push_back(std::move(filled_array_neighbor));
             } else {
                 all_neighbor_interaction_data.push_back(neighbor_gravity_channels[dir].get_future(gcycle).get());


### PR DESCRIPTION
The introduction of the stencil-based fmm kernels caused several issues which broke the distributed computation. These issues were mostly related to the size of the comm-arrays which transmitted less data than expected by the stencil. I fixed this by introducing a padding step on the receiver`s end, so that we do not communicate more data than necessary, but still are able to use the stencil-based fmm kernels!

This pull request should fix the issues with distributed runs of octotiger (Tested on Cori with 2 KNL nodes).