### PR TITLE
Check test problem output size against reference output

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ cmake_policy(SET CMP0074 NEW)
 
 # Search path for CMake modules to be loaded by include() and find_package()
 list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 ################################################################################
 # Options
 ################################################################################

--- a/cmake/FileSizeTest.cmake
+++ b/cmake/FileSizeTest.cmake
@@ -6,8 +6,7 @@
 # Used for checking reference Silo file sizes against produced ones
 
 function(add_file_size_test name file1 file2)
-  add_test(
-      NAME ${name}
-      COMMAND sh -c "test $(wc -c <${file1}) -eq $(wc -c <${file2})"
+  add_test(NAME ${name}
+      COMMAND ${PROJECT_SOURCE_DIR}/tools/size_checker/size_checker.py ${file1} ${file2}"
   )
 endfunction()

--- a/cmake/FileSizeTest.cmake
+++ b/cmake/FileSizeTest.cmake
@@ -1,0 +1,13 @@
+# Copyright (c) 2020 Parsa Amini
+#
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+# Used for checking reference Silo file sizes against produced ones
+
+function(add_file_size_test name file1 file2)
+  add_test(
+      NAME ${name}
+      COMMAND sh -c "test $(wc -c <${file1}) -eq $(wc -c <${file2})"
+  )
+endfunction()

--- a/cmake/FileSizeTest.cmake
+++ b/cmake/FileSizeTest.cmake
@@ -7,6 +7,6 @@
 
 function(add_file_size_test name file1 file2)
   add_test(NAME ${name}
-      COMMAND ${PROJECT_SOURCE_DIR}/tools/size_checker/size_checker.py ${file1} ${file2}"
+      COMMAND ${PROJECT_SOURCE_DIR}/tools/size_checker/size_checker.py ${file1} ${file2}
   )
 endfunction()

--- a/octotiger/profiler.hpp
+++ b/octotiger/profiler.hpp
@@ -7,12 +7,12 @@
 #define PROFILER_HPP_
 
 #include <hpx/include/serialization.hpp>
-//#include <hpx/util/high_resolution_timer.hpp>
-#include <hpx/timing.hpp>
+#include <hpx/modules/timing.hpp>
 
 #include <algorithm>
 #include <array>
 #include <iostream>
+#include <string>
 
 struct profiler_register {
 	profiler_register(const char*, int);
@@ -46,7 +46,7 @@ struct timings
             time_ += timer_.elapsed();
         }
 
-        hpx::util::high_resolution_timer timer_;
+        hpx::chrono::high_resolution_timer timer_;
         double& time_;
     };
 
