### PR TITLE
Fix timestep columns

### DIFF
--- a/.jenkins/lsu/node-level-tests-entry.sh
+++ b/.jenkins/lsu/node-level-tests-entry.sh
@@ -13,23 +13,23 @@ fi
 
 # Load everything
 echo "Loading modules: "
-module load "${compiler_module}" cuda/11.0 hwloc
+module load "${compiler_module}" cuda/11.4 hwloc
 
 # Tests with griddim = 8
 if [ "${kokkos_config}" = "with-kokkos" ]; then
 	echo "Running tests with griddim=8 on diablo"
-	srun -p QxV100 -N 1 -n 1 -t 01:00:00 bash -c "module load ${compiler_module} cuda/11.0 hwloc && ./build-all.sh Release ${compiler_config} ${cuda_config} without-mpi without-papi without-apex ${kokkos_config} with-simd with-hpx-backend-multipole without-hpx-backend-monopole with-hpx-cuda-polling boost jemalloc hdf5 silo vc hpx kokkos cppuddle octotiger && cd build/octotiger/build && ctest --output-on-failure " 
+	srun -p QxV100 -N 1 -n 1 -t 01:00:00 bash -c "module load ${compiler_module} cuda/11.4 hwloc && ./build-all.sh Release ${compiler_config} ${cuda_config} without-mpi without-papi without-apex ${kokkos_config} with-simd with-hpx-backend-multipole without-hpx-backend-monopole with-hpx-cuda-polling boost jemalloc hdf5 silo vc hpx kokkos cppuddle octotiger && cd build/octotiger/build && ctest --output-on-failure " 
 
 	# Tests with griddim = 16 - only test in full kokkos + cuda build
 	if [ "${cuda_config}" = "with-cuda" ]; then
 		sed -i 's/GRIDDIM=8/GRIDDIM=16/' build-octotiger.sh
 		echo "Running tests with griddim=16 on diablo"
-		srun -p QxV100 -N 1 -n 1 -t 01:00:00 bash -c "module load ${compiler_module} cuda/11.0 hwloc && ./build-all.sh Release ${compiler_config} ${cuda_config} without-mpi without-papi without-apex ${kokkos_config} with-simd with-hpx-backend-multipole without-hpx-backend-monopole with-hpx-cuda-polling boost jemalloc hdf5 silo vc hpx kokkos cppuddle octotiger && cd build/octotiger/build && ctest --output-on-failure " 
+		srun -p QxV100 -N 1 -n 1 -t 01:00:00 bash -c "module load ${compiler_module} cuda/11.4 hwloc && ./build-all.sh Release ${compiler_config} ${cuda_config} without-mpi without-papi without-apex ${kokkos_config} with-simd with-hpx-backend-multipole without-hpx-backend-monopole with-hpx-cuda-polling boost jemalloc hdf5 silo vc hpx kokkos cppuddle octotiger && cd build/octotiger/build && ctest --output-on-failure " 
 		sed -i 's/GRIDDIM=16/GRIDDIM=8/' build-octotiger.sh
 	fi
 else
 	echo "Running tests with griddim=8 on diablo"
-	srun -p QxV100 -N 1 -n 1 -t 01:00:00 bash -c "module load ${compiler_module} cuda/11.0 hwloc && ./build-all.sh Release ${compiler_config} ${cuda_config} without-mpi without-papi without-apex ${kokkos_config} with-simd with-hpx-backend-multipole without-hpx-backend-monopole with-hpx-cuda-polling boost jemalloc hdf5 silo vc hpx cppuddle octotiger && cd build/octotiger/build && ctest --output-on-failure " 
+	srun -p QxV100 -N 1 -n 1 -t 01:00:00 bash -c "module load ${compiler_module} cuda/11.4 hwloc && ./build-all.sh Release ${compiler_config} ${cuda_config} without-mpi without-papi without-apex ${kokkos_config} with-simd with-hpx-backend-multipole without-hpx-backend-monopole with-hpx-cuda-polling boost jemalloc hdf5 silo vc hpx cppuddle octotiger && cd build/octotiger/build && ctest --output-on-failure " 
 fi
 
 # Reset buildscripts (in case of failure, the next job will reset it in the checkout step)

