### PR TITLE
Added min_level runtime parameter

### DIFF
--- a/frontend/main.cpp
+++ b/frontend/main.cpp
@@ -164,6 +164,7 @@ void initialize(options _opts, std::vector<hpx::id_type> const& localities) {
 	_controlfp(_EM_INEXACT | _EM_DENORMAL | _EM_INVALID, _MCW_EM);
 #endif
 	grid::set_scaling_factor(opts().xscale);
+        grid::set_min_level(opts().min_level);
 	grid::set_max_level(opts().max_level);
 	if (opts().problem == RADIATION_TEST) {
 		assert(opts().radiation);

--- a/octotiger/grid.hpp
+++ b/octotiger/grid.hpp
@@ -110,6 +110,7 @@ class grid {
 public:
 	using xpoint = std::array<xpoint_type, NDIM>;
 	struct node_point;
+        OCTOTIGER_EXPORT static void set_min_level(integer l);
 	OCTOTIGER_EXPORT static void set_max_level(integer l);
 	OCTOTIGER_EXPORT static void set_fgamma(real fg) {
 		fgamma = fg;
@@ -128,6 +129,7 @@ private:
 	static std::unordered_map<int, std::string> index_to_str_gravity;
 	static real omega;
 	static real fgamma;
+        static integer min_level;
 	static integer max_level;
 	static hpx::lcos::local::spinlock omega_mtx;
 	static OCTOTIGER_EXPORT real scaling_factor;

--- a/octotiger/options.hpp
+++ b/octotiger/options.hpp
@@ -55,6 +55,7 @@ public:
 	integer extra_regrid;
 	integer accretor_refine;
 	integer donor_refine;
+	integer min_level;
 	integer max_level;
 	integer ngrids;
 	integer stop_step;
@@ -152,6 +153,7 @@ public:
 		arc & v1309;
 		arc & clight_retard;
 		arc & stop_time;
+                arc & min_level;
 		arc & max_level;
 		arc & xscale;
 		arc & cfl;

--- a/src/grid.cpp
+++ b/src/grid.cpp
@@ -663,6 +663,7 @@ hpx::lcos::local::spinlock grid::omega_mtx;
 real grid::omega = ZERO;
 real grid::scaling_factor = 1.0;
 
+integer grid::min_level = 0;
 integer grid::max_level = 0;
 
 space_vector grid::get_cell_center(integer i, integer j, integer k) {
@@ -1337,7 +1338,7 @@ bool grid::refine_me(integer lev, integer last_ngrids) const {
 	PROFILE();
 
 	auto test = get_refine_test();
-	if (lev < 1) {
+	if (lev < min_level) {
 
 		return true;
 	}
@@ -1767,6 +1768,10 @@ real grid::compute_fluxes() {
 		}
 	}
 	return max_lambda;
+}
+
+void grid::set_min_level(integer l) {
+        min_level = l;
 }
 
 void grid::set_max_level(integer l) {

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -109,6 +109,7 @@ bool options::process_options(int argc, char *argv[]) {
 	("restart_filename", po::value<std::string>(&(opts().restart_filename))->default_value(""), "restart filename")         //
 	("stop_time", po::value<real>(&(opts().stop_time))->default_value(std::numeric_limits<real>::max()), "time to end simulation") //
 	("stop_step", po::value<integer>(&(opts().stop_step))->default_value(std::numeric_limits<integer>::max() - 1), "number of timesteps to run")          //
+        ("min_level", po::value<integer>(&(opts().min_level))->default_value(1), "minimum number of refinement levels")         //
 	("max_level", po::value<integer>(&(opts().max_level))->default_value(1), "maximum number of refinement levels")         //
 	("multipole_kernel_type", po::value<interaction_kernel_type>(&(opts().m2m_kernel_type))->default_value(SOA_CPU), "boundary multipole-multipole kernel type") //
 	("p2p_kernel_type", po::value<interaction_kernel_type>(&(opts().p2p_kernel_type))->default_value(SOA_CPU), "boundary particle-particle kernel type")   //
@@ -230,6 +231,7 @@ bool options::process_options(int argc, char *argv[]) {
 		SHOW(hydro);
 		SHOW(input_file);
 		SHOW(m2m_kernel_type);
+                SHOW(min_level);
 		SHOW(max_level);
 		SHOW(n_species);
 		SHOW(ngrids);


### PR DESCRIPTION
A new runtime parameter, minimum number of refinement levels, was added.

This runtime parameter allows the user to have a base grid with refinement level greater than one.
The code will refine each subgrid to the minimum level and refine further if required until reach the maximum level of refinement. The default value for min_level is one.

For example setting this parameter to 4 will create a base grid of 128 cells across each dimension.

If not specified, this parameter will get the value of one, and the previous behavior of the code persists. 