@@ -82,8 +82,8 @@ struct timings
 
     void report(std::string const& name)
     {
-    	const auto tinv = 1.0/ times_[time_total];
-    	const auto tcr = times_[time_computation] + times_[time_regrid];
+        const auto tinv = 1.0 / times_[time_total];
+        const auto tcr = times_[time_computation] + times_[time_regrid];
         std::cout << name << ":\n";
         std::cout << "   Total: "             << times_[time_total] << '\n';
         std::cout << "   Computation: "       << times_[time_computation] << " (" <<  100*times_[time_computation] * tinv << "\%)\n";

--- a/octotiger/simd.hpp
+++ b/octotiger/simd.hpp
@@ -8,6 +8,7 @@
 
 //#include "octotiger/defs.hpp"
 
+#include <hpx/modules/collectives.hpp>
 #include <hpx/parallel/traits/vector_pack_type.hpp>
 #include <hpx/runtime/serialization/datapar.hpp>
 

--- a/src/node_server_actions_1.cpp
+++ b/src/node_server_actions_1.cpp
@@ -224,7 +224,7 @@ void node_server::regrid_scatter(integer a_, integer total) {
 
 node_count_type node_server::regrid(const hpx::id_type &root_gid, real omega, real new_floor, bool rb, bool grav_energy_comp) {
 	timings::scope ts(timings_, timings::time_regrid);
-	hpx::util::high_resolution_timer timer;
+	hpx::chrono::high_resolution_timer timer;
 	assert(grid_ptr != nullptr);
 	printf("-----------------------------------------------\n");
 	if (!rb) {

--- a/test_problems/CMakeLists.txt
+++ b/test_problems/CMakeLists.txt
@@ -4,6 +4,7 @@
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 include(DownloadTestReference)
+include(FileSizeTest)
 
 # *.diff tests fail when the output contains any .vals
 set(OCTOTIGER_SILODIFF_FAIL_PATTERN ".vals")

--- a/test_problems/blast/CMakeLists.txt
+++ b/test_problems/blast/CMakeLists.txt
@@ -25,7 +25,7 @@ add_test(NAME test_problems.cpu.blast.diff
 set_tests_properties(test_problems.cpu.blast PROPERTIES
   FIXTURES_SETUP test_problems.cpu.blast)
 set_tests_properties(test_problems.cpu.blast.filesize PROPERTIES
-  FIXTURES_REQUIRED test_problems.cpu.blast)
+  FIXTURES_SETUP test_problems.cpu.blast)
 set_tests_properties(test_problems.cpu.blast.diff PROPERTIES
   FIXTURES_REQUIRED test_problems.cpu.blast
   FAIL_REGULAR_EXPRESSION ${OCTOTIGER_SILODIFF_FAIL_PATTERN})

--- a/test_problems/blast/CMakeLists.txt
+++ b/test_problems/blast/CMakeLists.txt
@@ -14,12 +14,18 @@ download_test_reference("Blast test"
 add_test(NAME test_problems.cpu.blast
   COMMAND octotiger
     --config_file=${PROJECT_SOURCE_DIR}/test_problems/blast/blast.ini)
+
+add_file_size_test(test_problems.cpu.blast.filesize
+  ${PROJECT_BINARY_DIR}/blast.silo ${PROJECT_BINARY_DIR}/test_problems/blast/final.silo.data/0.silo)
+
 add_test(NAME test_problems.cpu.blast.diff
   COMMAND ${Silo_BROWSER} -e diff -q -x 1.0 -R 1.0e-12
     ${PROJECT_BINARY_DIR}/blast.silo ${PROJECT_BINARY_DIR}/test_problems/blast/final.silo.data/0.silo)
 
 set_tests_properties(test_problems.cpu.blast PROPERTIES
   FIXTURES_SETUP test_problems.cpu.blast)
+set_tests_properties(test_problems.cpu.blast.filesize PROPERTIES
+  FIXTURES_REQUIRED test_problems.cpu.blast)
 set_tests_properties(test_problems.cpu.blast.diff PROPERTIES
   FIXTURES_REQUIRED test_problems.cpu.blast
   FAIL_REGULAR_EXPRESSION ${OCTOTIGER_SILODIFF_FAIL_PATTERN})

--- a/test_problems/marshak/CMakeLists.txt
+++ b/test_problems/marshak/CMakeLists.txt
@@ -16,7 +16,7 @@ add_test(NAME test_problems.cpu.marshak
     --config_file=${PROJECT_SOURCE_DIR}/test_problems/marshak/marshak.ini)
 
 add_file_size_test(test_problems.cpu.marshak.filesize
-  ${PROJECT_BINARY_DIR}/marshak.silo ${PROJECT_BINARY_DIR}/test_problems/markshak/final.silo.data/0.silo)
+  ${PROJECT_BINARY_DIR}/marshak.silo ${PROJECT_BINARY_DIR}/test_problems/markshak/final.silo)
 
 add_test(NAME test_problems.cpu.marshak.diff
   COMMAND ${Silo_BROWSER} -e diff -q -x 1.0 -R 1.0e-12

--- a/test_problems/marshak/CMakeLists.txt
+++ b/test_problems/marshak/CMakeLists.txt
@@ -14,12 +14,18 @@ download_test_reference("Marshak wave test"
 add_test(NAME test_problems.cpu.marshak
   COMMAND octotiger
     --config_file=${PROJECT_SOURCE_DIR}/test_problems/marshak/marshak.ini)
+
+add_file_size_test(test_problems.cpu.marshak.filesize
+  ${PROJECT_BINARY_DIR}/marshak.silo ${PROJECT_BINARY_DIR}/test_problems/markshak/final.silo.data/0.silo)
+
 add_test(NAME test_problems.cpu.marshak.diff
   COMMAND ${Silo_BROWSER} -e diff -q -x 1.0 -R 1.0e-12
     ${PROJECT_BINARY_DIR}/marshak.silo ${PROJECT_BINARY_DIR}/test_problems/markshak/final.silo.data/0.silo)
 
 set_tests_properties(test_problems.cpu.marshak PROPERTIES
   FIXTURES_SETUP test_problems.cpu.marshak)
+  set_tests_properties(test_problems.cpu.marshak.filesize PROPERTIES
+  FIXTURES_REQUIRED test_problems.cpu.blast)
 set_tests_properties(test_problems.cpu.marshak.diff PROPERTIES
   FIXTURES_REQUIRED test_problems.cpu.marshak
   FAIL_REGULAR_EXPRESSION ${OCTOTIGER_SILODIFF_FAIL_PATTERN})

--- a/test_problems/marshak/CMakeLists.txt
+++ b/test_problems/marshak/CMakeLists.txt
@@ -24,8 +24,8 @@ add_test(NAME test_problems.cpu.marshak.diff
 
 set_tests_properties(test_problems.cpu.marshak PROPERTIES
   FIXTURES_SETUP test_problems.cpu.marshak)
-  set_tests_properties(test_problems.cpu.marshak.filesize PROPERTIES
-  FIXTURES_REQUIRED test_problems.cpu.blast)
+set_tests_properties(test_problems.cpu.marshak.filesize PROPERTIES
+  FIXTURES_SETUP test_problems.cpu.marshak)
 set_tests_properties(test_problems.cpu.marshak.diff PROPERTIES
   FIXTURES_REQUIRED test_problems.cpu.marshak
   FAIL_REGULAR_EXPRESSION ${OCTOTIGER_SILODIFF_FAIL_PATTERN})

--- a/test_problems/marshak/CMakeLists.txt
+++ b/test_problems/marshak/CMakeLists.txt
@@ -16,11 +16,11 @@ add_test(NAME test_problems.cpu.marshak
     --config_file=${PROJECT_SOURCE_DIR}/test_problems/marshak/marshak.ini)
 
 add_file_size_test(test_problems.cpu.marshak.filesize
-  ${PROJECT_BINARY_DIR}/marshak.silo ${PROJECT_BINARY_DIR}/test_problems/markshak/final.silo)
+  ${PROJECT_BINARY_DIR}/marshak.silo ${PROJECT_BINARY_DIR}/test_problems/marshak/final.silo)
 
 add_test(NAME test_problems.cpu.marshak.diff
   COMMAND ${Silo_BROWSER} -e diff -q -x 1.0 -R 1.0e-12
-    ${PROJECT_BINARY_DIR}/marshak.silo ${PROJECT_BINARY_DIR}/test_problems/markshak/final.silo.data/0.silo)
+    ${PROJECT_BINARY_DIR}/marshak.silo ${PROJECT_BINARY_DIR}/test_problems/marshak/final.silo.data/0.silo)
 
 set_tests_properties(test_problems.cpu.marshak PROPERTIES
   FIXTURES_SETUP test_problems.cpu.marshak)

--- a/test_problems/rotating_star/CMakeLists.txt
+++ b/test_problems/rotating_star/CMakeLists.txt
@@ -15,6 +15,10 @@ add_test(NAME test_problems.cpu.rotating_star.init COMMAND gen_rotating_star_ini
 add_test(NAME test_problems.cpu.rotating_star
   COMMAND octotiger
     --config_file=${PROJECT_SOURCE_DIR}/test_problems/rotating_star/rotating_star.ini)
+
+add_file_size_test(test_problems.cpu.rotating_star.filesize
+  ${PROJECT_BINARY_DIR}/rotating_star.silo ${PROJECT_BINARY_DIR}/test_problems/rotating_star/final.silo)
+
 add_test(NAME test_problems.cpu.rotating_star.diff
   COMMAND ${Silo_BROWSER} -e diff -q -x 1.0 -R 1.0e-12
     ${PROJECT_BINARY_DIR}/rotating_star.silo ${PROJECT_BINARY_DIR}/test_problems/rotating_star/final.silo.data/0.silo)
@@ -24,6 +28,8 @@ set_tests_properties(test_problems.cpu.rotating_star.init PROPERTIES
 set_tests_properties(test_problems.cpu.rotating_star PROPERTIES
   FIXTURES_REQUIRED test_problems.cpu.rotating_star.init)
 
+set_tests_properties(test_problems.cpu.rotating_star.filesize PROPERTIES
+  FIXTURES_SETUP test_problems.cpu.rotating_star)
 set_tests_properties(test_problems.cpu.rotating_star PROPERTIES
   FIXTURES_SETUP test_problems.cpu.rotating_star
   FIXTURES_REQUIRED test_problems.cpu.rotating_star.init)

--- a/test_problems/sod/CMakeLists.txt
+++ b/test_problems/sod/CMakeLists.txt
@@ -14,11 +14,17 @@ download_test_reference("Sod shock tube test"
 add_test(NAME test_problems.cpu.sod
   COMMAND octotiger
     --config_file=${PROJECT_SOURCE_DIR}/test_problems/sod/sod.ini)
+
+add_file_size_test(test_problems.cpu.sod.filesize
+  ${PROJECT_BINARY_DIR}/sod.silo ${PROJECT_BINARY_DIR}/test_problems/sod/final.silo)
+
 add_test(NAME test_problems.cpu.sod.diff
   COMMAND ${Silo_BROWSER} -e diff -q -x 1.0 -R 1.0e-12
     ${PROJECT_BINARY_DIR}/sod.silo ${PROJECT_BINARY_DIR}/test_problems/sod/final.silo.data/0.silo)
 
 set_tests_properties(test_problems.cpu.sod PROPERTIES
+  FIXTURES_SETUP test_problems.cpu.sod)
+set_tests_properties(test_problems.cpu.sod.filesize PROPERTIES
   FIXTURES_SETUP test_problems.cpu.sod)
 set_tests_properties(test_problems.cpu.sod.diff PROPERTIES
   FIXTURES_REQUIRED test_problems.cpu.sod

--- a/test_problems/sphere/CMakeLists.txt
+++ b/test_problems/sphere/CMakeLists.txt
@@ -14,11 +14,17 @@ download_test_reference("Solid sphere test"
 add_test(NAME test_problems.cpu.sphere
   COMMAND octotiger
     --config_file=${PROJECT_SOURCE_DIR}/test_problems/sphere/sphere.ini)
+
+add_file_size_test(test_problems.cpu.sphere.filesize
+  ${PROJECT_BINARY_DIR}/sphere.silo ${PROJECT_BINARY_DIR}/test_problems/sphere/X.${OCTOTIGER_WITH_GRIDDIM}.silo)
+
 add_test(NAME test_problems.cpu.sphere.diff
   COMMAND ${Silo_BROWSER} -e diff -q -x 1.0 -R 1.0e-12
     ${PROJECT_BINARY_DIR}/sphere.silo ${PROJECT_BINARY_DIR}/test_problems/sphere/X.${OCTOTIGER_WITH_GRIDDIM}.silo.data/0.silo)
 
 set_tests_properties(test_problems.cpu.sphere PROPERTIES
+  FIXTURES_SETUP test_problems.cpu.sphere)
+set_tests_properties(test_problems.cpu.sphere.filesize PROPERTIES
   FIXTURES_SETUP test_problems.cpu.sphere)
 set_tests_properties(test_problems.cpu.sphere.diff PROPERTIES
   FIXTURES_REQUIRED test_problems.cpu.sphere

--- a/tools/size_checker/size_checker.py
+++ b/tools/size_checker/size_checker.py
@@ -21,8 +21,10 @@ def fail_if_file_sizes_differ(original, target):
     fail_if_not(path.exists(target), '"{}" does not exist.'.format(target))
     fail_if_not(path.isfile(target), '"{}" is not a file.'.format(target))
 
-    fail_if_not(path.getsize(target) == path.getsize(original),
-                'File sizes differ between "{}" and "{}".'.format(target, original))
+    ofsz = path.getsize(original)
+    tfsz = path.getsize(target)
+    fail_if_not(tfsz == ofsz, 'File sizes differ between "{}" ({}) and "{}" ({}).'.format(
+        target, tfsz, original, ofsz))
 
 
 def get_data_dirname(p):

--- a/tools/size_checker/size_checker.py
+++ b/tools/size_checker/size_checker.py
@@ -1,30 +1,36 @@
 #!/usr/bin/env python3
 
 import argparse
+import sys
 from os import listdir
 from os import path
 
 
+def fail_if_not(expected, message):
+    if not expected:
+        print(message, file=sys.stderr)
+        sys.exit(1)
+
+
 def fail_if_file_sizes_differ(original, target):
-    assert path.exists(original), '"' + original + \
-        '" does not exist. Check failed.'
-    assert path.isfile(original), '"' + original + \
-        '" is not a file. Check failed.'
+    fail_if_not(path.exists(original), '"' + original +
+                '" does not exist.')
+    fail_if_not(path.isfile(original), '"' + original +
+                '" is not a file.')
 
-    assert path.exists(target), target + ' does not exist. Check failed.'
-    assert path.isfile(target), target + ' is not a file. Check failed.'
+    fail_if_not(path.exists(target), '"{}" does not exist.'.format(target))
+    fail_if_not(path.isfile(target), '"{}" is not a file.'.format(target))
 
-    assert path.getsize(target) == path.getsize(original), \
-        'File sizes differ between "{}" and "{}". Check failed.'.format(target, original)
+    fail_if_not(path.getsize(target) == path.getsize(original),
+                'File sizes differ between "{}" and "{}".'.format(target, original))
 
 
 def main():
     parser = argparse.ArgumentParser(
         description='Check generated Silo file size(s) against original')
-    parser.add_argument('original',
-                        help='Original Silo file to compare against')
-    parser.add_argument('target',
-                        help='Generated Silo file')
+    parser.add_argument(
+        'original', help='Original Silo file to compare against')
+    parser.add_argument('target', help='Generated Silo file')
 
     args = parser.parse_args()
 
@@ -38,15 +44,16 @@ def main():
     tfn = path.basename(args.target) + '.data'
     tfp = path.join(path.dirname(args.target), tfn)
     if path.isdir(ofp):
-        assert path.isdir(tfp), 'Target silo data directory does not exist. Check failed.'
+        fail_if_not(path.isdir(tfp),
+                    'Target silo data directory does not exist.')
 
         ossf = [path.join(ofp, f) for f in listdir(ofp) if path.isfile(
             path.join(ofp, f)) and path.splitext(path.join(ofp, f))[1] == '.silo']
         tssf = [path.join(tfp, f) for f in listdir(tfp) if path.isfile(
             path.join(tfp, f)) and path.splitext(path.join(tfp, f))[1] == '.silo']
 
-        assert len(ossf) == len(tssf), \
-            'Target silo data has a different number of Silo files. Check failed.'
+        fail_if_not(len(ossf) == len(tssf),
+                    'Target silo data has a different number of Silo files.')
 
         for o, t in zip(ossf, tssf):
             fail_if_file_sizes_differ(o, t)

--- a/tools/size_checker/size_checker.py
+++ b/tools/size_checker/size_checker.py
@@ -6,13 +6,16 @@ from os import path
 
 
 def fail_if_file_sizes_differ(original, target):
-    assert path.exists(original)
-    assert path.isfile(original)
+    assert path.exists(original), '"' + original + \
+        '" does not exist. Check failed.'
+    assert path.isfile(original), '"' + original + \
+        '" is not a file. Check failed.'
 
-    assert path.exists(target)
-    assert path.isfile(target)
+    assert path.exists(target), target + ' does not exist. Check failed.'
+    assert path.isfile(target), target + ' is not a file. Check failed.'
 
-    assert path.getsize(target) == path.getsize(original)
+    assert path.getsize(target) == path.getsize(original), \
+        'File sizes differ between "{}" and "{}". Check failed.'.format(target, original)
 
 
 def main():
@@ -35,14 +38,16 @@ def main():
     tfn = path.basename(args.target) + '.data'
     tfp = path.join(path.dirname(args.target), ofn)
     if path.isdir(ofp):
-        assert path.isdir(tfp)
+        assert path.isdir(
+            tfp), 'Target silo data file does not exist. Check failed.'
 
         ossf = [path.join(ofp, f) for f in listdir(ofp) if path.isfile(
             path.join(ofp, f)) and path.splitext(path.join(ofp, f))[1] == '.silo']
         tssf = [path.join(tfp, f) for f in listdir(tfp) if path.isfile(
             path.join(tfp, f)) and path.splitext(path.join(tfp, f))[1] == '.silo']
 
-        assert len(ossf) == len(tssf)
+        assert len(ossf) == len(
+            tssf), 'Target silo data has a different number of Silo files. Check failed.'
 
         for o, t in zip(ossf, tssf):
             fail_if_file_sizes_differ(o, t)

--- a/tools/size_checker/size_checker.py
+++ b/tools/size_checker/size_checker.py
@@ -25,6 +25,16 @@ def fail_if_file_sizes_differ(original, target):
                 'File sizes differ between "{}" and "{}".'.format(target, original))
 
 
+def get_data_dirname(p):
+    fn = path.basename(p) + '.data'
+    return path.join(path.dirname(p), fn)
+
+
+def listdir_silo(fp):
+    return [path.join(fp, f) for f in listdir(fp) if path.isfile(
+            path.join(fp, f)) and path.splitext(path.join(fp, f))[1] == '.silo']
+
+
 def main():
     parser = argparse.ArgumentParser(
         description='Check generated Silo file size(s) against original')
@@ -38,22 +48,18 @@ def main():
     fail_if_file_sizes_differ(args.original, args.target)
 
     # check for sub-silo files
-    ofn = path.basename(args.original) + '.data'
-    ofp = path.join(path.dirname(args.original), ofn)
+    ofp = get_data_dirname(args.original)
+    tfp = get_data_dirname(args.target)
 
-    tfn = path.basename(args.target) + '.data'
-    tfp = path.join(path.dirname(args.target), tfn)
     if path.isdir(ofp):
         fail_if_not(path.isdir(tfp),
                     'Target silo data directory does not exist.')
 
-        ossf = [path.join(ofp, f) for f in listdir(ofp) if path.isfile(
-            path.join(ofp, f)) and path.splitext(path.join(ofp, f))[1] == '.silo']
-        tssf = [path.join(tfp, f) for f in listdir(tfp) if path.isfile(
-            path.join(tfp, f)) and path.splitext(path.join(tfp, f))[1] == '.silo']
+        ossf = listdir_silo(ofp)
+        tssf = listdir_silo(tfp)
 
-        fail_if_not(len(ossf) == len(tssf),
-                    'Target silo data has a different number of Silo files.')
+        fail_if_not(len(ossf) == len(
+            tssf), 'Silo file count differs: {} != {}'.format(len(ossf), len(tssf)))
 
         for o, t in zip(ossf, tssf):
             fail_if_file_sizes_differ(o, t)

--- a/tools/size_checker/size_checker.py
+++ b/tools/size_checker/size_checker.py
@@ -36,18 +36,17 @@ def main():
     ofp = path.join(path.dirname(args.original), ofn)
 
     tfn = path.basename(args.target) + '.data'
-    tfp = path.join(path.dirname(args.target), ofn)
+    tfp = path.join(path.dirname(args.target), tfn)
     if path.isdir(ofp):
-        assert path.isdir(
-            tfp), 'Target silo data file does not exist. Check failed.'
+        assert path.isdir(tfp), 'Target silo data directory does not exist. Check failed.'
 
         ossf = [path.join(ofp, f) for f in listdir(ofp) if path.isfile(
             path.join(ofp, f)) and path.splitext(path.join(ofp, f))[1] == '.silo']
         tssf = [path.join(tfp, f) for f in listdir(tfp) if path.isfile(
             path.join(tfp, f)) and path.splitext(path.join(tfp, f))[1] == '.silo']
 
-        assert len(ossf) == len(
-            tssf), 'Target silo data has a different number of Silo files. Check failed.'
+        assert len(ossf) == len(tssf), \
+            'Target silo data has a different number of Silo files. Check failed.'
 
         for o, t in zip(ossf, tssf):
             fail_if_file_sizes_differ(o, t)

--- a/tools/size_checker/size_checker.py
+++ b/tools/size_checker/size_checker.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+
+import argparse
+from os import listdir
+from os import path
+
+
+def fail_if_file_sizes_differ(original, target):
+    assert path.exists(original)
+    assert path.isfile(original)
+
+    assert path.exists(target)
+    assert path.isfile(target)
+
+    assert path.getsize(target) == path.getsize(original)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Check generated Silo file size(s) against original')
+    parser.add_argument('original',
+                        help='Original Silo file to compare against')
+    parser.add_argument('target',
+                        help='Generated Silo file')
+
+    args = parser.parse_args()
+
+    # check original file sizes
+    fail_if_file_sizes_differ(args.original, args.target)
+
+    # check for sub-silo files
+    ofn = path.basename(args.original) + '.data'
+    ofp = path.join(path.dirname(args.original), ofn)
+
+    tfn = path.basename(args.target) + '.data'
+    tfp = path.join(path.dirname(args.target), ofn)
+    if path.isdir(ofp):
+        assert path.isdir(tfp)
+
+        ossf = [path.join(ofp, f) for f in listdir(ofp) if path.isfile(
+            path.join(ofp, f)) and path.splitext(path.join(ofp, f))[1] == '.silo']
+        tssf = [path.join(tfp, f) for f in listdir(tfp) if path.isfile(
+            path.join(tfp, f)) and path.splitext(path.join(tfp, f))[1] == '.silo']
+
+        assert len(ossf) == len(tssf)
+
+        for o, t in zip(ossf, tssf):
+            fail_if_file_sizes_differ(o, t)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Check test problem output size against reference output.
Notes:
* We have C++17 warnings because we are using 17 even though we only require 14. This PR raises the minimum to 17.
* There is still only one reference file being downloaded. Please comment on what you'd like to do instead.
* The test obviously fails because the file sizes at this time are actually different and this is expected.