### PR TITLE
Fix jenkins rostam config

### DIFF
--- a/.jenkins/lsu/Jenkinsfile-Node-Level
+++ b/.jenkins/lsu/Jenkinsfile-Node-Level
@@ -8,16 +8,16 @@ pipeline {
     options {
         buildDiscarder(
             logRotator(
-                daysToKeepStr: "28",
-                numToKeepStr: "100",
-                artifactDaysToKeepStr: "28",
-                artifactNumToKeepStr: "100"
+                daysToKeepStr: "21",
+                numToKeepStr: "50",
+                artifactDaysToKeepStr: "21",
+                artifactNumToKeepStr: "50"
             )
         )
         disableConcurrentBuilds()
     }
     environment {
-        GITHUB_TOKEN = credentials('STELLARBOT_GITHUB_TOKEN')
+        GITHUB_TOKEN = credentials('GITHUB_TOKEN_OCTOTIGER')
         MAINTAINER_MAIL = credentials('OCTOTIGER_MAINTAINER_EMAIL')
     }
     stages {
@@ -62,11 +62,12 @@ pipeline {
                         steps {
                             dir('octotiger') {
                                 sh '''
+                                github_token=$(echo ${GITHUB_TOKEN} | cut -f2 -d':')
                                 curl --verbose\
                                     --request POST \
                                     --url "https://api.github.com/repos/STEllAR-GROUP/octotiger/statuses/$GIT_COMMIT" \
                                     --header "Content-Type: application/json" \
-                                    --header "authorization: Bearer ${GITHUB_TOKEN}" \
+                                    --header "authorization: Bearer ${github_token}" \
                                     --data "{
                                         \\"state\\": \\"pending\\",
                                         \\"context\\": \\"jenkins-${compiler_config}-${cuda_config}-${kokkos_config}\\",
@@ -125,11 +126,12 @@ pipeline {
                 post {
                     success {
                         sh '''
+                        github_token=$(echo ${GITHUB_TOKEN} | cut -f2 -d':')
                         curl --verbose\
                             --request POST \
                             --url "https://api.github.com/repos/STEllAR-GROUP/octotiger/statuses/$GIT_COMMIT" \
                             --header "Content-Type: application/json" \
-                            --header "authorization: Bearer ${GITHUB_TOKEN}" \
+                            --header "authorization: Bearer ${github_token}" \
                             --data "{
                                 \\"state\\": \\"success\\",
                                 \\"context\\": \\"jenkins-${compiler_config}-${cuda_config}-${kokkos_config}\\",
@@ -140,11 +142,12 @@ pipeline {
                     }
                     failure {
                         sh '''
+                        github_token=$(echo ${GITHUB_TOKEN} | cut -f2 -d':')
                         curl --verbose\
                             --request POST \
                             --url "https://api.github.com/repos/STEllAR-GROUP/octotiger/statuses/$GIT_COMMIT" \
                             --header "Content-Type: application/json" \
-                            --header "authorization: Bearer ${GITHUB_TOKEN}" \
+                            --header "authorization: Bearer ${github_token}" \
                             --data "{
                                 \\"state\\": \\"failure\\",
                                 \\"context\\": \\"jenkins-${compiler_config}-${cuda_config}-${kokkos_config}\\",
@@ -155,11 +158,12 @@ pipeline {
                     }
                     aborted {
                         sh '''
+                        github_token=$(echo ${GITHUB_TOKEN} | cut -f2 -d':')
                         curl --verbose\
                             --request POST \
                             --url "https://api.github.com/repos/STEllAR-GROUP/octotiger/statuses/$GIT_COMMIT" \
                             --header "Content-Type: application/json" \
-                            --header "authorization: Bearer ${GITHUB_TOKEN}" \
+                            --header "authorization: Bearer ${github_token}" \
                             --data "{
                                 \\"state\\": \\"error\\",
                                 \\"context\\": \\"jenkins-${compiler_config}-${cuda_config}-${kokkos_config}\\",

--- a/.jenkins/lsu/Jenkinsfile-Node-Level
+++ b/.jenkins/lsu/Jenkinsfile-Node-Level
@@ -8,16 +8,16 @@ pipeline {
     options {
         buildDiscarder(
             logRotator(
-                daysToKeepStr: "21",
-                numToKeepStr: "50",
-                artifactDaysToKeepStr: "21",
-                artifactNumToKeepStr: "50"
+                daysToKeepStr: "28",
+                numToKeepStr: "100",
+                artifactDaysToKeepStr: "28",
+                artifactNumToKeepStr: "100"
             )
         )
         disableConcurrentBuilds()
     }
     environment {
-        GITHUB_TOKEN = credentials('GITHUB_TOKEN_OCTOTIGER')
+        GITHUB_TOKEN = credentials('STELLARBOT_GITHUB_TOKEN')
         MAINTAINER_MAIL = credentials('OCTOTIGER_MAINTAINER_EMAIL')
     }
     stages {
@@ -62,12 +62,11 @@ pipeline {
                         steps {
                             dir('octotiger') {
                                 sh '''
-                                github_token=$(echo ${GITHUB_TOKEN} | cut -f2 -d':')
                                 curl --verbose\
                                     --request POST \
                                     --url "https://api.github.com/repos/STEllAR-GROUP/octotiger/statuses/$GIT_COMMIT" \
                                     --header "Content-Type: application/json" \
-                                    --header "authorization: Bearer ${github_token}" \
+                                    --header "authorization: Bearer ${GITHUB_TOKEN}" \
                                     --data "{
                                         \\"state\\": \\"pending\\",
                                         \\"context\\": \\"jenkins-${compiler_config}-${cuda_config}-${kokkos_config}\\",
@@ -126,12 +125,11 @@ pipeline {
                 post {
                     success {
                         sh '''
-                        github_token=$(echo ${GITHUB_TOKEN} | cut -f2 -d':')
                         curl --verbose\
                             --request POST \
                             --url "https://api.github.com/repos/STEllAR-GROUP/octotiger/statuses/$GIT_COMMIT" \
                             --header "Content-Type: application/json" \
-                            --header "authorization: Bearer ${github_token}" \
+                            --header "authorization: Bearer ${GITHUB_TOKEN}" \
                             --data "{
                                 \\"state\\": \\"success\\",
                                 \\"context\\": \\"jenkins-${compiler_config}-${cuda_config}-${kokkos_config}\\",
@@ -142,12 +140,11 @@ pipeline {
                     }
                     failure {
                         sh '''
-                        github_token=$(echo ${GITHUB_TOKEN} | cut -f2 -d':')
                         curl --verbose\
                             --request POST \
                             --url "https://api.github.com/repos/STEllAR-GROUP/octotiger/statuses/$GIT_COMMIT" \
                             --header "Content-Type: application/json" \
-                            --header "authorization: Bearer ${github_token}" \
+                            --header "authorization: Bearer ${GITHUB_TOKEN}" \
                             --data "{
                                 \\"state\\": \\"failure\\",
                                 \\"context\\": \\"jenkins-${compiler_config}-${cuda_config}-${kokkos_config}\\",
@@ -158,12 +155,11 @@ pipeline {
                     }
                     aborted {
                         sh '''
-                        github_token=$(echo ${GITHUB_TOKEN} | cut -f2 -d':')
                         curl --verbose\
                             --request POST \
                             --url "https://api.github.com/repos/STEllAR-GROUP/octotiger/statuses/$GIT_COMMIT" \
                             --header "Content-Type: application/json" \
-                            --header "authorization: Bearer ${github_token}" \
+                            --header "authorization: Bearer ${GITHUB_TOKEN}" \
                             --data "{
                                 \\"state\\": \\"error\\",
                                 \\"context\\": \\"jenkins-${compiler_config}-${cuda_config}-${kokkos_config}\\",

--- a/.jenkins/lsu/Jenkinsfile-Node-Level
+++ b/.jenkins/lsu/Jenkinsfile-Node-Level
@@ -92,7 +92,7 @@ pipeline {
                                     git checkout main
                                     git pull
                                     rm -rf build/octotiger
-                                    rn -rf build/kokkos
+                                    rm -rf build/kokkos
                                     rm -rf src/octotiger
                                 else
                                     git clone https://github.com/diehlpk/PowerTiger.git "octo-buildscripts-${compiler_config}-${cuda_config}-${kokkos_config}"
@@ -100,7 +100,7 @@ pipeline {
                                     git checkout main # change to different branch if needed for target machine
                                     mkdir src
                                     rm -rf build/octotiger
-                                    rn -rf build/kokkos
+                                    rm -rf build/kokkos
                                     rm -rf src/octotiger
                                 fi
 

--- a/.jenkins/lsu/Jenkinsfile-Node-Level
+++ b/.jenkins/lsu/Jenkinsfile-Node-Level
@@ -2,23 +2,6 @@
 
 def buildbadge = addEmbeddableBadgeConfiguration(id: "nodelevel", subject: "CPU / GPU Kernel Tests", status: "skipped")
 
-// Skip builds that are likely to be tested already (by push) and unlikely to be critical (not on master)
-if (currentBuild.getBuildCauses().toString().contains('BranchIndexingCause')) {
-    print "INFO: Build on ${env.BRANCH_NAME}/${env.BUILD_NUMBER} triggered by branch indexing..."
-    if (env.BRANCH_NAME != "master") { // Always run on master
-        if (env.BUILD_NUMBER != "1") { // Always run first build on a new branch pipeline to load the options (and thus github hook triggers) for the pipeline
-            print "INFO: Build on ${env.BRANCH_NAME}/${env.BUILD_NUMBER} skipped due being triggered by Branch Indexing instead of SCM change!"
-            currentBuild.result = 'ABORTED' 
-            buildbadge.setStatus('skipped')
-            return // Early exit to avoid redundant builds
-        }
-    }
-} else {
-    print "INFO: Build on ${env.BRANCH_NAME}/${env.BUILD_NUMBER} triggered by SCM change..."
-    print "Proceeding!"
-} 
-
-
 pipeline {
     agent any
 
@@ -32,10 +15,6 @@ pipeline {
             )
         )
         disableConcurrentBuilds()
-    }
-    triggers {
-        githubPush() // Trigger by push to respective github branch
-        pollSCM 'H/5 * * * *' // Fallback polling solution as some pushes are somehow lost
     }
     environment {
         GITHUB_TOKEN = credentials('GITHUB_TOKEN_OCTOTIGER')
@@ -115,12 +94,16 @@ pipeline {
                                     git checkout main
                                     git pull
                                     rm -rf build/octotiger
+                                    rn -rf build/kokkos
                                     rm -rf src/octotiger
                                 else
                                     git clone https://github.com/diehlpk/PowerTiger.git "octo-buildscripts-${compiler_config}-${cuda_config}-${kokkos_config}"
                                     cd "octo-buildscripts-${compiler_config}-${cuda_config}-${kokkos_config}"
                                     git checkout main # change to different branch if needed for target machine
                                     mkdir src
+                                    rm -rf build/octotiger
+                                    rn -rf build/kokkos
+                                    rm -rf src/octotiger
                                 fi
 
                                 cd ..

--- a/.jenkins/lsu/Jenkinsfile-Node-Level
+++ b/.jenkins/lsu/Jenkinsfile-Node-Level
@@ -8,10 +8,10 @@ pipeline {
     options {
         buildDiscarder(
             logRotator(
-                daysToKeepStr: "21",
-                numToKeepStr: "50",
-                artifactDaysToKeepStr: "21",
-                artifactNumToKeepStr: "50"
+                daysToKeepStr: "28",
+                numToKeepStr: "100",
+                artifactDaysToKeepStr: "28",
+                artifactNumToKeepStr: "100"
             )
         )
         disableConcurrentBuilds()
@@ -32,7 +32,6 @@ pipeline {
                         cd octotiger
                         git submodule update --init --recursive
                         cd ..
-                        echo "Build started on pipeline ${JOB_BASE_NAME} with build ID ${BUILD_NUMBER} using GIT commit ${GIT_COMMIT}" | mail -s "Jenkins Octo-Tiger Node-Level Tests: Build ${JOB_BASE_NAME}/${BUILD_NUMBER} just started..." "${MAINTAINER_MAIL}"
                     '''
                 }
             }
@@ -181,9 +180,6 @@ pipeline {
             script {
                 buildbadge.setStatus('success')
             }
-            sh '''
-                echo "Build succeded! Pipeline ${JOB_BASE_NAME} with build ID ${BUILD_NUMBER} using GIT commit ${GIT_COMMIT}" | mail -s "Jenkins Octo-Tiger Node-Level Tests: Build ${JOB_BASE_NAME}/${BUILD_NUMBER} succeded" "${MAINTAINER_MAIL}"
-            '''
         }
         failure {
             script {

--- a/.jenkins/lsu/Jenkinsfile-Node-Level
+++ b/.jenkins/lsu/Jenkinsfile-Node-Level
@@ -23,7 +23,6 @@ pipeline {
     stages {
         stage('checkout') {
             steps {
-                scmSkip(deleteBuild: false, skipPattern:'.*\\[ci skip\\].*')
                 script {
                     buildbadge.setStatus('running')
                 }

--- a/.jenkins/lsu/node-level-tests-entry.sh
+++ b/.jenkins/lsu/node-level-tests-entry.sh
@@ -24,6 +24,7 @@ if [ "${kokkos_config}" = "with-kokkos" ]; then
 	if [ "${cuda_config}" = "with-cuda" ]; then
 		sed -i 's/GRIDDIM=8/GRIDDIM=16/' build-octotiger.sh
 		echo "Running tests with griddim=16 on diablo"
+		rm -rf build/kokkos build/octotiger # in case we end up on a different cuda node we need to rebuild with its architecture
 		srun -p cuda -N 1 -n 1 -t 08:00:00 bash -c "module load ${compiler_module} cuda/11.4 hwloc && ./build-all.sh Release ${compiler_config} ${cuda_config} without-mpi without-papi without-apex ${kokkos_config} with-simd with-hpx-backend-multipole without-hpx-backend-monopole with-hpx-cuda-polling without-otf2 boost jemalloc hdf5 silo vc hpx kokkos cppuddle octotiger && cd build/octotiger/build && ctest --output-on-failure " 
 		sed -i 's/GRIDDIM=16/GRIDDIM=8/' build-octotiger.sh
 	fi

--- a/.jenkins/lsu/node-level-tests-entry.sh
+++ b/.jenkins/lsu/node-level-tests-entry.sh
@@ -18,19 +18,19 @@ module load "${compiler_module}" cuda/11.4 hwloc
 # Tests with griddim = 8
 if [ "${kokkos_config}" = "with-kokkos" ]; then
 	echo "Running tests with griddim=8 on diablo"
-	srun -p cuda-V100 -w diablo -N 1 -n 1 -t 08:00:00 bash -c "module load ${compiler_module} cuda/11.4 hwloc && ./build-all.sh Release ${compiler_config} ${cuda_config} without-mpi without-papi without-apex ${kokkos_config} with-simd with-hpx-backend-multipole without-hpx-backend-monopole with-hpx-cuda-polling boost jemalloc hdf5 silo vc hpx kokkos cppuddle octotiger && cd build/octotiger/build && ctest --output-on-failure " 
+	srun -p cuda-V100 -w diablo -N 1 -n 1 -t 08:00:00 bash -c "module load ${compiler_module} cuda/11.4 hwloc && ./build-all.sh Release ${compiler_config} ${cuda_config} without-mpi without-papi without-apex ${kokkos_config} with-simd with-hpx-backend-multipole without-hpx-backend-monopole with-hpx-cuda-polling without-otf2 boost jemalloc hdf5 silo vc hpx kokkos cppuddle octotiger && cd build/octotiger/build && ctest --output-on-failure " 
 
 	# Tests with griddim = 16 - only test in full kokkos + cuda build
 	if [ "${cuda_config}" = "with-cuda" ]; then
 		sed -i 's/GRIDDIM=8/GRIDDIM=16/' build-octotiger.sh
 		echo "Running tests with griddim=16 on diablo"
-		srun -p cuda-V100 -w diablo -N 1 -n 1 -t 08:00:00 bash -c "module load ${compiler_module} cuda/11.4 hwloc && ./build-all.sh Release ${compiler_config} ${cuda_config} without-mpi without-papi without-apex ${kokkos_config} with-simd with-hpx-backend-multipole without-hpx-backend-monopole with-hpx-cuda-polling boost jemalloc hdf5 silo vc hpx kokkos cppuddle octotiger && cd build/octotiger/build && ctest --output-on-failure " 
+		srun -p cuda-V100 -w diablo -N 1 -n 1 -t 08:00:00 bash -c "module load ${compiler_module} cuda/11.4 hwloc && ./build-all.sh Release ${compiler_config} ${cuda_config} without-mpi without-papi without-apex ${kokkos_config} with-simd with-hpx-backend-multipole without-hpx-backend-monopole with-hpx-cuda-polling without-otf2 boost jemalloc hdf5 silo vc hpx kokkos cppuddle octotiger && cd build/octotiger/build && ctest --output-on-failure " 
 		sed -i 's/GRIDDIM=16/GRIDDIM=8/' build-octotiger.sh
 	fi
 else
 	# TODO Run this on a different server as intended to cut the test time?
 	echo "Running tests with griddim=8 on diablo"
-	srun -p cuda-V100 -w diablo -N 1 -n 1 -t 08:00:00 bash -c "module load ${compiler_module} cuda/11.4 hwloc && ./build-all.sh Release ${compiler_config} ${cuda_config} without-mpi without-papi without-apex ${kokkos_config} with-simd with-hpx-backend-multipole without-hpx-backend-monopole with-hpx-cuda-polling boost jemalloc hdf5 silo vc hpx cppuddle octotiger && cd build/octotiger/build && ctest --output-on-failure " 
+	srun -p cuda-V100 -w diablo -N 1 -n 1 -t 08:00:00 bash -c "module load ${compiler_module} cuda/11.4 hwloc && ./build-all.sh Release ${compiler_config} ${cuda_config} without-mpi without-papi without-apex ${kokkos_config} with-simd with-hpx-backend-multipole without-hpx-backend-monopole with-hpx-cuda-polling without-otf2 boost jemalloc hdf5 silo vc hpx cppuddle octotiger && cd build/octotiger/build && ctest --output-on-failure " 
 fi
 
 # Reset buildscripts (in case of failure, the next job will reset it in the checkout step)

--- a/.jenkins/lsu/node-level-tests-entry.sh
+++ b/.jenkins/lsu/node-level-tests-entry.sh
@@ -3,11 +3,11 @@
 set -eux
 
 #default: Assume gcc 
-compiler_module="gcc/9.3.0"
+compiler_module="gcc/9.4.0"
 
 # if clang: change modules and no blast test (no quadmath..)
 if [ "${compiler_config}" = "with-CC-clang" ]; then
-  compiler_module="clang/11.0.1"
+  compiler_module="llvm/11.1.0"
   sed -i 's/OCTOTIGER_WITH_BLAST_TEST=ON/OCTOTIGER_WITH_BLAST_TEST=OFF/' build-octotiger.sh
 fi
 
@@ -18,18 +18,19 @@ module load "${compiler_module}" cuda/11.4 hwloc
 # Tests with griddim = 8
 if [ "${kokkos_config}" = "with-kokkos" ]; then
 	echo "Running tests with griddim=8 on diablo"
-	srun -p QxV100 -N 1 -n 1 -t 08:00:00 bash -c "module load ${compiler_module} cuda/11.4 hwloc && ./build-all.sh Release ${compiler_config} ${cuda_config} without-mpi without-papi without-apex ${kokkos_config} with-simd with-hpx-backend-multipole without-hpx-backend-monopole with-hpx-cuda-polling boost jemalloc hdf5 silo vc hpx kokkos cppuddle octotiger && cd build/octotiger/build && ctest --output-on-failure " 
+	srun -p cuda-V100 -w diablo -N 1 -n 1 -t 08:00:00 bash -c "module load ${compiler_module} cuda/11.4 hwloc && ./build-all.sh Release ${compiler_config} ${cuda_config} without-mpi without-papi without-apex ${kokkos_config} with-simd with-hpx-backend-multipole without-hpx-backend-monopole with-hpx-cuda-polling boost jemalloc hdf5 silo vc hpx kokkos cppuddle octotiger && cd build/octotiger/build && ctest --output-on-failure " 
 
 	# Tests with griddim = 16 - only test in full kokkos + cuda build
 	if [ "${cuda_config}" = "with-cuda" ]; then
 		sed -i 's/GRIDDIM=8/GRIDDIM=16/' build-octotiger.sh
 		echo "Running tests with griddim=16 on diablo"
-		srun -p QxV100 -N 1 -n 1 -t 08:00:00 bash -c "module load ${compiler_module} cuda/11.4 hwloc && ./build-all.sh Release ${compiler_config} ${cuda_config} without-mpi without-papi without-apex ${kokkos_config} with-simd with-hpx-backend-multipole without-hpx-backend-monopole with-hpx-cuda-polling boost jemalloc hdf5 silo vc hpx kokkos cppuddle octotiger && cd build/octotiger/build && ctest --output-on-failure " 
+		srun -p cuda-V100 -w diablo -N 1 -n 1 -t 08:00:00 bash -c "module load ${compiler_module} cuda/11.4 hwloc && ./build-all.sh Release ${compiler_config} ${cuda_config} without-mpi without-papi without-apex ${kokkos_config} with-simd with-hpx-backend-multipole without-hpx-backend-monopole with-hpx-cuda-polling boost jemalloc hdf5 silo vc hpx kokkos cppuddle octotiger && cd build/octotiger/build && ctest --output-on-failure " 
 		sed -i 's/GRIDDIM=16/GRIDDIM=8/' build-octotiger.sh
 	fi
 else
+	# TODO Run this on a different server as intended to cut the test time?
 	echo "Running tests with griddim=8 on diablo"
-	srun -p QxV100 -N 1 -n 1 -t 08:00:00 bash -c "module load ${compiler_module} cuda/11.4 hwloc && ./build-all.sh Release ${compiler_config} ${cuda_config} without-mpi without-papi without-apex ${kokkos_config} with-simd with-hpx-backend-multipole without-hpx-backend-monopole with-hpx-cuda-polling boost jemalloc hdf5 silo vc hpx cppuddle octotiger && cd build/octotiger/build && ctest --output-on-failure " 
+	srun -p cuda-V100 -w diablo -N 1 -n 1 -t 08:00:00 bash -c "module load ${compiler_module} cuda/11.4 hwloc && ./build-all.sh Release ${compiler_config} ${cuda_config} without-mpi without-papi without-apex ${kokkos_config} with-simd with-hpx-backend-multipole without-hpx-backend-monopole with-hpx-cuda-polling boost jemalloc hdf5 silo vc hpx cppuddle octotiger && cd build/octotiger/build && ctest --output-on-failure " 
 fi
 
 # Reset buildscripts (in case of failure, the next job will reset it in the checkout step)

--- a/.jenkins/lsu/node-level-tests-entry.sh
+++ b/.jenkins/lsu/node-level-tests-entry.sh
@@ -4,12 +4,18 @@ set -eux
 
 #default: Assume gcc 
 compiler_module="gcc/9.4.0"
+simd_config="with-simd"
 
 # if clang: change modules and no blast test (no quadmath..)
 if [ "${compiler_config}" = "with-CC-clang" ]; then
   compiler_module="llvm/11.1.0"
   sed -i 's/OCTOTIGER_WITH_BLAST_TEST=ON/OCTOTIGER_WITH_BLAST_TEST=OFF/' build-octotiger.sh
 fi
+# Test gcc 9.4.0 and nvcc without kokkos simd types for now
+if [ "${compiler_config}" = "with-CC" ] && [ "${kokkos_config}" = "with-kokkos" ] && [ "${kokkos_config}" = "with-kokkos" ]; then
+  simd_config="without-simd"
+fi
+
 
 # Load everything
 echo "Loading modules: "
@@ -18,20 +24,20 @@ module load "${compiler_module}" cuda/11.4 hwloc
 # Tests with griddim = 8
 if [ "${kokkos_config}" = "with-kokkos" ]; then
 	echo "Running tests with griddim=8 on diablo"
-	srun -p cuda -N 1 -n 1 -t 08:00:00 bash -c "module load ${compiler_module} cuda/11.4 hwloc && ./build-all.sh Release ${compiler_config} ${cuda_config} without-mpi without-papi without-apex ${kokkos_config} with-simd with-hpx-backend-multipole without-hpx-backend-monopole with-hpx-cuda-polling without-otf2 boost jemalloc hdf5 silo vc hpx kokkos cppuddle octotiger && cd build/octotiger/build && ctest --output-on-failure " 
+	srun -p cuda -N 1 -n 1 -t 08:00:00 bash -c "module load ${compiler_module} cuda/11.4 hwloc && ./build-all.sh Release ${compiler_config} ${cuda_config} without-mpi without-papi without-apex ${kokkos_config} ${simd_config} with-hpx-backend-multipole without-hpx-backend-monopole with-hpx-cuda-polling without-otf2 boost jemalloc hdf5 silo vc hpx kokkos cppuddle octotiger && cd build/octotiger/build && ctest --output-on-failure " 
 
 	# Tests with griddim = 16 - only test in full kokkos + cuda build
 	if [ "${cuda_config}" = "with-cuda" ]; then
 		sed -i 's/GRIDDIM=8/GRIDDIM=16/' build-octotiger.sh
 		echo "Running tests with griddim=16 on diablo"
 		rm -rf build/kokkos build/octotiger # in case we end up on a different cuda node we need to rebuild with its architecture
-		srun -p cuda -N 1 -n 1 -t 08:00:00 bash -c "module load ${compiler_module} cuda/11.4 hwloc && ./build-all.sh Release ${compiler_config} ${cuda_config} without-mpi without-papi without-apex ${kokkos_config} with-simd with-hpx-backend-multipole without-hpx-backend-monopole with-hpx-cuda-polling without-otf2 boost jemalloc hdf5 silo vc hpx kokkos cppuddle octotiger && cd build/octotiger/build && ctest --output-on-failure " 
+		srun -p cuda -N 1 -n 1 -t 08:00:00 bash -c "module load ${compiler_module} cuda/11.4 hwloc && ./build-all.sh Release ${compiler_config} ${cuda_config} without-mpi without-papi without-apex ${kokkos_config} ${simd_config} with-hpx-backend-multipole without-hpx-backend-monopole with-hpx-cuda-polling without-otf2 boost jemalloc hdf5 silo vc hpx kokkos cppuddle octotiger && cd build/octotiger/build && ctest --output-on-failure " 
 		sed -i 's/GRIDDIM=16/GRIDDIM=8/' build-octotiger.sh
 	fi
 else
 	# TODO Run this on a different server as intended to cut the test time?
 	echo "Running tests with griddim=8 on diablo"
-	srun -p cuda -N 1 -n 1 -t 08:00:00 bash -c "module load ${compiler_module} cuda/11.4 hwloc && ./build-all.sh Release ${compiler_config} ${cuda_config} without-mpi without-papi without-apex ${kokkos_config} with-simd with-hpx-backend-multipole without-hpx-backend-monopole with-hpx-cuda-polling without-otf2 boost jemalloc hdf5 silo vc hpx cppuddle octotiger && cd build/octotiger/build && ctest --output-on-failure " 
+	srun -p cuda -N 1 -n 1 -t 08:00:00 bash -c "module load ${compiler_module} cuda/11.4 hwloc && ./build-all.sh Release ${compiler_config} ${cuda_config} without-mpi without-papi without-apex ${kokkos_config} ${simd_config} with-hpx-backend-multipole without-hpx-backend-monopole with-hpx-cuda-polling without-otf2 boost jemalloc hdf5 silo vc hpx cppuddle octotiger && cd build/octotiger/build && ctest --output-on-failure " 
 fi
 
 # Reset buildscripts (in case of failure, the next job will reset it in the checkout step)

--- a/.jenkins/lsu/node-level-tests-entry.sh
+++ b/.jenkins/lsu/node-level-tests-entry.sh
@@ -18,19 +18,19 @@ module load "${compiler_module}" cuda/11.4 hwloc
 # Tests with griddim = 8
 if [ "${kokkos_config}" = "with-kokkos" ]; then
 	echo "Running tests with griddim=8 on diablo"
-	srun -p cuda-V100 -w diablo -N 1 -n 1 -t 08:00:00 bash -c "module load ${compiler_module} cuda/11.4 hwloc && ./build-all.sh Release ${compiler_config} ${cuda_config} without-mpi without-papi without-apex ${kokkos_config} with-simd with-hpx-backend-multipole without-hpx-backend-monopole with-hpx-cuda-polling without-otf2 boost jemalloc hdf5 silo vc hpx kokkos cppuddle octotiger && cd build/octotiger/build && ctest --output-on-failure " 
+	srun -p cuda -N 1 -n 1 -t 08:00:00 bash -c "module load ${compiler_module} cuda/11.4 hwloc && ./build-all.sh Release ${compiler_config} ${cuda_config} without-mpi without-papi without-apex ${kokkos_config} with-simd with-hpx-backend-multipole without-hpx-backend-monopole with-hpx-cuda-polling without-otf2 boost jemalloc hdf5 silo vc hpx kokkos cppuddle octotiger && cd build/octotiger/build && ctest --output-on-failure " 
 
 	# Tests with griddim = 16 - only test in full kokkos + cuda build
 	if [ "${cuda_config}" = "with-cuda" ]; then
 		sed -i 's/GRIDDIM=8/GRIDDIM=16/' build-octotiger.sh
 		echo "Running tests with griddim=16 on diablo"
-		srun -p cuda-V100 -w diablo -N 1 -n 1 -t 08:00:00 bash -c "module load ${compiler_module} cuda/11.4 hwloc && ./build-all.sh Release ${compiler_config} ${cuda_config} without-mpi without-papi without-apex ${kokkos_config} with-simd with-hpx-backend-multipole without-hpx-backend-monopole with-hpx-cuda-polling without-otf2 boost jemalloc hdf5 silo vc hpx kokkos cppuddle octotiger && cd build/octotiger/build && ctest --output-on-failure " 
+		srun -p cuda -N 1 -n 1 -t 08:00:00 bash -c "module load ${compiler_module} cuda/11.4 hwloc && ./build-all.sh Release ${compiler_config} ${cuda_config} without-mpi without-papi without-apex ${kokkos_config} with-simd with-hpx-backend-multipole without-hpx-backend-monopole with-hpx-cuda-polling without-otf2 boost jemalloc hdf5 silo vc hpx kokkos cppuddle octotiger && cd build/octotiger/build && ctest --output-on-failure " 
 		sed -i 's/GRIDDIM=16/GRIDDIM=8/' build-octotiger.sh
 	fi
 else
 	# TODO Run this on a different server as intended to cut the test time?
 	echo "Running tests with griddim=8 on diablo"
-	srun -p cuda-V100 -w diablo -N 1 -n 1 -t 08:00:00 bash -c "module load ${compiler_module} cuda/11.4 hwloc && ./build-all.sh Release ${compiler_config} ${cuda_config} without-mpi without-papi without-apex ${kokkos_config} with-simd with-hpx-backend-multipole without-hpx-backend-monopole with-hpx-cuda-polling without-otf2 boost jemalloc hdf5 silo vc hpx cppuddle octotiger && cd build/octotiger/build && ctest --output-on-failure " 
+	srun -p cuda -N 1 -n 1 -t 08:00:00 bash -c "module load ${compiler_module} cuda/11.4 hwloc && ./build-all.sh Release ${compiler_config} ${cuda_config} without-mpi without-papi without-apex ${kokkos_config} with-simd with-hpx-backend-multipole without-hpx-backend-monopole with-hpx-cuda-polling without-otf2 boost jemalloc hdf5 silo vc hpx cppuddle octotiger && cd build/octotiger/build && ctest --output-on-failure " 
 fi
 
 # Reset buildscripts (in case of failure, the next job will reset it in the checkout step)

--- a/.jenkins/stuttgart/Jenkinsfile-DEV-NODE
+++ b/.jenkins/stuttgart/Jenkinsfile-DEV-NODE
@@ -2,39 +2,19 @@
 
 def buildbadge = addEmbeddableBadgeConfiguration(id: "devbuild", subject: "Dev-Environment Tests", status: "skipped")
 
-if (currentBuild.getBuildCauses().toString().contains('BranchIndexingCause')) {
-    print "INFO: Build on ${env.BRANCH_NAME}/${env.BUILD_NUMBER}  triggered by branch indexing..."
-    if (env.BRANCH_NAME != "master") {
-        if (env.BUILD_NUMBER != "1") { // Always execute first build to load this configuration and thus the triggers
-            print "INFO: Build on ${env.BRANCH_NAME}/${env.BUILD_NUMBER} skipped due being triggered by Branch Indexing instead of SCM change!"
-            buildbadge.setStatus('skipped')
-            currentBuild.result = 'ABORTED'
-            return // early exit to avoid redundant builds 
-        }
-    }
-} else {
-    print "INFO: Build on ${env.BRANCH_NAME}/${env.BUILD_NUMBER} triggered by SCM change..."
-    print "Proceeding!"
-}
-
-
 pipeline {
     agent { label 'pcsgs05' }
 
     options {
         buildDiscarder(
             logRotator(
-                daysToKeepStr: "21",
-                numToKeepStr: "50",
-                artifactDaysToKeepStr: "21",
-                artifactNumToKeepStr: "50"
+                daysToKeepStr: "28",
+                numToKeepStr: "100",
+                artifactDaysToKeepStr: "28",
+                artifactNumToKeepStr: "100"
             )
         )
         disableConcurrentBuilds()
-    }
-    triggers {
-        githubPush() // Trigger by push to respective github branch
-        pollSCM 'H/30 * * * *' // Fallback polling solution as some pushes are somehow lost
     }
     environment {
         GITHUB_TOKEN = credentials('GITHUB_TOKEN_OCTOTIGER')

--- a/.jenkins/stuttgart/Jenkinsfile-DEV-NODE
+++ b/.jenkins/stuttgart/Jenkinsfile-DEV-NODE
@@ -24,7 +24,6 @@ pipeline {
     stages {
         stage('init') {
             steps {
-                scmSkip(deleteBuild: false, skipPattern:'.*\\[ci skip\\].*')
                 script {
                     buildbadge.setStatus('running')
                 }

--- a/.jenkins/stuttgart/Jenkinsfile-KNL
+++ b/.jenkins/stuttgart/Jenkinsfile-KNL
@@ -2,40 +2,19 @@
 
 def buildbadge = addEmbeddableBadgeConfiguration(id: "knlbuild", subject: "KNL Kokkos SIMD Tests", status: "skipped")
 
-if (currentBuild.getBuildCauses().toString().contains('BranchIndexingCause')) {
-    print "INFO: Build on ${env.BRANCH_NAME}/${env.BUILD_NUMBER}  triggered by branch indexing..."
-    if (env.BRANCH_NAME != "master") {
-        if (env.BUILD_NUMBER != "1") { // Always execute first build to load this configuration and thus the triggers
-            print "INFO: Build on ${env.BRANCH_NAME}/${env.BUILD_NUMBER} skipped due being triggered by Branch Indexing instead of SCM change!"
-            buildbadge.setStatus('skipped')
-            currentBuild.result = 'ABORTED'
-            return // early exit to avoid redundant builds
-        }
-    }
-} else {
-    print "INFO: Build on ${env.BRANCH_NAME}/${env.BUILD_NUMBER} triggered by SCM change..."
-    print "Proceeding!"
-}
-
-
-
 pipeline {
     agent { label 'argon-fs' }
 
     options {
         buildDiscarder(
             logRotator(
-                daysToKeepStr: "21",
-                numToKeepStr: "50",
-                artifactDaysToKeepStr: "21",
-                artifactNumToKeepStr: "50"
+                daysToKeepStr: "28",
+                numToKeepStr: "100",
+                artifactDaysToKeepStr: "28",
+                artifactNumToKeepStr: "100"
             )
         )
 	disableConcurrentBuilds()
-    }
-    triggers {
-        githubPush() // Trigger by push to respective github branch
-        pollSCM 'H/30 * * * *' // Fallback polling solution as some pushes are somehow lost
     }
     environment {
         GITHUB_TOKEN = credentials('GITHUB_TOKEN_OCTOTIGER')

--- a/.jenkins/stuttgart/Jenkinsfile-KNL
+++ b/.jenkins/stuttgart/Jenkinsfile-KNL
@@ -24,7 +24,6 @@ pipeline {
     stages {
         stage('init') {
             steps {
-                scmSkip(deleteBuild: false, skipPattern:'.*\\[ci skip\\].*')
                 script {
                     buildbadge.setStatus('running')
                 }

--- a/.jenkins/stuttgart/Jenkinsfile-KNL
+++ b/.jenkins/stuttgart/Jenkinsfile-KNL
@@ -42,7 +42,6 @@ pipeline {
                                 \\"description\\": \\"Jenkins CI Job: jenkins-KNL-SIMD\\",
                                 \\"target_url\\": \\"https://simsgs.informatik.uni-stuttgart.de/jenkins/job/Octo-Tiger%20KNL/job/${JOB_BASE_NAME}/${BUILD_NUMBER}/console\\"
                         }"
-                        echo "Build started on pipeline ${JOB_BASE_NAME} with build ID ${BUILD_NUMBER} using GIT commit ${GIT_COMMIT}" | mail -s "Jenkins Octo-Tiger KNL: Build ${JOB_BASE_NAME}/${BUILD_NUMBER} just started..." "${MAINTAINER_MAIL}"
                     '''
                 }
             }
@@ -162,7 +161,6 @@ pipeline {
                         \\"description\\": \\"Jenkins CI Job: jenkins-KNL-SIMD\\",
                         \\"target_url\\": \\"https://simsgs.informatik.uni-stuttgart.de/jenkins/job/Octo-Tiger%20KNL/job/${JOB_BASE_NAME}/${BUILD_NUMBER}/console\\"
                 }"
-                echo "Build succeded on pipeline ${JOB_BASE_NAME} with build ID ${BUILD_NUMBER} using GIT commit ${GIT_COMMIT}" | mail -s "Jenkins Octo-Tiger KNL: Build ${JOB_BASE_NAME}/${BUILD_NUMBER} succeded" "${MAINTAINER_MAIL}"
             '''
         }
         failure {

--- a/.jenkins/stuttgart/Jenkinsfile-POWER9
+++ b/.jenkins/stuttgart/Jenkinsfile-POWER9
@@ -2,38 +2,19 @@
 
 def buildbadge = addEmbeddableBadgeConfiguration(id: "powerbuild", subject: "Power9 CUDA/Kokkos Tests", status: "skipped")
 
-if (currentBuild.getBuildCauses().toString().contains('BranchIndexingCause')) {
-    print "INFO: Build on ${env.BRANCH_NAME}/${env.BUILD_NUMBER}  triggered by branch indexing..."
-    if (env.BRANCH_NAME != "master") {
-        if (env.BUILD_NUMBER != "1") { // Always execute first build to load this configuration and thus the triggers
-            print "INFO: Build on ${env.BRANCH_NAME}/${env.BUILD_NUMBER} skipped due being triggered by Branch Indexing instead of SCM change!"
-            buildbadge.setStatus('skipped')
-            currentBuild.result = 'ABORTED'
-            return // early exit to avoid redundant builds
-        }
-    }
-} else {
-    print "INFO: Build on ${env.BRANCH_NAME}/${env.BUILD_NUMBER} triggered by SCM change..."
-    print "Proceeding!"
-}
-
 pipeline {
     agent { label 'argon-fs' }
 
     options {
         buildDiscarder(
             logRotator(
-                daysToKeepStr: "21",
-                numToKeepStr: "50",
-                artifactDaysToKeepStr: "21",
-                artifactNumToKeepStr: "50"
+                daysToKeepStr: "28",
+                numToKeepStr: "100",
+                artifactDaysToKeerStr: "28",
+                artifactNumToKeepStr: "100"
             )
         )
 	disableConcurrentBuilds()
-    }
-    triggers {
-        githubPush() // Trigger by push to respective github branch
-        pollSCM 'H/30 * * * *' // Fallback polling solution as some pushes are somehow lost
     }
 
     environment {

--- a/.jenkins/stuttgart/Jenkinsfile-POWER9
+++ b/.jenkins/stuttgart/Jenkinsfile-POWER9
@@ -10,7 +10,7 @@ pipeline {
             logRotator(
                 daysToKeepStr: "28",
                 numToKeepStr: "100",
-                artifactDaysToKeerStr: "28",
+                artifactDaysToKeepStr: "28",
                 artifactNumToKeepStr: "100"
             )
         )

--- a/.jenkins/stuttgart/Jenkinsfile-POWER9
+++ b/.jenkins/stuttgart/Jenkinsfile-POWER9
@@ -43,7 +43,6 @@ pipeline {
                                 \\"description\\": \\"Jenkins CI Job: jenkins-POWER9\\",
                                 \\"target_url\\": \\"https://simsgs.informatik.uni-stuttgart.de/jenkins/job/Octo-Tiger%20POWER9/job/${JOB_BASE_NAME}/${BUILD_NUMBER}/console\\"
                         }"
-                        echo "Build started on pipeline ${JOB_BASE_NAME} with build ID ${BUILD_NUMBER} using GIT commit ${GIT_COMMIT}" | mail -s "Jenkins Octo-Tiger POWER9: Build ${JOB_BASE_NAME}/${BUILD_NUMBER} just started..." "${MAINTAINER_MAIL}"
                     '''
                 }
             }
@@ -132,7 +131,6 @@ pipeline {
                         \\"description\\": \\"Jenkins CI Job: jenkins-POWER9\\",
                         \\"target_url\\": \\"https://simsgs.informatik.uni-stuttgart.de/jenkins/job/Octo-Tiger%20POWER9/job/${JOB_BASE_NAME}/${BUILD_NUMBER}/console\\"
                 }"
-                echo "Build succeded on pipeline ${JOB_BASE_NAME} with build ID ${BUILD_NUMBER} using GIT commit ${GIT_COMMIT}" | mail -s "Jenkins Octo-Tiger POWER9: Build ${JOB_BASE_NAME}/${BUILD_NUMBER} succeded" "${MAINTAINER_MAIL}"
             '''
         }
         failure {

--- a/.jenkins/stuttgart/Jenkinsfile-POWER9
+++ b/.jenkins/stuttgart/Jenkinsfile-POWER9
@@ -25,7 +25,6 @@ pipeline {
     stages {
         stage('init') {
             steps {
-                scmSkip(deleteBuild: false, skipPattern:'.*\\[ci skip\\].*')
                 script {
                     buildbadge.setStatus('running')
                 }


### PR DESCRIPTION
The available compiler and machine configuration on Rostam changed (breaking the rostam Jenkins pipeline).

This PR resolves any issues regarding this! 

I further took the opportunity and streamlined the entire pipeline while I was at it:
- The tests are now being run on all available CUDA machines, speeding the testing up.
- The tests are now only triggered by the Jenkins branch indexing (queried every 5 minutes). This seems to work more reliably than the push trigger
- Removed ci_skip (it had the unfortunate tendency of skipping a test on a merge if just one out of X commits had the ci_skip annotation).
- Test logs are being stored for a longer duration.
- Reduced Jenkins Emails verbosity.