### PR TITLE
Fix power9 jenkins

### DIFF
--- a/.jenkins/stuttgart/Jenkinsfile-POWER9
+++ b/.jenkins/stuttgart/Jenkinsfile-POWER9
@@ -72,7 +72,7 @@ pipeline {
                 dir('octotiger') {
                     /* Get spack cmake */
                     sh '''
-                    srun -p sgs-only -N 1 -n 1 -t 03:00:00 bash -c "\
+                    srun -p sgs-only -N 1 -n 1 -t 03:00:00 --exclusive bash -c "\
                     cd /scratch && \
                     mkdir -p jenkins && cd jenkins; \
                     if [[ ! -d spack ]]; then git clone -b v0.17 --depth 1 https://github.com/spack/spack.git;fi; \
@@ -83,7 +83,7 @@ pipeline {
                     /* Log into the slurm node, create jenkins dir if not in existence, checkout octotiger and the buildscripts 
                       (OctoTigerToolChain), move octotiger src to the correct folder within the buildscripts, download silo */
                     sh '''
-                    srun -p sgs-only -N 1 -n 1 -t 03:00:00 bash -c "\
+                    srun -p sgs-only -N 1 -n 1 -t 03:00:00 --exclusive bash -c "\
                     cd /scratch && \
                     mkdir -p jenkins && cd jenkins && \
                     mkdir -p octotiger-${JOB_BASE_NAME} && cd octotiger-${JOB_BASE_NAME} && \
@@ -116,7 +116,7 @@ pipeline {
         stage('build') {
             steps {
                 sh '''
-                srun -p sgs-only -N 1 -n 1 -t 02:00:00 -D /data/scratch/jenkins/octotiger-${JOB_BASE_NAME}/OctoTigerBuildChain bash -c \
+                srun -p sgs-only -N 1 -n 1 -t 02:00:00 --exclusive -D /data/scratch/jenkins/octotiger-${JOB_BASE_NAME}/OctoTigerBuildChain bash -c \
                 "source /scratch/jenkins/spack/share/spack/setup-env.sh && spack load cmake@3.17.1 &&\
                  module load gcc/8.2.0 && module load cuda/10.2 &&\
                  ./build-all.sh Release with-CC with-cuda without-mpi without-papi without-apex with-kokkos with-simd without-hpx-backend-multipole without-hpx-backend-monopole with-hpx-cuda-polling "
@@ -126,7 +126,7 @@ pipeline {
         stage('ctest-all') {
             steps {
                 sh '''
-                srun -p sgs-only -N 1 -n 1 -t 02:00:00 -D /data/scratch/jenkins/octotiger-${JOB_BASE_NAME}/OctoTigerBuildChain/build/octotiger/build bash -c \
+                srun -p sgs-only -N 1 -n 1 -t 02:00:00 --exclusive -D /data/scratch/jenkins/octotiger-${JOB_BASE_NAME}/OctoTigerBuildChain/build/octotiger/build bash -c \
                 "source /scratch/jenkins/spack/share/spack/setup-env.sh && spack load cmake@3.17.1 &&\
                 module load gcc/8.2.0 && module load cuda/10.2 && ctest --output-on-failure"
                 '''

--- a/.jenkins/stuttgart/Jenkinsfile-POWER9
+++ b/.jenkins/stuttgart/Jenkinsfile-POWER9
@@ -74,8 +74,8 @@ pipeline {
                     sh '''
                     srun -p sgs-only -N 1 -n 1 -t 03:00:00 bash -c "\
                     cd /scratch && \
-                    mkdir -p jenkins && cd jenkins; \
-                    if [[ ! -d spack ]]; then git clone --depth 1 https://github.com/spack/spack.git;fi; \
+                    mkdir -p jenkins && cd jenkins && rm -rf spack; \
+                    if [[ ! -d spack ]]; then git clone -b v0.17 --depth 1 https://github.com/spack/spack.git;fi; \
                     source spack/share/spack/setup-env.sh && \
                     spack install cmake@3.17.1 && \
                     spack load cmake@3.17.1 && echo 'Successfully installed/loaded spack cmake'"

--- a/.jenkins/stuttgart/Jenkinsfile-POWER9
+++ b/.jenkins/stuttgart/Jenkinsfile-POWER9
@@ -74,7 +74,7 @@ pipeline {
                     sh '''
                     srun -p sgs-only -N 1 -n 1 -t 03:00:00 bash -c "\
                     cd /scratch && \
-                    mkdir -p jenkins && cd jenkins && rm -rf spack; \
+                    mkdir -p jenkins && cd jenkins; \
                     if [[ ! -d spack ]]; then git clone -b v0.17 --depth 1 https://github.com/spack/spack.git;fi; \
                     source spack/share/spack/setup-env.sh && \
                     spack install cmake@3.17.1 && \


### PR DESCRIPTION
This PR fixes the POWER9 Jenkins pipeline! It got broken as it pulled a Spack commit from master that did not work on POWER9, breaking the installation of the dependencies! The pipeline now uses a fixed Spack tag and runs on the node exclusively.