### PR TITLE
Switch CCI to GCC 8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ version: 2
 anchors:
     - &docker_config
         docker:
-            - image: stellargroup/octotiger:prerequisites-gcc6
+            - image: stellargroup/octotiger:prerequisites-gcc8
 
 jobs:
     build:

--- a/tools/docker/base_image/prerequisites-gcc.dockerfile
+++ b/tools/docker/base_image/prerequisites-gcc.dockerfile
@@ -27,7 +27,7 @@ RUN apt-get update \
         libgoogle-perftools-dev \
         ninja-build \
         vim \
-        linux-perf-4.9 \
+        linux-perf-4.* \
     && rm -rf /var/lib/apt/lists/*
 
 RUN curl -JL https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}.tar.gz \


### PR DESCRIPTION
@dmarce1 asked to bump the CircleCI image's GCC version from 6 to 8. This PR switches to the GCC 8 image.