### PR TITLE
Temperature calculation fix

### DIFF
--- a/src/grid.cpp
+++ b/src/grid.cpp
@@ -1964,7 +1964,7 @@ std::vector<std::pair<std::string, std::string>> grid::get_scalar_expressions() 
 	if (opts().problem == MARSHAK) {
 		rc.push_back(std::make_pair(std::string("T"), std::string("(ei/rho)^(1.0/3.0)")));
 	} else {
-		rc.push_back(std::make_pair(std::string("T"), hpx::util::format("{:e} * ei / n", 1.0 / kb / (fgamma - 1.0))));
+		rc.push_back(std::make_pair(std::string("T"), hpx::util::format("{:e} * ei / n", 1.0 / (kb / (fgamma - 1.0)))));
 	}
 	rc.push_back(std::make_pair(std::string("P"), hpx::util::format("{:e} * ei", (fgamma - 1.0))));
 	rc.push_back(


### PR DESCRIPTION
---
name: Temperature calculation fix
about: Pullrequest template for octotiger
---

Fixes the temperature calculation in grid.cpp - multiplying by (gamma-1) instead of dividing by it.

Just added parentheses to the calculation to overturn it to multiplication.

This modification solves issue #189.