### PR TITLE
Fixed the initialization of the sod problem

### DIFF
--- a/octotiger/test_problems/exact_sod.hpp
+++ b/octotiger/test_problems/exact_sod.hpp
@@ -15,7 +15,7 @@ typedef struct {
 	double rho, v, p;
 } sod_state_t;
 
-void exact_sod(sod_state_t* out, const sod_init_t* in, double x, double t);
+void exact_sod(sod_state_t* out, const sod_init_t* in, double x, double t, double dx);
 
 
 constexpr sod_init_t sod_init = { 1.0, 0.125, 1.0, 0.1, 7.0 / 5.0 };

--- a/octotiger/unitiger/physics_impl.hpp
+++ b/octotiger/unitiger/physics_impl.hpp
@@ -470,7 +470,7 @@ void physics<NDIM>::analytic_solution(test_type test, hydro::state_type &U, cons
 			}
 		} else if (test == SOD) {
 			sod_state_t sod_state;
-			exact_sod(&sod_state, &sod_init, rsum / std::sqrt(NDIM), time);
+			exact_sod(&sod_state, &sod_init, rsum / std::sqrt(NDIM), time, 1.0 / INX);
 			den = sod_state.rho;
 			vel = sod_state.v;
 			for (int dim = 0; dim < NDIM; dim++) {

--- a/src/test_problems/sod/exact_sod.cpp
+++ b/src/test_problems/sod/exact_sod.cpp
@@ -17,16 +17,19 @@ static double pl, pr, rhol, rhor, cl, cr, Gamma;
 static double func(double pm);
 static double rtbis(double x1, double x2, double xacc);
 
-void exact_sod(sod_state_t* out, const sod_init_t* in, double x, double t) {
-	if (t == 0.0) {
-		out->v = 0.0;
-		if( x > 0.0) {
-			out->p = in->pr;
-			out->rho = in->rhor;
-		} else {
-			out->p = in->pl;
-			out->rho = in->rhol;
-		}
+void exact_sod(sod_state_t* out, const sod_init_t* in, double x, double t, double dx) {
+        if (t == 0.0) {
+                out->v = 0.0;
+                if (x + 0.5 * dx <= 0.0) {
+                        out->p = in->pl;
+                        out->rho = in->rhol;
+                } else if (x - 0.5 * dx >= 0.0) {
+                        out->p = in->pr;
+                        out->rho = in->rhor;
+                } else {
+                        out->p = 0.5 * (in->pr + in->pl);
+                        out->rho = 0.5 * (in->rhor + in->rhol);
+                }
 	} else {
 		Gamma = in->gamma;
 		const double mu2 = (Gamma - 1.) / (Gamma + 1.);


### PR DESCRIPTION
Fixes problems with asymmetrical initialization under certain conditions.

The asymmetrical initialization caused insufficient accurate results and odd pattern were developed as the simulation evolved in time. 

To fix these problems I made the following changes:
1. I treat now separately special degrees that make the sine or the cosine of the sod_theta and sod_phi parameters to be zero.
2. In the cells that reside across the initial discontinuity boundary, I set the density (and pressure) to the average value between the density (and pressure) on the left sides of the discontinuity and the right side of the continuity.
