### PR TITLE
Fix blast flag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -139,8 +139,6 @@ set(source_files
     src/radiation/rad_grid.cpp
     src/test_problems/marshak/marshak.cpp
     src/test_problems/rotating_star/rotating_star.cpp
-    src/test_problems/blast/sedov.cpp
-    src/test_problems/blast/sedovf_c.cpp
     src/test_problems/sod/sod.cpp
     src/test_problems/sod/exact_sod.cpp
     src/test_problems/amr/amr.cpp
@@ -255,13 +253,15 @@ set(hydro_header_files
 
 set(hydro_source_files
    src/unitiger/hydro.cpp
-   src/test_problems/blast/sedovf_c.cpp
    src/test_problems/sod/exact_sod.cpp
    src/unitiger/hydro_impl/hydro_cuda/reconstruct_cuda_kernel.cu)
 
-list(APPEND hydro_dependencies Silo::silo Vc::Vc Boost::boost quadmath octolib)
+list(APPEND hydro_dependencies Silo::silo Vc::Vc Boost::boost octolib)
 if(OCTOTIGER_WITH_KOKKOS)
   list(APPEND hydro_dependencies Kokkos::kokkos)
+endif()
+if(OCTOTIGER_WITH_BLAST_TEST)
+  list(APPEND hydro_dependencies quadmath)
 endif()
 
 # Hydro library
@@ -313,8 +313,6 @@ if(OCTOTIGER_WITH_KOKKOS)
     src/multipole_interactions/multipole_interaction_interface.cpp
     src/radiation/rad_grid.cpp
     src/test_problems/amr/amr.cpp
-    src/test_problems/blast/sedov.cpp
-    src/test_problems/blast/sedovf_c.cpp
     src/test_problems/marshak/marshak.cpp
     src/test_problems/rotating_star/rotating_star.cpp
     src/test_problems/sod/sod.cpp
@@ -488,6 +486,7 @@ if(OCTOTIGER_WITH_BLAST_TEST)
   target_compile_definitions(octolib PUBLIC OCTOTIGER_HAVE_BLAST_TEST)
   set(blast_sources
     src/test_problems/blast/sedov.cpp
+    src/test_problems/blast/sedovf_c.cpp
     )
   target_sources(octolib PRIVATE ${blast_sources})
   source_group(TREE ${PROJECT_SOURCE_DIR}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -261,6 +261,9 @@ if(OCTOTIGER_WITH_KOKKOS)
   list(APPEND hydro_dependencies Kokkos::kokkos)
 endif()
 if(OCTOTIGER_WITH_BLAST_TEST)
+  list(APPEND hydro_source_files 
+    src/test_problems/blast/sedov.cpp
+    src/test_problems/blast/sedovf_c.cpp)
   list(APPEND hydro_dependencies quadmath)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -319,6 +319,8 @@ if(OCTOTIGER_WITH_KOKKOS)
     src/unitiger/hydro.cpp
     frontend/main.cpp
     src/unitiger/main.cpp
+    src/test_problems/blast/sedov.cpp
+    src/test_problems/blast/sedovf_c.cpp
   )
   set(vc_tainted_header_files
     octotiger/grid.hpp

--- a/frontend/main.cpp
+++ b/frontend/main.cpp
@@ -182,13 +182,16 @@ void initialize(options _opts, std::vector<hpx::id_type> const& localities) {
 		set_problem(sod_shock_tube_init);
 		set_refine_test(refine_sod);
 		set_analytic(sod_shock_tube_analytic);
-#if defined(OCTOTIGER_HAVE_BLAST_TEST)
 	} else if (opts().problem == BLAST) {
+#if defined(OCTOTIGER_HAVE_BLAST_TEST)
 		grid::set_fgamma(7.0 / 5.0);
 //		opts().gravity = false;
 		set_problem(blast_wave);
 		set_refine_test(refine_blast);
 		set_analytic(blast_wave_analytic);
+# else
+                std::cout << "Error! Octotiger has been compiled without BLAST test support!" << std::endl;
+                exit(EXIT_FAILURE);
 #endif
 	} else if (opts().problem == STAR) {
 		grid::set_fgamma(5.0 / 3.0);

--- a/octotiger/unitiger/physics_impl.hpp
+++ b/octotiger/unitiger/physics_impl.hpp
@@ -464,10 +464,15 @@ void physics<NDIM>::analytic_solution(test_type test, hydro::state_type &U, cons
 		double den = 0, vel = 0, pre = 0;
 
 		if (test == BLAST) {
+#if defined(OCTOTIGER_HAVE_BLAT_TEST)
 			sedov::solution(time + 7e-4, r, rmax, den, vel, pre, NDIM);
 			for (int dim = 0; dim < NDIM; dim++) {
 				U[sx_i + dim][i] = den * vel * X[dim][i] / r;
 			}
+#else
+			std::cout << "ERROR! Octo-Tiger was not compiled with BLAST test support!" << std::endl;
+			exit(EXIT_FAILURE);
+#endif
 		} else if (test == SOD) {
 			sod_state_t sod_state;
 			exact_sod(&sod_state, &sod_init, rsum / std::sqrt(NDIM), time, 1.0 / INX);
@@ -612,6 +617,7 @@ std::vector<typename hydro_computer<NDIM, INX, physics<NDIM>>::bc_type> physics<
 			}
 			break;
 		case BLAST:
+#if defined(OCTOTIGER_HAVE_BLAT_TEST)
 
 			double v;
 			sedov::solution(7e-4, r, std::sqrt(3) + 5.0 * dx, rho, v, p, NDIM);
@@ -634,6 +640,10 @@ std::vector<typename hydro_computer<NDIM, INX, physics<NDIM>>::bc_type> physics<
 			U[rho_i][i] += rho;
 			U[spc_i][i] += rho;
 			break;
+#else
+			std::cout << "ERROR! Octo-Tiger was not compiled with BLAST test support!" << std::endl;
+			exit(EXIT_FAILURE);
+#endif
 		case KH:
 
 			U[physics < NDIM > ::tau_i][i] = 1.0;


### PR DESCRIPTION
OCTOTIGER_WITH_BLAST_TEST=OFF does not completely disable the blast test, as it is still compiled and linked. Hence, it is not possible to compile Octo-Tiger without quadmath support even with the BLAST test disabled.

This PR fixes this issue and enables builds without quadmath. The behavior with OCTOTIGER_WITH_BLAST_TEST=ON should not change. The PR further adds support to compile the blast test together with the Octotiger-Kokkos toolchain.