--- a/.jenkins/stuttgart/Jenkinsfile-DEV-NODE
+++ b/.jenkins/stuttgart/Jenkinsfile-DEV-NODE
@@ -84,7 +84,7 @@ pipeline {
                     mkdir src 
                     cp -r ../octotiger src/octotiger 
                     cd src 
-                    curl -u "qE2mrmzt6rAreW5:${NEXTCLOUD_OCTOTIGER_DEPENDENCIES_TOKEN}" -H 'X-Requested-With: XMLHttpRequest' 'https://ipvs.informatik.uni-stuttgart.de/cloud/public.php/webdav/' -o silo.tar.gz 
+                    curl -u "6PRsT5XzKK2pHam:${NEXTCLOUD_OCTOTIGER_DEPENDENCIES_TOKEN}" -H 'X-Requested-With: XMLHttpRequest' 'https://ipvs.informatik.uni-stuttgart.de/cloud/public.php/webdav/' -o silo.tar.gz 
                     tar -xvf silo.tar.gz 
                     mv silo-4.10.2 silo 
                     rm silo.tar.gz 

--- a/.jenkins/stuttgart/Jenkinsfile-KNL
+++ b/.jenkins/stuttgart/Jenkinsfile-KNL
@@ -94,7 +94,7 @@ pipeline {
                     mkdir -p src && \
                     cp -r ../octotiger src/octotiger && \
                     cd src && \
-                    curl -u "qE2mrmzt6rAreW5:${NEXTCLOUD_OCTOTIGER_DEPENDENCIES_TOKEN}" -H 'X-Requested-With: XMLHttpRequest' 'https://ipvs.informatik.uni-stuttgart.de/cloud/public.php/webdav/' -o silo.tar.gz && \
+                    curl -u "6PRsT5XzKK2pHam:${NEXTCLOUD_OCTOTIGER_DEPENDENCIES_TOKEN}" -H 'X-Requested-With: XMLHttpRequest' 'https://ipvs.informatik.uni-stuttgart.de/cloud/public.php/webdav/' -o silo.tar.gz && \
                     tar -xvf silo.tar.gz && \
                     mv silo-4.10.2 silo && \
                     rm silo.tar.gz && \

--- a/.jenkins/stuttgart/Jenkinsfile-POWER9
+++ b/.jenkins/stuttgart/Jenkinsfile-POWER9
@@ -103,7 +103,7 @@ pipeline {
                     mkdir -p src && \
                     cp -r ../octotiger src/octotiger && \
                     cd src && \
-                    curl -u "qE2mrmzt6rAreW5:${NEXTCLOUD_OCTOTIGER_DEPENDENCIES_TOKEN}" -H 'X-Requested-With: XMLHttpRequest' 'https://ipvs.informatik.uni-stuttgart.de/cloud/public.php/webdav/' -o silo.tar.gz && \
+                    curl -u "6PRsT5XzKK2pHam:${NEXTCLOUD_OCTOTIGER_DEPENDENCIES_TOKEN}" -H 'X-Requested-With: XMLHttpRequest' 'https://ipvs.informatik.uni-stuttgart.de/cloud/public.php/webdav/' -o silo.tar.gz && \
                     tar -xvf silo.tar.gz && \
                     mv silo-4.10.2 silo && \
                     rm silo.tar.gz && \

--- a/octotiger/unitiger/hydro_impl/flux.hpp
+++ b/octotiger/unitiger/hydro_impl/flux.hpp
@@ -361,8 +361,8 @@ timestep_t hydro_computer<NDIM, INX, PHYS>::flux_experimental(const hydro::recon
 		UR[f] = Q[f][current_d][current_max_index];
 		UL[f] = Q[f][flipped_dim][current_max_index - geo.H_DN[current_dim]];
 	}
-	ts.ul = UL;
-	ts.ur = UR;
+	ts.ul = UR;
+	ts.ur = UL;
 	ts.dim = current_dim;
 	return ts;
 }

--- a/octotiger/unitiger/hydro_impl/hydro_kokkos_kernel.hpp
+++ b/octotiger/unitiger/hydro_impl/hydro_kokkos_kernel.hpp
@@ -470,8 +470,8 @@ timestep_t device_interface_kokkos_hydro(executor_t& exec, const host_buffer<dou
         URs[f] = host_amax[NDIM * number_blocks + current_i * 2 * nf + f];
         ULs[f] = host_amax[NDIM * number_blocks + current_i * 2 * nf + nf + f];
     }
-    ts.ul = std::move(ULs);
-    ts.ur = std::move(URs);
+    ts.ul = std::move(URs);
+    ts.ur = std::move(ULs);
     ts.dim = current_dim;
     return ts;
 }
@@ -538,8 +538,8 @@ timestep_t device_interface_kokkos_hydro(executor_t& exec, const host_buffer<dou
         URs[f] = amax[blocks + current_i * 2 * nf + f];
         ULs[f] = amax[blocks + current_i * 2 * nf + nf + f];
     }
-    ts.ul = std::move(ULs);
-    ts.ur = std::move(URs);
+    ts.ul = std::move(URs);
+    ts.ur = std::move(ULs);
     ts.dim = current_dim;
     // std::cout << ts.a << std::endl;
     return ts;

--- a/src/node_server_actions_3.cpp
+++ b/src/node_server_actions_3.cpp
@@ -403,8 +403,12 @@ void node_server::execute_solver(bool scf, node_count_type ngrids) {
 				[=]() {
 					const auto vr = sqrt(sqr(dt_.ur[sx_i]) + sqr(dt_.ur[sy_i]) + sqr(dt_.ur[sz_i])) / dt_.ur[0];
 					const auto vl = sqrt(sqr(dt_.ul[sx_i]) + sqr(dt_.ul[sy_i]) + sqr(dt_.ul[sz_i])) / dt_.ul[0];
-					print("%i %e %e %e %e %e %e %e %e %e %e %e %e %i %i %i %i\n", int(next_step - 1), double(t), double(dt_.dt), time_elapsed, rotational_time,
-							dt_.x, dt_.y, dt_.z, dt_.a, dt_.ur[0], dt_.ul[0], vr, vl, dt_.dim, int(ngrids.total), int(ngrids.leaf), int(ngrids.amr_bnd));
+					print("TS %i:: t: %e, dt: %e, time_elapsed: %e, rotational_time: %e, x: %e, y: %e, z: %e, ",
+						int(next_step - 1), double(t), double(dt_.dt), time_elapsed, rotational_time,
+						dt_.x, dt_.y, dt_.z);
+					print("a: %e, ur: %e, ul: %e, vr: %e, vl: %e, dim: %i, ngrids: %i, leafs: %i, amr_boundaries: %i\n", 
+						dt_.a, dt_.ur[0], dt_.ul[0], vr, vl, dt_.dim, int(ngrids.total),
+						int(ngrids.leaf), int(ngrids.amr_bnd));
 				});     // do not wait for output to finish
 
 		step_num = next_step;

--- a/src/unitiger/hydro_impl/flux_cpu_kernel.cpp
+++ b/src/unitiger/hydro_impl/flux_cpu_kernel.cpp
@@ -210,8 +210,8 @@ timestep_t flux_cpu_kernel(const hydro::recon_type<NDIM>& Q, hydro::flux_type& F
         URs[f] = Q[f][current_d][current_max_index];
         ULs[f] = Q[f][flipped_dim][current_max_index - geo.H_DN[current_dim]];
     }
-    ts.ul = ULs;
-    ts.ur = URs;
+    ts.ul = URs;
+    ts.ur = ULs;
     ts.dim = current_dim;
     return ts;
 }

