### PR TITLE
Allow using Boost.Multiprecision everywhere

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,8 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${PROJECT_SOURCE_DIR}/cmake")
 option(OCTOTIGER_WITH_GRAV_PAR "Enable parallelism in gravitational solver" OFF)
 option(OCTOTIGER_WITH_RADIATION "Enable radiation transport solver" OFF)
 option(OCTOTIGER_WITH_CUDA "Enable CUDA fmm kernels" OFF)
+option(OCTOTIGER_WITH_BOOST_MULTIPRECISION
+  "Use Boost.Multiprecision Instead of GCC Quad-Precision Math Library" OFF)
 
 ################################################################################
 # Find required packages
@@ -193,9 +195,12 @@ if(MSVC)
     /wd4996)
 
   target_compile_options(octotiger PRIVATE /EHsc)
+
+  if(NOT OCTOTIGER_WITH_BOOST_MULTIPRECISION)
+    message(WARNING "GCC Quad-Precision Math Library is not available with "
+    "MSVC. Consider setting OCTOTIGER_WITH_BOOST_MULTIPRECISION to ON")
+  endif()
 else()
-  target_link_libraries(octotiger quadmath)
-  
   if(${CMAKE_CXX_COMPILER_ID} STREQUAL GNU)
     target_compile_options(octotiger PRIVATE
       -Wno-ignored-attributes -Wno-attributes -Wno-deprecated-declarations
@@ -205,6 +210,12 @@ else()
       #set(CMAKE_EXE_LINKER_FLAGS_RELEASE "-Ofast -ipo")
       target_compile_options(octotiger -Wno-attributes -Wno-deprecated)
   endif()
+endif()
+
+if(OCTOTIGER_WITH_BOOST_MULTIPRECISION)
+  target_compile_definitions(octotiger PRIVATE OCTOTIGER_HAVE_BOOST_MULTIPRECISION)
+else()
+  target_link_libraries(octotiger quadmath)
 endif()
 
 if(USE_AVX2)

--- a/src/test_problems/blast/sedov.cpp
+++ b/src/test_problems/blast/sedov.cpp
@@ -10,7 +10,7 @@
 #include <vector>
 
 
-#ifndef _MSC_VER
+#if !defined(OCTOTIGER_HAVE_BOOST_MULTIPRECISION)
 #include <quadmath.h>
 using sed_real = __float128;
 #else
@@ -94,7 +94,7 @@ void solution(real time, real r, real rmax, real& d, real& v, real& p) {
 		vel[1] = -vel[2];
 		cs[1] = cs[2];
 
-#ifdef _MSC_VER
+#if defined(OCTOTIGER_HAVE_BOOST_MULTIPRECISION)
 		std::transform(den.begin(), den.end(), den1.begin(),
 			[](sed_real v) { return v.convert_to<double>(); });
 		std::transform(vel.begin(), vel.end(), vel1.begin(),

--- a/src/test_problems/blast/sedovf_c.cpp
+++ b/src/test_problems/blast/sedovf_c.cpp
@@ -23,7 +23,7 @@
 #include <cmath>
 //#include "f2c.h"
 
-#ifndef _MSC_VER
+#if !defined(OCTOTIGER_HAVE_BOOST_MULTIPRECISION)
 #include <quadmath.h>
 using sed_real = __float128;
 


### PR DESCRIPTION
GCC Boost Quad-Precision Math Library is not available for MSVC. Therefore, Boost.Multiprecision was used to provide quad-precision doubles and make the code work on MSVC. However Octotiger built with CUDA on Windows does not work . This PR enables testing Octotiger with Boost.Multiprecision for non-MSVC builds.