### PR TITLE
Added runtime parameters for the Star problem

### DIFF
--- a/octotiger/lane_emden.hpp
+++ b/octotiger/lane_emden.hpp
@@ -8,7 +8,7 @@
 
 #include "octotiger/real.hpp"
 
-real lane_emden(real r0, real dr, real* m_enc = nullptr);
+real lane_emden(real r0, real dr, real n, real* m_enc = nullptr);
 real wd_radius(double mass, double* rho0);
 real binary_separation( real accretor_mass, real donor_mass, real donor_radius, real fill_factor = 1.0);
 

--- a/octotiger/options.hpp
+++ b/octotiger/options.hpp
@@ -96,6 +96,16 @@ public:
 	real sod_phi;
 	real sod_gamma;
 
+        real star_xcenter;
+        real star_ycenter;
+        real star_zcenter;
+        real star_rmax;
+        real star_alpha;
+        real star_rho_out;
+        real star_dr;
+        real star_n;
+        real star_rho_center;
+
 	size_t cuda_streams_per_locality;
 	size_t cuda_streams_per_gpu;
 	size_t cuda_scheduling_threads;
@@ -133,6 +143,15 @@ public:
 		arc & sod_theta;
 		arc & sod_phi;
 		arc & sod_gamma;
+                arc & star_xcenter;
+                arc & star_ycenter;
+                arc & star_zcenter;
+                arc & star_rmax;
+                arc & star_alpha;
+                arc & star_dr;
+                arc & star_n;
+                arc & star_rho_center;
+                arc & star_rho_out;
 		arc & reflect_bc;
 		arc & cdisc_detect;
 		arc & experiment;

--- a/src/lane_emden.cpp
+++ b/src/lane_emden.cpp
@@ -9,27 +9,27 @@
 
 #include <cmath>
 
