### PR TITLE
Upgrade to C++17 and add compatibility to the most current hpx master branch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ project(octotiger CXX C)
 
 # Search path for CMake modules to be loaded by include() and find_package()
 list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 ################################################################################
 # Options
 ################################################################################

--- a/frontend/frontend-helper.cpp
+++ b/frontend/frontend-helper.cpp
@@ -42,7 +42,10 @@
 #include <hpx/include/actions.hpp>
 #include <hpx/include/lcos.hpp>
 #include <hpx/include/util.hpp>
+#if HPX_VERSION_FULL > 0x010600
+// Can't find hpx::find_all_localities() in newer HPX versions without this header
 #include <hpx/modules/runtime_distributed.hpp>
+#endif
 
 #include <chrono>
 #include <cstdio>

--- a/frontend/frontend-helper.cpp
+++ b/frontend/frontend-helper.cpp
@@ -42,6 +42,7 @@
 #include <hpx/include/actions.hpp>
 #include <hpx/include/lcos.hpp>
 #include <hpx/include/util.hpp>
+#include <hpx/modules/runtime_distributed.hpp>
 
 #include <chrono>
 #include <cstdio>

--- a/octotiger/future.hpp
+++ b/octotiger/future.hpp
@@ -65,7 +65,7 @@ inline void wait_all_and_propagate_exceptions(Ts &&futs) {
 	 (void)sequencer;*/
 }
 
-template<class T>
+/*template<class T>
 inline T debug_get(future<T> &f, const char *file, int line) {
 	if (f.valid() == false) {
 		print("get on invalid future file %s line %i\n", file, line);
@@ -79,9 +79,9 @@ inline T debug_get(future<T> &f, const char *file, int line) {
 		}
 	}
 	return f.get();
-}
+}*/
 
-template<class T>
+/*template<class T>
 inline T debug_get(future<T> &&_f, const char *file, int line) {
 	future<T> f = std::move(_f);
 	return debug_get(f, file, line);
@@ -102,7 +102,7 @@ inline T debug_get(const hpx::shared_future<T> &f, const char *file, int line) {
 //		}
 //	}
 	return f.get();
-}
+}*/
 
 //#ifndef NDEBUG
 //#define GET(fut) debug_get(fut,__FILE__,__LINE__)
