### PR TITLE
Add the star_egas_out param for the star problem

### DIFF
--- a/octotiger/options.hpp
+++ b/octotiger/options.hpp
@@ -110,6 +110,7 @@ public:
 	real star_rmax;
 	real star_alpha;
 	real star_rho_out;
+	real star_egas_out;
 	real star_dr;
 	real star_n;
 	real star_rho_center;
@@ -170,6 +171,7 @@ public:
 		arc & star_n;
 		arc & star_rho_center;
 		arc & star_rho_out;
+		arc & star_egas_out;
 		arc & moving_star_xvelocity;
 		arc & moving_star_yvelocity;
 		arc & moving_star_zvelocity;

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -90,6 +90,7 @@ bool options::process_options(int argc, char *argv[]) {
         ("star_alpha", po::value<real>(&(opts().star_alpha))->default_value(1.0 / (3.0 * 3.65375)), "scaling factor for the Lane-Emden equation") // for default n=3/2, ksi_1=3.65375 and alpha=rmax/ksi_1
         ("star_rho_center", po::value<real>(&(opts().star_rho_center))->default_value(1.0), "density at the center of the star")     //
         ("star_rho_out", po::value<real>(&(opts().star_rho_out))->default_value(1.0e-10), "density outside the star")     //
+	("star_egas_out", po::value<real>(&(opts().star_egas_out))->default_value(1.0e-10), "gas energy outside the star")     //
         ("moving_star_xvelocity", po::value<real>(&(opts().moving_star_xvelocity))->default_value(1.0), "velocity of the star in the x-direction")     //
         ("moving_star_yvelocity", po::value<real>(&(opts().moving_star_yvelocity))->default_value(1.0), "velocity of the star in the y-direction")     //
         ("moving_star_zvelocity", po::value<real>(&(opts().moving_star_zvelocity))->default_value(1.0), "velocity of the star in the z-direction")     //

--- a/src/problem.cpp
+++ b/src/problem.cpp
@@ -380,10 +380,7 @@ std::vector<real> star(real x, real y, real z, real) {
 		}
 //		u[rho_i] = std::max(rho_c * std::pow(theta, n), rho_out);
 		u[spc_i] = u[rho_i];
-		u[egas_i] = std::pow(rho_c * std::pow(theta, n), (real(1) + real(1)/n)) * c0 * n;
-		if (theta <= theta_min) {
-			u[egas_i] *= real(100);
-		}
+		u[egas_i] = std::max(opts().star_egas_out, std::pow(rho_c * std::pow(theta, n), (real(1) + real(1)/n)) * c0 * n);
 		u[tau_i] = std::pow(u[egas_i], (n / (real(1) + n)));
 
 		/*		const real r = std::sqrt(x * x + y * y + z * z);


### PR DESCRIPTION
---
Add a parameter for specifying the energy outside the star in the STAR problem
---
Added the following runtime parameter to Octo-Tiger (default value in parenthesis):
star_egas_out (1.0e-10) - gas energy outside the star.

This is important for the benchmark release.