-static inline real pow_1_5(real y) {
-    return y * std::sqrt(y);
+static inline real pow_n(real y, real n) {
+    return std::pow(y, n);
 }
 
 static inline real fy(real y, real z, real r) {
 	return z;
 }
 
-static inline real fz(real y, real z, real r) {
+static inline real fz(real y, real z, real r, real n) {
 	if (r != 0.0) {
-		return -(pow_1_5(y) + 2.0 * z / r);
+		return -(pow_n(y, n) + 2.0 * z / r);
 	}
 	return -3.0;
 }
 
-static inline real fm(real theta, real dummy, real r) {
+static inline real fm(real theta, real dummy, real r, real n) {
     constexpr static real four_pi = real(4) * M_PI;
-	return four_pi * pow_1_5(theta) * r * r;
+	return four_pi * pow_n(theta, n) * r * r;
 }
 
-real lane_emden(real r0, real dr, real* m_enc) {
+real lane_emden(real r0, real dr, real n, real* m_enc) {
     real dy1, dz1, y, z, r, dy2, dz2, dy3, dz3, dy4, dz4, y0, z0;
 	real dm1, m, dm2, dm3, dm4, m0;
 	int done = 0;
@@ -50,8 +50,8 @@ real lane_emden(real r0, real dr, real* m_enc) {
 		z0 = z;
 		m0 = m;
 		dy1 = fy(y, z, r) * dr;
-		dz1 = fz(y, z, r) * dr;
-		dm1 = fm(y, z, r) * dr;
+		dz1 = fz(y, z, r, n) * dr;
+		dm1 = fm(y, z, r, n) * dr;
 		y += 0.5 * dy1;
 		z += 0.5 * dz1;
 		m += 0.5 * dm1;
@@ -61,8 +61,8 @@ real lane_emden(real r0, real dr, real* m_enc) {
 		}
         real rdr2 = r + 0.5 * dr;
 		dy2 = fy(y, z, rdr2) * dr;
-		dz2 = fz(y, z, rdr2) * dr;
-		dm2 = fm(y, z, rdr2) * dr;
+		dz2 = fz(y, z, rdr2, n) * dr;
+		dm2 = fm(y, z, rdr2, n) * dr;
 		y = y0 + 0.5 * dy2;
 		z = z0 + 0.5 * dz2;
 		m = m0 + 0.5 * dm2;
@@ -71,8 +71,8 @@ real lane_emden(real r0, real dr, real* m_enc) {
 			break;
 		}
 		dy3 = fy(y, z, rdr2) * dr;
-		dz3 = fz(y, z, rdr2) * dr;
-		dm3 = fm(y, z, rdr2) * dr;
+		dz3 = fz(y, z, rdr2, n) * dr;
+		dm3 = fm(y, z, rdr2, n) * dr;
 		y = y0 + dy3;
 		z = z0 + dz3;
 		m = m0 + dm3;
@@ -82,8 +82,8 @@ real lane_emden(real r0, real dr, real* m_enc) {
 		}
         real rdr = r + dr;
 		dy4 = fy(y, z, rdr) * dr;
-		dz4 = fz(y, z, rdr) * dr;
-		dm4 = fm(y, z, rdr) * dr;
+		dz4 = fz(y, z, rdr, n) * dr;
+		dm4 = fm(y, z, rdr, n) * dr;
 		y = y0 + (dy1 + dy4 + 2.0 * (dy3 + dy2)) / 6.0;
 		z = z0 + (dz1 + dz4 + 2.0 * (dz3 + dz2)) / 6.0;
 		m = m0 + (dm1 + dm4 + 2.0 * (dm3 + dm2)) / 6.0;
@@ -110,7 +110,7 @@ real wd_radius(real mass, real* rho0) {
 	real r;
 	do {
 		rho_mid = sqrt(rho_min * rho_max);
-		r = lane_emden(rho_mid, 0.001, &test_mass);
+		r = lane_emden(rho_mid, 0.001, 1.5, &test_mass);
 		if (test_mass > mass) {
 			rho_max = rho_mid;
 		} else {

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -75,6 +75,15 @@ bool options::process_options(int argc, char *argv[]) {
 	("sod_theta", po::value<real>(&(opts().sod_theta))->default_value(0.0), "angle made by diaphragm normal w/x-axis (deg)")     //
 	("sod_phi", po::value<real>(&(opts().sod_phi))->default_value(90.0), "angle made by diaphragm normal w/z-axis (deg)")     //
 	("sod_gamma", po::value<real>(&(opts().sod_gamma))->default_value(1.4), "ratio of specific heats for gas")     //
+        ("star_xcenter", po::value<real>(&(opts().star_xcenter))->default_value(0.0), "x-position of the star center")     //
+        ("star_ycenter", po::value<real>(&(opts().star_ycenter))->default_value(0.0), "y-position of the star center")     //
+        ("star_zcenter", po::value<real>(&(opts().star_zcenter))->default_value(0.0), "z-position of the star center")     //
+        ("star_n", po::value<real>(&(opts().star_n))->default_value(1.5), "polytropic index of the star")     //
+        ("star_rmax", po::value<real>(&(opts().star_rmax))->default_value(1.0 / 3.0), "maximal star radius")     //
+        ("star_dr", po::value<real>(&(opts().star_dr))->default_value(1.0 / (3.0 * 128.0)), "differential radius for solving the Lane-Emden equation")     //
+        ("star_alpha", po::value<real>(&(opts().star_alpha))->default_value(1.0 / (3.0 * 3.65375)), "scaling factor for the Lane-Emden equation") // for default n=3/2, ksi_1=3.65375 and alpha=rmax/ksi_1
+        ("star_rho_center", po::value<real>(&(opts().star_rho_center))->default_value(1.0), "density at the center of the star")     //
+        ("star_rho_out", po::value<real>(&(opts().star_rho_out))->default_value(1.0e-10), "density outside the star")     //
 	("clight_retard", po::value<real>(&(opts().clight_retard))->default_value(1.0), "retardation factor for speed of light")                 //
 	("driving_rate", po::value<real>(&(opts().driving_rate))->default_value(0.0), "angular momentum loss driving rate")     //
 	("driving_time", po::value<real>(&(opts().driving_time))->default_value(0.0), "A.M. driving rate time")                 //


### PR DESCRIPTION
Added the following runtime parameters, which are being used in STAR problem simulations (default values in parenthesis):
1. star_xcenter (0.0) - x-position of the star center.
2. star_ycenter (0.0) - y-position of the star center.
3. star_zcenter (0.0) - z-position of the star center.
4. star_n (1.5) - polytropic index of the star.
5. star_rmax (1.0 / 3.0) - maximal star radius. This parameter is highly useful when polytrope index higher (or equal) than 5 is being used. The polytrope will be truncated at this radius.
6. star_dr (1.0 / (3.0 * 128.0)) - differential radius for solving the Lane-Emden equation. Set this value to rmax divided by some integer number N, which in default is 128. higher N values should give more precise solution just in case the grid has high enough levels of refinement.
7. star_alpha (1.0 / (3.0 * 3.65375)) - scaling factor for the Lane-Emden equation. One needs to remember that conventionally the polytrope radius equal to \ksi_1 multiplied by the scale factor, where \ksi_1 is the surface of a polytropic star. By setting star_alpha correctly you can scale the star into certain radius (which, in principle,  can be smaller than rmax). For the default value, n=3/2, according to the theory, ksi_1=3.65375, and setting alpha=rmax/ksi_1 ensures the star will have a radius of 1/3. For n < 5, \ksi_1 is finite, while for higher n values, \ksi_1 is infinite and the star will be truncated by rmax.
8. star_rho_center (1.0) - density at the center of the star.
9. star_rho_out (1.0e-10) - density outside the star.
