### PR TITLE
Use the same timeout value used in CTest in CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,6 +49,7 @@ jobs:
             - run:
                 name: Marshak wave test
                 command: ctest --output-on-failure -R test_problems.cpu.marshak.diff
+                no_output_timeout: 25m
             - run:
                 name: Move artifacts
                 command: |
@@ -69,6 +70,7 @@ jobs:
             - run:
                 name: Blast test
                 command: ctest --output-on-failure -R test_problems.cpu.blast.diff
+                no_output_timeout: 25m
             - run:
                 name: Move artifacts
                 command: |
@@ -89,6 +91,7 @@ jobs:
             - run:
                 name: Sod shock tube test
                 command: ctest --output-on-failure -R test_problems.cpu.sod.diff
+                no_output_timeout: 25m
             - run:
                 name: Move artifacts
                 command: |
@@ -109,6 +112,7 @@ jobs:
             - run:
                 name: Solid sphere test
                 command: ctest --output-on-failure -R test_problems.cpu.sphere.diff
+                no_output_timeout: 25m
             - run:
                 name: Move artifacts
                 command: |
@@ -129,6 +133,7 @@ jobs:
             - run:
                 name: Rotating star test
                 command: ctest --output-on-failure -R test_problems.cpu.rotating_star.diff
+                no_output_timeout: 25m
             - run:
                 name: Move artifacts
                 command: |

--- a/cmake/DownloadTestReference.cmake
+++ b/cmake/DownloadTestReference.cmake
@@ -1,3 +1,10 @@
+# Copyright (c) 2019 Parsa Amini
+#
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+# Used for downloading reference silo files for Octo-Tiger tests
+
 function(download_test_reference test_name url dest)
   message(STATUS "Downloading reference SILO file for ${test_name}")
   if(NOT EXISTS ${dest})


### PR DESCRIPTION
[Some tests are failing](https://circleci.com/workflow-run/ee5773bc-7dff-4d57-8051-ae570b07bf69) ([SOD](https://app.circleci.com/jobs/github/STEllAR-GROUP/octotiger/5849), [Blast](https://app.circleci.com/jobs/github/STEllAR-GROUP/octotiger/5853)) because CircleCI runs time out after 10 minutes of waiting without output instead of the default 1500 second (25 minute) value used by CMake. This PR instructs CircleCI to not timeout unless the 25 minutes pass.