--- a/src/unitiger/hydro_impl/hydro_cuda_interface.cpp
+++ b/src/unitiger/hydro_impl/hydro_cuda_interface.cpp
@@ -107,8 +107,8 @@ timestep_t launch_flux_cuda(stream_interface<hpx::cuda::experimental::cuda_execu
         URs[f] = amax[NDIM * number_blocks + current_i * 2 * nf_ + f];
         ULs[f] = amax[NDIM * number_blocks + current_i * 2 * nf_ + nf_ + f];
     }
-    ts.ul = std::move(ULs);
-    ts.ur = std::move(URs);
+    ts.ul = std::move(URs);
+    ts.ur = std::move(ULs);
     ts.dim = current_dim;
     return ts;
 }


### PR DESCRIPTION
The legacy flux kernel swaps UL and UR when storing the respective values for the time step:
https://github.com/STEllAR-GROUP/octotiger/blob/f2a9c5d50d05d6050ffb5980601b68501de1ee6c/octotiger/unitiger/hydro_impl/flux.hpp#L111
https://github.com/STEllAR-GROUP/octotiger/blob/f2a9c5d50d05d6050ffb5980601b68501de1ee6c/octotiger/unitiger/hydro_impl/flux.hpp#L112

The newer hydro flux kernels (all of them, VC, CUDA, Kokkos) were not doing this, causing swapped ur/ul and vr/vl columns in the time step output on the console!

@dmarce1 @shibersag  I assume the UL/UR swap in the legacy mentioned above is intentional? In case it is: This PR adds the swap when storing UL and UR in the time step variable for all kernels.

