### PR TITLE
Set policy CMP0074 to make find hdf5 better 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,7 @@ cmake_policy(VERSION 3.10)
 
 # Libraries linked via full path no longer produce linker search paths.
 cmake_policy(SET CMP0003 NEW)
+cmake_policy(SET CMP0074 NEW)
 
 project(octotiger CXX)
 


### PR DESCRIPTION
(HDF5_ROOT is used on command line)