### PR TITLE
Adding runtime parameters for the solid sphere problem

### DIFF
--- a/octotiger/options.hpp
+++ b/octotiger/options.hpp
@@ -97,6 +97,13 @@ public:
 	real sod_phi;
 	real sod_gamma;
 
+	real solid_sphere_xcenter;
+	real solid_sphere_ycenter;
+	real solid_sphere_zcenter;
+	real solid_sphere_radius;
+	real solid_sphere_mass;
+	real solid_sphere_rho_min;
+
 	real star_xcenter;
 	real star_ycenter;
 	real star_zcenter;
@@ -148,6 +155,12 @@ public:
 		arc & sod_theta;
 		arc & sod_phi;
 		arc & sod_gamma;
+		arc & solid_sphere_xcenter;
+		arc & solid_sphere_ycenter;
+		arc & solid_sphere_zcenter;
+		arc & solid_sphere_radius;
+		arc & solid_sphere_mass;
+		arc & solid_sphere_rho_min;
 		arc & star_xcenter;
 		arc & star_ycenter;
 		arc & star_zcenter;
@@ -157,9 +170,9 @@ public:
 		arc & star_n;
 		arc & star_rho_center;
 		arc & star_rho_out;
-    arc & moving_star_xvelocity;
-    arc & moving_star_yvelocity;
-    arc & moving_star_zvelocity;
+		arc & moving_star_xvelocity;
+		arc & moving_star_yvelocity;
+		arc & moving_star_zvelocity;
 		arc & inflow_bc;
 		arc & reflect_bc;
 		arc & cdisc_detect;

--- a/src/grid.cpp
+++ b/src/grid.cpp
@@ -1631,6 +1631,7 @@ analytic_t grid::compute_analytic(real t) {
 					for (int f = 0; f < 4; f++) {
 						G[gindex(i - H_BW, j - H_BW, k - H_BW)][f] = a[f];
 					}
+					U[pot_i][hindex(i, j, k)] = a[0] * U[rho_i][hindex(i, j, k)];
 				}
 			}
 	return a;

--- a/src/node_server_actions_3.cpp
+++ b/src/node_server_actions_3.cpp
@@ -268,9 +268,9 @@ void node_server::execute_solver(bool scf, node_count_type ngrids) {
 		}
 		if (get_analytic() != nullptr) {
 			compare_analytic();
-			if (opts().gravity) {
-				solve_gravity(true, false);
-			}
+	//		if (opts().gravity) {
+	//			solve_gravity(true, false);
+	//		}
 			if (!opts().disable_output) {
 				output_all(this, "analytic", output_cnt, true);
 			}

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -75,6 +75,12 @@ bool options::process_options(int argc, char *argv[]) {
 	("sod_theta", po::value<real>(&(opts().sod_theta))->default_value(0.0), "angle made by diaphragm normal w/x-axis (deg)")     //
 	("sod_phi", po::value<real>(&(opts().sod_phi))->default_value(90.0), "angle made by diaphragm normal w/z-axis (deg)")     //
 	("sod_gamma", po::value<real>(&(opts().sod_gamma))->default_value(1.4), "ratio of specific heats for gas")     //
+        ("solid_sphere_xcenter", po::value<real>(&(opts().solid_sphere_xcenter))->default_value(0.25), "x-position of the sphere center")     //
+        ("solid_sphere_ycenter", po::value<real>(&(opts().solid_sphere_ycenter))->default_value(0.0), "y-position of the sphere center")     //
+        ("solid_sphere_zcenter", po::value<real>(&(opts().solid_sphere_zcenter))->default_value(0.0), "z-position of the sphere center")     //
+        ("solid_sphere_radius", po::value<real>(&(opts().solid_sphere_radius))->default_value(1.0 / 3.0), "radius of the sphere")     //
+        ("solid_sphere_mass", po::value<real>(&(opts().solid_sphere_mass))->default_value(1.0), "total mass enclosed inside the sphere")     //
+        ("solid_sphere_rho_min", po::value<real>(&(opts().solid_sphere_rho_min))->default_value(1.0e-12), "minimal density outside (and within) the sphere")     //
         ("star_xcenter", po::value<real>(&(opts().star_xcenter))->default_value(0.0), "x-position of the star center")     //
         ("star_ycenter", po::value<real>(&(opts().star_ycenter))->default_value(0.0), "y-position of the star center")     //
         ("star_zcenter", po::value<real>(&(opts().star_zcenter))->default_value(0.0), "z-position of the star center")     //

--- a/src/problem.cpp
+++ b/src/problem.cpp
@@ -245,13 +245,13 @@ std::vector<real> double_solid_sphere_analytic_phi(real x0, real y0, real z0) {
 }
 
 std::vector<real> solid_sphere_analytic_phi(real x, real y, real z, real xshift) {
-	const real r0 = ssr0;
-	const real M = 1.0;
 	std::vector<real> g(4);
-	x -= xshift;
-//	x0 -= -0.0444;
-//	y0 -= +0.345;
-//	z0 -= -.2565;
+	x -= opts().solid_sphere_xcenter;
+	y -= opts().solid_sphere_ycenter;
+	z -= opts().solid_sphere_zcenter;
+	const real r0 = opts().solid_sphere_radius;
+	const real M = opts().solid_sphere_mass;
+
 	const real r = std::sqrt(x * x + y * y + z * z);
 	const real r3 = r * r * r;
 	const real Menc = M * std::pow(std::min(r / r0, 1.0), 3);
@@ -279,14 +279,15 @@ std::vector<real> double_solid_sphere(real x0, real y0, real z0, real dx) {
 
 std::vector<real> solid_sphere(real x0, real y0, real z0, real dx, real xshift) {
 	const integer N = 25;
-	const real r0 = ssr0;
+	const real r0 = opts().solid_sphere_radius;
+	const real M = opts().solid_sphere_mass;
 	const real V = 4.0 / 3.0 * M_PI * r0 * r0 * r0;
-	const real drho = 1.0 / real(N * N * N) / V;
+	const real drho = M / real(N * N * N) / V;
 	std::vector<real> u(opts().n_fields, real(0));
-	x0 -= xshift;
-//	x0 -= -0.0444;
-//	y0 -= +0.345;
-//	z0 -= -.2565;
+	x0 -= opts().solid_sphere_xcenter;
+	y0 -= opts().solid_sphere_ycenter;
+	z0 -= opts().solid_sphere_zcenter;
+
 	const auto mm = [](real a, real b) {
 		if( a * b < ZERO ) {
 			return ZERO;
@@ -327,7 +328,7 @@ std::vector<real> solid_sphere(real x0, real y0, real z0, real dx, real xshift) 
 			}
 		}
 	}
-	u[rho_i] = std::max(u[rho_i], rho_floor);
+	u[rho_i] = u[spc_i] = std::max(u[rho_i], opts().solid_sphere_rho_min);
 	return u;
 }
 


### PR DESCRIPTION
Added the following runtime parameters, which are being used in SOLID_SPHERE problem simulations (default values in parenthesis):

1. solid_sphere_xcenter (0.25) - x-position of the sphere center.
2. solid_sphere_ycenter (0.0) - y-position of the sphere center.
3. solid_sphere_zcenter (0.0) - z-position of the sphere center.
4. solid_sphere_radius (1.0/3.0) - radius of the sphere.
5. solid_sphere_mass (1.0) - total mass enclosed inside the sphere.
6. solid_sphere_rho_min (1e-12) - minimal density outside (and within) the sphere. The density is set to this value wherever the density is lower than this threshold.
