### PR TITLE
Fixed the problem with n_species other than 5

### DIFF
--- a/frontend/main.cpp
+++ b/frontend/main.cpp
@@ -155,6 +155,7 @@ void initialize(options _opts, std::vector<hpx::id_type> const& localities) {
 	options::all_localities = localities;
 	opts() = _opts;
 	physics<NDIM>::set_n_species(opts().n_species);
+	physics<NDIM>::update_n_field();
 	grid::get_omega() = opts().omega;
 #if !defined(_MSC_VER) && !defined(__APPLE__)
 	feenableexcept(FE_DIVBYZERO);

--- a/octotiger/unitiger/physics.hpp
+++ b/octotiger/unitiger/physics.hpp
@@ -94,6 +94,8 @@ struct physics {
 
 	static void set_n_species(int n);
 
+	static void update_n_field();
+
 	static void set_dual_energy_switches(safe_real one, safe_real two);
 
 	static void set_central_force(safe_real GM) {

--- a/octotiger/unitiger/physics_impl.hpp
+++ b/octotiger/unitiger/physics_impl.hpp
@@ -510,6 +510,12 @@ void physics<NDIM>::set_n_species(int n) {
 }
 
 template<int NDIM>
+void physics<NDIM>::update_n_field() {
+        nf_ = (4 + NDIM + (NDIM == 1 ? 0 : std::pow(3, NDIM - 2))) + n_species_;;
+}
+
+
+template<int NDIM>
 template<int INX>
 std::vector<typename hydro_computer<NDIM, INX, physics<NDIM>>::bc_type> physics<NDIM>::initialize(physics<NDIM>::test_type t, hydro::state_type &U,
 		hydro::x_type &X) {

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -173,8 +173,11 @@ bool options::process_options(int argc, char *argv[]) {
 		opts().silo_num_groups = hpx::find_all_localities().size();
 
 	}
-	if (opts().problem == DWD || opts().problem == ROTATING_STAR) {
+	if (opts().problem == DWD) {
 		opts().n_species = std::max(int(5), int(opts().n_species));
+	}
+        if (opts().problem == MOVING_STAR || opts().problem == ROTATING_STAR) {
+                opts().n_species = std::max(int(2), int(opts().n_species));
 	}
 	n_fields = n_species + 10;
 	if (!opts().restart_filename.empty()) {


### PR DESCRIPTION
With the integration of unitiger into octotiger the code was crashing when n_species was set other than five, due to the initialization of the grids with the wrong number of fields.

I added update function for the number of the fields so the grids will be initialize with the correct number (according to what is specified in the configuration file).

That can reduce running time for simulation that use less species than five.
For example, the Sod problem running time with only one species was reduced by 20%, when I tested it.
