### PR TITLE
Added runtime parameters for the sod problem.

### DIFF
--- a/frontend/main.cpp
+++ b/frontend/main.cpp
@@ -175,7 +175,8 @@ void initialize(options _opts, std::vector<hpx::id_type> const& localities) {
 		set_problem(scf_binary);
 		set_refine_test(refine_test);
 	} else if (opts().problem == SOD) {
-		grid::set_fgamma(7.0 / 5.0);
+		grid::set_fgamma(opts().sod_gamma);
+		//grid::set_fgamma(7.0 / 5.0);
 //		opts().gravity = false;
 		set_problem(sod_shock_tube_init);
 		set_refine_test(refine_sod);

--- a/octotiger/options.hpp
+++ b/octotiger/options.hpp
@@ -84,6 +84,14 @@ public:
 	real rho_floor;
 	real tau_floor;
 
+        real sod_rhol;
+        real sod_rhor;
+        real sod_pl;
+        real sod_pr;
+        real sod_theta;
+        real sod_phi;
+        real sod_gamma;
+
 	size_t cuda_streams_per_locality;
 	size_t cuda_streams_per_gpu;
 	size_t cuda_scheduling_threads;
@@ -113,6 +121,15 @@ public:
 	void serialize(Arc &arc, unsigned) {
 		arc & rho_floor;
 		arc & tau_floor;
+
+                arc & sod_rhol;
+                arc & sod_rhor;
+                arc & sod_pl;
+                arc & sod_pr;
+                arc & sod_theta;
+                arc & sod_phi;
+                arc & sod_gamma;
+
 		arc & cdisc_detect;
 		arc & experiment;
 		arc & unigrid;

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -66,6 +66,13 @@ bool options::process_options(int argc, char *argv[]) {
 	("idle_rates", po::value<bool>(&(opts().idle_rates))->default_value(true), "show idle rates and locality info in SILO")                 //
 	("rho_floor", po::value<real>(&(opts().rho_floor))->default_value(0.0), "density floor")     //
 	("tau_floor", po::value<real>(&(opts().tau_floor))->default_value(0.0), "entropy tracer floor")     //
+        ("sod_rhol", po::value<real>(&(opts().sod_rhol))->default_value(1.0), "density in the left part of the grid")     //
+        ("sod_rhor", po::value<real>(&(opts().sod_rhor))->default_value(0.125), "density in the right part of the grid")     //
+        ("sod_pl", po::value<real>(&(opts().sod_pl))->default_value(1.0), "pressure in the left part of the grid")     //
+        ("sod_pr", po::value<real>(&(opts().sod_pr))->default_value(0.1), "pressure in the right part of the grid")     //
+        ("sod_theta", po::value<real>(&(opts().sod_theta))->default_value(0.0), "angle made by diaphragm normal w/x-axis (deg)")     //
+        ("sod_phi", po::value<real>(&(opts().sod_phi))->default_value(90.0), "angle made by diaphragm normal w/z-axis (deg)")     //
+        ("sod_gamma", po::value<real>(&(opts().sod_gamma))->default_value(1.4), "ratio of specific heats for gas")     //
 	("clight_retard", po::value<real>(&(opts().clight_retard))->default_value(1.0), "retardation factor for speed of light")                 //
 	("driving_rate", po::value<real>(&(opts().driving_rate))->default_value(0.0), "angular momentum loss driving rate")     //
 	("driving_time", po::value<real>(&(opts().driving_time))->default_value(0.0), "A.M. driving rate time")                 //

--- a/src/test_problems/sod/sod.cpp
+++ b/src/test_problems/sod/sod.cpp
@@ -20,16 +20,48 @@ std::vector<real> sod_shock_tube_init(real x, real y, real z, real ) {
 
 std::vector<real> sod_shock_tube_analytic(real x0, real y, real z, real t) {
 	std::vector<real> U(opts().n_fields, 0.0);
-	const real fgamma = grid::get_fgamma();
-	sod_state_t s;
-//	real x = (x0 + y + z) / std::sqrt(3.0);
-	real x =x0;
-	exact_sod(&s, &sod_init, x, t);
+        const real fgamma = grid::get_fgamma();
+        const real theta = opts().sod_theta;
+	const real theta_rad = theta * M_PI / 180.0;
+        const real phi = opts().sod_phi;
+	const real phi_rad = phi * M_PI / 180.0;
+        sod_state_t s;
+        sod_init_t sod_initial;
+        sod_initial.rhol = opts().sod_rhol;
+        sod_initial.rhor = opts().sod_rhor;
+        sod_initial.pl = opts().sod_pl;
+        sod_initial.pr = opts().sod_pr;
+        sod_initial.gamma = fgamma;
+        real x = x0*std::cos(theta_rad)*std::sin(phi_rad) + y*std::sin(theta_rad)*std::sin(phi_rad) + z*std::cos(phi_rad);
+        exact_sod(&s, &sod_initial, x, t);
 	U[rho_i] = s.rho;
 	U[egas_i] = s.p / (fgamma - 1.0);
-	U[sx_i] = s.rho * s.v / std::sqrt(3.0);
-	U[sy_i] = s.rho * s.v / std::sqrt(3.0);
-	U[sz_i] = s.rho * s.v / std::sqrt(3.0);
+        U[sx_i] = s.rho * s.v * std::cos(theta_rad) * std::sin(phi_rad); 
+        U[sy_i] = s.rho * s.v * std::sin(theta_rad) * std::sin(phi_rad);
+        U[sz_i] = s.rho * s.v * std::cos(phi_rad);
+	
+	if (std::floor(phi) == phi) {     // handling special degrees that result in exactly zero velocities
+		if (std::abs((int)phi) % 180 == 90) {
+			// set z-velocity to 0
+			U[sz_i] = 0.0;
+		}
+		else if (std::abs((int)phi) % 180 == 0) {
+	        	// set x,y-velocity to 0
+                        U[sx_i] = 0.0;
+                        U[sy_i] = 0.0;
+		}
+	}
+	if (std::floor(theta) == theta) { 
+	        if (std::abs((int)theta) % 180 == 90) {
+        	        // set x-velocity to 0
+                	U[sx_i] = 0.0;
+		}
+                else if (std::abs((int)theta) % 180 == 0) {
+                        // set y-velocity to 0
+                        U[sy_i] = 0.0;
+                }
+
+        }
 	U[tau_i] = std::pow(U[egas_i], 1.0 / fgamma);
 	U[egas_i] += s.rho * s.v * s.v / 2.0;
 	U[spc_i] = s.rho;


### PR DESCRIPTION
This fix makes the Sod problem more flexible.
Instead of recompiling octotiger in order to change the initial configuration
you just need to change a parameter in the config file.
This is more user-friendly and important for testing (benchmark) purposes.

The following runtime parameters were added (default value):
1. sod_rhol - density in the left part of the grid (1.0)
2. sod_rhor - density in the right part of the grid (0.125)
3. sod_pl - pressure in the left part of the grid (1.0)
4. sod_pr - pressure in the right part of the grid (0.1)
5. sod_theta - angle made by diaphragm normal w/x-axis (deg), (0.0) 
6. sod_phi - angle made by diaphragm normal w/z-axis (deg), (90.0)
7. sod_gamma - ratio of specific heats for gas (1.4)

For example, with just adjusting the sod_theta and sod_phi parameters you can set the shock along the x,y or z-axis. The default behavior is a shock aligned to the x-axis.
The change in the default behavior may cause this fix to fail on CircleCI.
Adjustments to the sod problem tests on CircleCI are required.
