### PR TITLE
Added scheduling threads parameter

### DIFF
--- a/octotiger/options.hpp
+++ b/octotiger/options.hpp
@@ -66,6 +66,7 @@ public:
 
     size_t cuda_streams_per_locality;
 	size_t cuda_streams_per_gpu;
+	size_t cuda_scheduling_threads;
 
 	std::string input_file;
 	std::string config_file;
@@ -144,6 +145,7 @@ public:
 		arc & p2m_kernel_type;
 		arc & cuda_streams_per_locality;
 		arc & cuda_streams_per_gpu;
+		arc & cuda_scheduling_threads;
 		arc & atomic_mass;
 		arc & atomic_number;
 		arc & X;

--- a/src/cuda_util/cuda_scheduler.cpp
+++ b/src/cuda_util/cuda_scheduler.cpp
@@ -94,97 +94,105 @@ namespace octotiger {
             if (is_initialized)
                 return;
             // Determine what the scheduler has to manage
-            const size_t total_worker_count = hpx::get_os_thread_count();
+            // const size_t total_worker_count = hpx::get_os_thread_count();
             const size_t worker_id = hpx::get_worker_thread_num();
             const size_t streams_per_locality = opts().cuda_streams_per_locality;
             size_t streams_per_gpu = opts().cuda_streams_per_gpu;
-            if (streams_per_gpu == 0)
-                streams_per_gpu = streams_per_locality;
-            if (streams_per_locality > 0) { // is cuda activated?
-                size_t gpu_count = streams_per_locality / streams_per_gpu;
-                // handle remaining streams by putting it on the next gpu
-                if (streams_per_locality % streams_per_gpu != 0)
-                    gpu_count++;
-                // How many streams does each worker handle?
-                size_t number_of_streams_managed = streams_per_locality / total_worker_count;
-                const size_t remaining_streams = streams_per_locality % total_worker_count;
-                // if there are remaining streams, each worker receives one of them until there an
-                // non left
-                size_t offset = 0;
-                if (remaining_streams != 0) {
-                    if (worker_id < remaining_streams)
-                        // offset indicates that the current worker will get one of the remaining extra streams
-                        offset = 1;
-                }
 
-                const size_t accumulated_offset =
-                    worker_id < remaining_streams ? worker_id : remaining_streams;
-                const size_t worker_stream_id =
-                                worker_id * number_of_streams_managed + accumulated_offset;
-                const size_t gpu_id = (worker_stream_id) / streams_per_gpu;
-                // increase the number of streams by one of the remaining streams if necessary
-                number_of_streams_managed += offset;
-                std::cout << "Worker " << worker_id << " uses gpu " << gpu_id << " with "
-                          << number_of_streams_managed << " streams "<< std::endl;
-
-                // Number of streams the current HPX worker thread has to handle
-                number_cuda_streams_managed = number_of_streams_managed;
-                number_slots = number_cuda_streams_managed * slots_per_cuda_stream;
-
-                // Get one slot per stream to handle the data on the cpu
-                local_expansions_slots =
-                    std::vector<struct_of_array_data<expansion, real, 20, ENTRIES,
-                                                     SOA_PADDING,
-                                                     std::vector<real, cuda_pinned_allocator<real>>>>(number_slots);
-                center_of_masses_slots =
-                    std::vector<struct_of_array_data<space_vector, real, 3, ENTRIES, SOA_PADDING,
-                                                     std::vector<real, cuda_pinned_allocator<real>>>>(number_slots);
-                local_monopole_slots =
-                    std::vector<std::vector<real, cuda_pinned_allocator<real>>>(number_slots);
-                for (std::vector<real, cuda_pinned_allocator<real>>& mons : local_monopole_slots) {
-                    mons = std::vector<real, cuda_pinned_allocator<real>>(ENTRIES);
-                }
-
-                // Get one kernel enviroment per stream to handle the data on the gpu
-                kernel_device_enviroments = std::vector<kernel_device_enviroment>(number_slots);
-                size_t cur_interface = 0;
-                // Todo: Remove slots
-                size_t cur_slot = 0;
-
-                // Allocate buffers on the gpus - once per stream
-                size_t local_stream_id = 0;
-                stream_interfaces.reserve(number_cuda_streams_managed);
-                for (kernel_device_enviroment& env : kernel_device_enviroments) {
-                    const size_t worker_gpu_id = (worker_stream_id + local_stream_id) / streams_per_gpu;
-                    util::cuda_helper::cuda_error(cudaSetDevice(worker_gpu_id));
-                    stream_interfaces.emplace_back(worker_gpu_id);
-
-                    // Allocate memory on device
-                    util::cuda_helper::cuda_error(
-                        cudaMalloc((void**) &(env.device_local_monopoles), local_monopoles_size));
-                    util::cuda_helper::cuda_error(
-                        cudaMalloc((void**) &(env.device_local_expansions), local_expansions_size));
-                    util::cuda_helper::cuda_error(
-                        cudaMalloc((void**) &(env.device_center_of_masses), center_of_masses_size));
-                    util::cuda_helper::cuda_error(cudaMalloc(
-                                                      (void**) &(env.device_potential_expansions), potential_expansions_size));
-                    util::cuda_helper::cuda_error(cudaMalloc(
-                                                      (void**) &(env.device_angular_corrections), angular_corrections_size));
-
-                    util::cuda_helper::cuda_error(cudaMalloc(
-                                                      (void**) &(env.device_blocked_monopoles), 3 * potential_expansions_small_size));
-
-                    // Change stream interface if necessary
-                    local_stream_id++;
-                    cur_slot++;
-                    if (cur_slot >= slots_per_cuda_stream) {
-                        //util::cuda_helper::cuda_error(cudaThreadSynchronize());
-                        cur_slot = 0;
-                        cur_interface++;
+            number_cuda_streams_managed = 0;
+            size_t total_worker_count = opts().cuda_scheduling_threads;
+            if (total_worker_count == 0 && streams_per_locality != 0) {
+                total_worker_count = hpx::get_os_thread_count();
+            }
+            if (worker_id < total_worker_count) {
+                if (streams_per_gpu == 0)
+                    streams_per_gpu = streams_per_locality;
+                if (streams_per_locality > 0) { // is cuda activated?
+                    size_t gpu_count = streams_per_locality / streams_per_gpu;
+                    // handle remaining streams by putting it on the next gpu
+                    if (streams_per_locality % streams_per_gpu != 0)
+                        gpu_count++;
+                    // How many streams does each worker handle?
+                    size_t number_of_streams_managed = streams_per_locality / total_worker_count;
+                    const size_t remaining_streams = streams_per_locality % total_worker_count;
+                    // if there are remaining streams, each worker receives one of them until there an
+                    // non left
+                    size_t offset = 0;
+                    if (remaining_streams != 0) {
+                        if (worker_id < remaining_streams)
+                            // offset indicates that the current worker will get one of the remaining extra streams
+                            offset = 1;
                     }
+
+                    const size_t accumulated_offset =
+                        worker_id < remaining_streams ? worker_id : remaining_streams;
+                    const size_t worker_stream_id =
+                                    worker_id * number_of_streams_managed + accumulated_offset;
+                    const size_t gpu_id = (worker_stream_id) / streams_per_gpu;
+                    // increase the number of streams by one of the remaining streams if necessary
+                    number_of_streams_managed += offset;
+                    std::cout << "Worker " << worker_id << " uses gpu " << gpu_id << " with "
+                              << number_of_streams_managed << " streams "<< std::endl;
+
+                    // Number of streams the current HPX worker thread has to handle
+                    number_cuda_streams_managed = number_of_streams_managed;
+                    number_slots = number_cuda_streams_managed * slots_per_cuda_stream;
+
+                    // Get one slot per stream to handle the data on the cpu
+                    local_expansions_slots =
+                        std::vector<struct_of_array_data<expansion, real, 20, ENTRIES,
+                                                         SOA_PADDING,
+                                                         std::vector<real, cuda_pinned_allocator<real>>>>(number_slots);
+                    center_of_masses_slots =
+                        std::vector<struct_of_array_data<space_vector, real, 3, ENTRIES, SOA_PADDING,
+                                                         std::vector<real, cuda_pinned_allocator<real>>>>(number_slots);
+                    local_monopole_slots =
+                        std::vector<std::vector<real, cuda_pinned_allocator<real>>>(number_slots);
+                    for (std::vector<real, cuda_pinned_allocator<real>>& mons : local_monopole_slots) {
+                        mons = std::vector<real, cuda_pinned_allocator<real>>(ENTRIES);
+                    }
+
+                    // Get one kernel enviroment per stream to handle the data on the gpu
+                    kernel_device_enviroments = std::vector<kernel_device_enviroment>(number_slots);
+                    size_t cur_interface = 0;
+                    // Todo: Remove slots
+                    size_t cur_slot = 0;
+
+                    // Allocate buffers on the gpus - once per stream
+                    size_t local_stream_id = 0;
+                    stream_interfaces.reserve(number_cuda_streams_managed);
+                    for (kernel_device_enviroment& env : kernel_device_enviroments) {
+                        const size_t worker_gpu_id = (worker_stream_id + local_stream_id) / streams_per_gpu;
+                        util::cuda_helper::cuda_error(cudaSetDevice(worker_gpu_id));
+                        stream_interfaces.emplace_back(worker_gpu_id);
+
+                        // Allocate memory on device
+                        util::cuda_helper::cuda_error(
+                            cudaMalloc((void**) &(env.device_local_monopoles), local_monopoles_size));
+                        util::cuda_helper::cuda_error(
+                            cudaMalloc((void**) &(env.device_local_expansions), local_expansions_size));
+                        util::cuda_helper::cuda_error(
+                            cudaMalloc((void**) &(env.device_center_of_masses), center_of_masses_size));
+                        util::cuda_helper::cuda_error(cudaMalloc(
+                                                          (void**) &(env.device_potential_expansions), potential_expansions_size));
+                        util::cuda_helper::cuda_error(cudaMalloc(
+                                                          (void**) &(env.device_angular_corrections), angular_corrections_size));
+
+                        util::cuda_helper::cuda_error(cudaMalloc(
+                                                          (void**) &(env.device_blocked_monopoles), 3 * potential_expansions_small_size));
+
+                        // Change stream interface if necessary
+                        local_stream_id++;
+                        cur_slot++;
+                        if (cur_slot >= slots_per_cuda_stream) {
+                            //util::cuda_helper::cuda_error(cudaThreadSynchronize());
+                            cur_slot = 0;
+                            cur_interface++;
+                        }
+                    }
+                    // continue when all cuda things are handled
+                    util::cuda_helper::cuda_error(cudaThreadSynchronize());
                 }
-                // continue when all cuda things are handled
-                util::cuda_helper::cuda_error(cudaThreadSynchronize());
             }
             is_initialized = true;
         }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -295,7 +295,7 @@ std::array<size_t, 6> analyze_local_launch_counters() {
     if (total_multipole_cpu_launches + total_multipole_cuda_launches > 0) {
         float percentage = static_cast<float>(total_multipole_cuda_launches) /
             (static_cast<float>(total_multipole_cuda_launches) + total_multipole_cpu_launches);
-        std::cout << "=> Percentage of multipole on the GPU on locality " << hpx::get_locality_id() << ":" << percentage * 100 << "\n";
+        std::cout << "=> Percentage of multipole on the GPU on locality " << hpx::get_locality_id() << ": " << percentage * 100 << "\n";
     }
     std::cout << "----------------------------------------" << std::endl;
     std::cout << "Total non-rho-multipole launches on locality " << hpx::get_locality_id() << ": "
@@ -305,7 +305,7 @@ std::array<size_t, 6> analyze_local_launch_counters() {
     if (total_multipole_cpu_launches_non_rho + total_multipole_cuda_launches_non_rho > 0) {
         float percentage = static_cast<float>(total_multipole_cuda_launches_non_rho) /
             (static_cast<float>(total_multipole_cuda_launches_non_rho) + total_multipole_cpu_launches_non_rho);
-        std::cout << "=> Percentage of non-rho-multipole on the GPU on locality " << hpx::get_locality_id() << ":" << percentage * 100 << "\n";
+        std::cout << "=> Percentage of non-rho-multipole on the GPU on locality " << hpx::get_locality_id() << ": " << percentage * 100 << "\n";
     }
     std::cout << "----------------------------------------" << std::endl;
     std::cout << "Total p2p launches on locality " << hpx::get_locality_id() << ": "

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -113,6 +113,8 @@ bool options::process_options(int argc, char* argv[]) {
 			"cuda streams per HPX locality") //
 	("cuda_streams_per_gpu", po::value<size_t>(&(opts().cuda_streams_per_gpu))->default_value(size_t(0)),
 			"cuda streams per GPU (per locality)") //
+	("cuda_scheduling_threads", po::value<size_t>(&(opts().cuda_scheduling_threads))->default_value(size_t(0)),
+			"Number of worker threads per locality that mamage cuda streams") //
 	("input_file", po::value<std::string>(&(opts().input_file))->default_value(""), "input file for test problems") //
 	("config_file", po::value<std::string>(&(opts().config_file))->default_value(""), "configuration file") //
 	("n_species", po::value<integer>(&(opts().n_species))->default_value(1), "number of mass species") //


### PR DESCRIPTION
This PR add the parameter cuda_scheduling_threads which specifies how many threads per locality should do cuda work at all. Default is all worker threads if cuda_streams_per_locality is > 0