@@ -110,6 +110,7 @@ inline T debug_get(const hpx::shared_future<T> &f, const char *file, int line) {
 //#define GET(fut) ((fut).get())
 //#endif
 
-#define GET(fut) debug_get(fut,__FILE__,__LINE__)
+//#define GET(fut) debug_get(fut,__FILE__,__LINE__)
+#define GET(fut) fut.get()
 
 #endif /* FUTURE_HPP_ */

--- a/src/io/silo_out.cpp
+++ b/src/io/silo_out.cpp
@@ -103,7 +103,7 @@ void output_stage1(std::string fname, int cycle) {
 	for (auto i = node_registry::begin(); i != node_registry::end(); ++i) {
 		const auto *node_ptr_ = GET(i->second.get_ptr());
 		if (!node_ptr_->refined()) {
-			futs_.push_back(hpx::async(hpx::launch::async(hpx::threads::thread_priority_boost), [](node_location loc, node_registry::node_ptr ptr) {
+			futs_.push_back(hpx::async(hpx::launch::async_policy(hpx::threads::thread_priority::boost), [](node_location loc, node_registry::node_ptr ptr) {
 				const auto *this_ptr = ptr.get_ptr().get();
 				assert(this_ptr);
 				const real dx = TWO / real(1 << loc.level()) / real(INX);
@@ -246,7 +246,7 @@ void output_stage3(std::string fname, int cycle, int gn, int gb, int ge) {
 		DBClose(db);
 	}, cycle).get();
 	if (this_id < ge - 1) {
-		auto f = hpx::async<output_stage3_action>(hpx::launch::async(hpx::threads::thread_priority_boost), localities[this_id + 1], fname, cycle, gn, gb, ge);
+		auto f = hpx::async<output_stage3_action>(hpx::launch::async_policy(hpx::threads::thread_priority::boost), localities[this_id + 1], fname, cycle, gn, gb, ge);
 
 		GET(f);
 	}
@@ -536,13 +536,13 @@ void output_all(node_server *root_ptr, std::string fname, int cycle, bool block)
 	start_step = nsteps;
 	std::vector<hpx::future<void>> futs1;
 	for (auto &id : localities) {
-		futs1.push_back(hpx::async<output_stage1_action>(hpx::launch::async(hpx::threads::thread_priority_boost), id, fname, cycle));
+		futs1.push_back(hpx::async<output_stage1_action>(hpx::launch::async_policy(hpx::threads::thread_priority::boost), id, fname, cycle));
 	}
 	GET(hpx::when_all(futs1));
 
 	std::vector<hpx::future<node_list_t>> id_futs;
 	for (auto &id : localities) {
-		id_futs.push_back(hpx::async<output_stage2_action>(hpx::launch::async(hpx::threads::thread_priority_boost), id, fname, cycle));
+		id_futs.push_back(hpx::async<output_stage2_action>(hpx::launch::async_policy(hpx::threads::thread_priority::boost), id, fname, cycle));
 	}
 	node_list_.silo_leaves.clear();
 	node_list_.group_num.clear();
@@ -575,10 +575,10 @@ void output_all(node_server *root_ptr, std::string fname, int cycle, bool block)
 	for (int i = 0; i < ng; i++) {
 		int gb = (i * localities.size()) / ng;
 		int ge = ((i + 1) * localities.size()) / ng;
-		futs.push_back(hpx::async < output_stage3_action > (hpx::launch::async(hpx::threads::thread_priority_boost), localities[gb], fname, cycle, i, gb, ge));
+		futs.push_back(hpx::async < output_stage3_action > (hpx::launch::async_policy(hpx::threads::thread_priority::boost), localities[gb], fname, cycle, i, gb, ge));
 	}
 
-	barrier = hpx::async(hpx::launch::async(hpx::threads::thread_priority_boost), [tstart, fname, cycle](std::vector<hpx::future<void>> &&futs) {
+	barrier = hpx::async(hpx::launch::async_policy(hpx::threads::thread_priority::boost), [tstart, fname, cycle](std::vector<hpx::future<void>> &&futs) {
 		for (auto &f : futs) {
 			GET(f);
 		}

--- a/src/io/silo_out.cpp
+++ b/src/io/silo_out.cpp
@@ -6,6 +6,8 @@
 
 #include <ctime>
 #include <hpx/runtime/threads/run_as_os_thread.hpp>
+
+
 #include <cerrno>
 
 #include <sys/stat.h>
@@ -103,7 +105,7 @@ void output_stage1(std::string fname, int cycle) {
 	for (auto i = node_registry::begin(); i != node_registry::end(); ++i) {
 		const auto *node_ptr_ = GET(i->second.get_ptr());
 		if (!node_ptr_->refined()) {
-			futs_.push_back(hpx::async(hpx::launch::async(hpx::threads::thread_priority_boost), [](node_location loc, node_registry::node_ptr ptr) {
+			futs_.push_back(hpx::async([](node_location loc, node_registry::node_ptr ptr) {
 				const auto *this_ptr = ptr.get_ptr().get();
 				assert(this_ptr);
 				const real dx = TWO / real(1 << loc.level()) / real(INX);
@@ -246,7 +248,7 @@ void output_stage3(std::string fname, int cycle, int gn, int gb, int ge) {
 		DBClose(db);
 	}, cycle).get();
 	if (this_id < ge - 1) {
-		auto f = hpx::async<output_stage3_action>(hpx::launch::async(hpx::threads::thread_priority_boost), localities[this_id + 1], fname, cycle, gn, gb, ge);
+		auto f = hpx::async<output_stage3_action>(localities[this_id + 1], fname, cycle, gn, gb, ge);
 
 		GET(f);
 	}
@@ -536,13 +538,13 @@ void output_all(node_server *root_ptr, std::string fname, int cycle, bool block)
 	start_step = nsteps;
 	std::vector<hpx::future<void>> futs1;
 	for (auto &id : localities) {
-		futs1.push_back(hpx::async<output_stage1_action>(hpx::launch::async(hpx::threads::thread_priority_boost), id, fname, cycle));
+		futs1.push_back(hpx::async<output_stage1_action>(id, fname, cycle));
 	}
 	GET(hpx::when_all(futs1));
 
 	std::vector<hpx::future<node_list_t>> id_futs;
 	for (auto &id : localities) {
-		id_futs.push_back(hpx::async<output_stage2_action>(hpx::launch::async(hpx::threads::thread_priority_boost), id, fname, cycle));
+		id_futs.push_back(hpx::async<output_stage2_action>(id, fname, cycle));
 	}
 	node_list_.silo_leaves.clear();
 	node_list_.group_num.clear();
@@ -575,10 +577,10 @@ void output_all(node_server *root_ptr, std::string fname, int cycle, bool block)
 	for (int i = 0; i < ng; i++) {
 		int gb = (i * localities.size()) / ng;
 		int ge = ((i + 1) * localities.size()) / ng;
-		futs.push_back(hpx::async < output_stage3_action > (hpx::launch::async(hpx::threads::thread_priority_boost), localities[gb], fname, cycle, i, gb, ge));
+		futs.push_back(hpx::async < output_stage3_action > (localities[gb], fname, cycle, i, gb, ge));
 	}
 
-	barrier = hpx::async(hpx::launch::async(hpx::threads::thread_priority_boost), [tstart, fname, cycle](std::vector<hpx::future<void>> &&futs) {
+	barrier = hpx::async([tstart, fname, cycle](std::vector<hpx::future<void>> &&futs) {
 		for (auto &f : futs) {
 			GET(f);
 		}

--- a/src/io/silo_out.cpp
+++ b/src/io/silo_out.cpp
@@ -6,8 +6,6 @@
 
 #include <ctime>
 #include <hpx/runtime/threads/run_as_os_thread.hpp>
-
-
 #include <cerrno>
 
 #include <sys/stat.h>
@@ -105,7 +103,7 @@ void output_stage1(std::string fname, int cycle) {
 	for (auto i = node_registry::begin(); i != node_registry::end(); ++i) {
 		const auto *node_ptr_ = GET(i->second.get_ptr());
 		if (!node_ptr_->refined()) {
-			futs_.push_back(hpx::async([](node_location loc, node_registry::node_ptr ptr) {
+			futs_.push_back(hpx::async(hpx::launch::async(hpx::threads::thread_priority_boost), [](node_location loc, node_registry::node_ptr ptr) {
 				const auto *this_ptr = ptr.get_ptr().get();
 				assert(this_ptr);
 				const real dx = TWO / real(1 << loc.level()) / real(INX);
@@ -248,7 +246,7 @@ void output_stage3(std::string fname, int cycle, int gn, int gb, int ge) {
 		DBClose(db);
 	}, cycle).get();
 	if (this_id < ge - 1) {
-		auto f = hpx::async<output_stage3_action>(localities[this_id + 1], fname, cycle, gn, gb, ge);
+		auto f = hpx::async<output_stage3_action>(hpx::launch::async(hpx::threads::thread_priority_boost), localities[this_id + 1], fname, cycle, gn, gb, ge);
 
 		GET(f);
 	}
@@ -538,13 +536,13 @@ void output_all(node_server *root_ptr, std::string fname, int cycle, bool block)
 	start_step = nsteps;
 	std::vector<hpx::future<void>> futs1;
 	for (auto &id : localities) {
-		futs1.push_back(hpx::async<output_stage1_action>(id, fname, cycle));
+		futs1.push_back(hpx::async<output_stage1_action>(hpx::launch::async(hpx::threads::thread_priority_boost), id, fname, cycle));
 	}
 	GET(hpx::when_all(futs1));
 
 	std::vector<hpx::future<node_list_t>> id_futs;
 	for (auto &id : localities) {
-		id_futs.push_back(hpx::async<output_stage2_action>(id, fname, cycle));
+		id_futs.push_back(hpx::async<output_stage2_action>(hpx::launch::async(hpx::threads::thread_priority_boost), id, fname, cycle));
 	}
 	node_list_.silo_leaves.clear();
 	node_list_.group_num.clear();
@@ -577,10 +575,10 @@ void output_all(node_server *root_ptr, std::string fname, int cycle, bool block)
 	for (int i = 0; i < ng; i++) {
 		int gb = (i * localities.size()) / ng;
 		int ge = ((i + 1) * localities.size()) / ng;
-		futs.push_back(hpx::async < output_stage3_action > (localities[gb], fname, cycle, i, gb, ge));
+		futs.push_back(hpx::async < output_stage3_action > (hpx::launch::async(hpx::threads::thread_priority_boost), localities[gb], fname, cycle, i, gb, ge));
 	}
 
-	barrier = hpx::async([tstart, fname, cycle](std::vector<hpx::future<void>> &&futs) {
+	barrier = hpx::async(hpx::launch::async(hpx::threads::thread_priority_boost), [tstart, fname, cycle](std::vector<hpx::future<void>> &&futs) {
 		for (auto &f : futs) {
 			GET(f);
 		}

--- a/src/node_server_actions_3.cpp
+++ b/src/node_server_actions_3.cpp
@@ -544,7 +544,7 @@ future<void> node_server::nonrefined_step() {
 
 	for (integer rk = 0; rk < NRK; ++rk) {
 
-		fut = fut.then(hpx::launch::async(hpx::threads::thread_priority_boost),
+		fut = fut.then(
 		hpx::util::annotated_function(
 				[rk, cfl0, this, dt_fut](future<void> f) {
 					GET(f);
@@ -622,7 +622,7 @@ future<real> node_server::local_step(integer steps) {
 			}
 		}
 
-		fut = fut.then(hpx::launch::async(hpx::threads::thread_priority_boost), hpx::util::annotated_function([this, i, steps](future<void> fut) -> real {
+		fut = fut.then(hpx::util::annotated_function([this, i, steps](future<void> fut) -> real {
 			GET(fut);
 			auto time_start = std::chrono::high_resolution_clock::now();
 			auto next_dt = timestep_driver_descend();

--- a/src/node_server_actions_3.cpp
+++ b/src/node_server_actions_3.cpp
@@ -544,7 +544,7 @@ future<void> node_server::nonrefined_step() {
 
 	for (integer rk = 0; rk < NRK; ++rk) {
 
-		fut = fut.then(
+		fut = fut.then(hpx::launch::async(hpx::threads::thread_priority_boost),
 		hpx::util::annotated_function(
 				[rk, cfl0, this, dt_fut](future<void> f) {
 					GET(f);
@@ -622,7 +622,7 @@ future<real> node_server::local_step(integer steps) {
 			}
 		}
 
-		fut = fut.then(hpx::util::annotated_function([this, i, steps](future<void> fut) -> real {
+		fut = fut.then(hpx::launch::async(hpx::threads::thread_priority_boost), hpx::util::annotated_function([this, i, steps](future<void> fut) -> real {
 			GET(fut);
 			auto time_start = std::chrono::high_resolution_clock::now();
 			auto next_dt = timestep_driver_descend();

--- a/src/node_server_actions_3.cpp
+++ b/src/node_server_actions_3.cpp
@@ -544,7 +544,7 @@ future<void> node_server::nonrefined_step() {
 
 	for (integer rk = 0; rk < NRK; ++rk) {
 
-		fut = fut.then(hpx::launch::async(hpx::threads::thread_priority_boost),
+		fut = fut.then(hpx::launch::async_policy(hpx::threads::thread_priority::boost),
 		hpx::util::annotated_function(
 				[rk, cfl0, this, dt_fut](future<void> f) {
 					GET(f);
@@ -622,7 +622,7 @@ future<real> node_server::local_step(integer steps) {
 			}
 		}
 
-		fut = fut.then(hpx::launch::async(hpx::threads::thread_priority_boost), hpx::util::annotated_function([this, i, steps](future<void> fut) -> real {
+		fut = fut.then(hpx::launch::async_policy(hpx::threads::thread_priority::boost), hpx::util::annotated_function([this, i, steps](future<void> fut) -> real {
 			GET(fut);
 			auto time_start = std::chrono::high_resolution_clock::now();
 			auto next_dt = timestep_driver_descend();

--- a/src/options_processing.cpp
+++ b/src/options_processing.cpp
@@ -11,7 +11,10 @@
 #include "octotiger/common_kernel/interaction_constants.hpp"
 
 #include <boost/program_options.hpp>
- #include <hpx/modules/runtime_distributed.hpp>
+#if HPX_VERSION_FULL > 0x010600
+// Can't find hpx::find_all_localities() in newer HPX versions without this header
+#include <hpx/modules/runtime_distributed.hpp>
+#endif
 
 #include <cmath>
 #include <iosfwd>

--- a/src/options_processing.cpp
+++ b/src/options_processing.cpp
@@ -11,12 +11,15 @@
 #include "octotiger/common_kernel/interaction_constants.hpp"
 
 #include <boost/program_options.hpp>
+ #include <hpx/modules/runtime_distributed.hpp>
 
 #include <cmath>
 #include <iosfwd>
 #include <sstream>
 #include <string>
 #include <vector>
+
+#include <fstream>
 
 #define IN_OPTIONS_CPP
 


### PR DESCRIPTION
- Adapt to deprecated functions and different headers in HPX to make Octo-Tiger compatible with the HPX master again (whilst maintaining current compatibility with older HPX versions as well)
- Upgrade Octo-Tiger to C++17 