### PR TITLE
Fixes the problem with compare analytic

### DIFF
--- a/octotiger/grid.hpp
+++ b/octotiger/grid.hpp
@@ -90,7 +90,7 @@ public:
 	}
 };
 
-HPX_IS_BITWISE_SERIALIZABLE(analytic_t);
+//HPX_IS_BITWISE_SERIALIZABLE(analytic_t);  commenting this line because it causes failures when futures return analytic_t type from one locality to another
 
 using line_of_centers_t = std::vector<std::pair<real,std::vector<real>>>;
 


### PR DESCRIPTION
Fixes issue #283:
Segmentation fault error when comparing with the analytic solution on more than one locality run.

I am not entirely sure why commenting out the line:
HPX_IS_BITWISE_SERIALIZABLE(analytic_t);
fixes the issue of the segmentation fault.

My hunch is that futures from different locality could not bitwise serialize the analytic_t type because it contains some vectors.

Anyway commenting this line solved the issue on 2 and more nodes runs, and it still working on one node either. 
However, I do not completely know what other implications this change might have.
That is why I just commenting this line and not deleting it entirely.