### PR TITLE
Update jenkins compiler

### DIFF
--- a/.jenkins/lsu/node-level-tests-entry.sh
+++ b/.jenkins/lsu/node-level-tests-entry.sh
@@ -3,12 +3,12 @@
 set -eux
 
 #default: Assume gcc 
-compiler_module="gcc/11.2.0"
+compiler_module="gcc/10.3.0"
 simd_config="with-simd"
 
 # if clang: change modules and no blast test (no quadmath..)
 if [ "${compiler_config}" = "with-CC-clang" ]; then
-  compiler_module="llvm/13.0.0"
+  compiler_module="llvm/12.0.1"
   sed -i 's/OCTOTIGER_WITH_BLAST_TEST=ON/OCTOTIGER_WITH_BLAST_TEST=OFF/' build-octotiger.sh
 fi
 

--- a/.jenkins/lsu/node-level-tests-entry.sh
+++ b/.jenkins/lsu/node-level-tests-entry.sh
@@ -8,7 +8,7 @@ simd_config="with-simd"
 
 # if clang: change modules and no blast test (no quadmath..)
 if [ "${compiler_config}" = "with-CC-clang" ]; then
-  compiler_module="llvm/11.1.0"
+  compiler_module="llvm/13.0.0"
   sed -i 's/OCTOTIGER_WITH_BLAST_TEST=ON/OCTOTIGER_WITH_BLAST_TEST=OFF/' build-octotiger.sh
 fi
 

--- a/.jenkins/lsu/node-level-tests-entry.sh
+++ b/.jenkins/lsu/node-level-tests-entry.sh
@@ -3,7 +3,7 @@
 set -eux
 
 #default: Assume gcc 
-compiler_module="gcc/9.4.0"
+compiler_module="gcc/11.2.0"
 simd_config="with-simd"
 
 # if clang: change modules and no blast test (no quadmath..)
@@ -11,32 +11,28 @@ if [ "${compiler_config}" = "with-CC-clang" ]; then
   compiler_module="llvm/11.1.0"
   sed -i 's/OCTOTIGER_WITH_BLAST_TEST=ON/OCTOTIGER_WITH_BLAST_TEST=OFF/' build-octotiger.sh
 fi
-# Test gcc 9.4.0 and nvcc without kokkos simd types for now
-if [ "${compiler_config}" = "with-CC" ] && [ "${kokkos_config}" = "with-kokkos" ] && [ "${kokkos_config}" = "with-kokkos" ]; then
-  simd_config="without-simd"
-fi
 
 
 # Load everything
 echo "Loading modules: "
-module load "${compiler_module}" cuda/11.4 hwloc
+module load "${compiler_module}" cuda/11.5 hwloc
 
 # Tests with griddim = 8
 if [ "${kokkos_config}" = "with-kokkos" ]; then
 	echo "Running tests with griddim=8"
-	srun --partition=cuda-V100,cuda-A100 -N 1 -n 1 -t 08:00:00 bash -c "module load ${compiler_module} cuda/11.4 hwloc && ./build-all.sh Release ${compiler_config} ${cuda_config} without-mpi without-papi without-apex ${kokkos_config} ${simd_config} with-hpx-backend-multipole without-hpx-backend-monopole with-hpx-cuda-polling without-otf2 boost jemalloc hdf5 silo vc hpx kokkos cppuddle octotiger && cd build/octotiger/build && ctest --output-on-failure " 
+	srun --partition=cuda-V100,cuda-A100 -N 1 -n 1 -t 08:00:00 bash -c "module load ${compiler_module} cuda/11.5 hwloc && ./build-all.sh Release ${compiler_config} ${cuda_config} without-mpi without-papi without-apex ${kokkos_config} ${simd_config} with-hpx-backend-multipole without-hpx-backend-monopole with-hpx-cuda-polling without-otf2 boost jemalloc hdf5 silo vc hpx kokkos cppuddle octotiger && cd build/octotiger/build && ctest --output-on-failure " 
 
 	# Tests with griddim = 16 - only test in full kokkos + cuda build
 	if [ "${cuda_config}" = "with-cuda" ]; then
 		sed -i 's/GRIDDIM=8/GRIDDIM=16/' build-octotiger.sh
 		echo "Running tests with griddim=16 on diablo"
 		rm -rf build # in case we end up on a different cuda node we need to rebuild with its architecture
-		srun --partition=cuda-V100,cuda-A100 -N 1 -n 1 -t 08:00:00 bash -c "module load ${compiler_module} cuda/11.4 hwloc && ./build-all.sh Release ${compiler_config} ${cuda_config} without-mpi without-papi without-apex ${kokkos_config} ${simd_config} with-hpx-backend-multipole without-hpx-backend-monopole with-hpx-cuda-polling without-otf2 boost jemalloc hdf5 silo vc hpx kokkos cppuddle octotiger && cd build/octotiger/build && ctest --output-on-failure " 
+		srun --partition=cuda-V100,cuda-A100 -N 1 -n 1 -t 08:00:00 bash -c "module load ${compiler_module} cuda/11.5 hwloc && ./build-all.sh Release ${compiler_config} ${cuda_config} without-mpi without-papi without-apex ${kokkos_config} ${simd_config} with-hpx-backend-multipole without-hpx-backend-monopole with-hpx-cuda-polling without-otf2 boost jemalloc hdf5 silo vc hpx kokkos cppuddle octotiger && cd build/octotiger/build && ctest --output-on-failure " 
 		sed -i 's/GRIDDIM=16/GRIDDIM=8/' build-octotiger.sh
 	fi
 else
 	echo "Running tests with griddim=8"
-	srun --partition=cuda-V100,cuda-A100 -N 1 -n 1 -t 08:00:00 bash -c "module load ${compiler_module} cuda/11.4 hwloc && ./build-all.sh Release ${compiler_config} ${cuda_config} without-mpi without-papi without-apex ${kokkos_config} ${simd_config} with-hpx-backend-multipole without-hpx-backend-monopole with-hpx-cuda-polling without-otf2 boost jemalloc hdf5 silo vc hpx cppuddle octotiger && cd build/octotiger/build && ctest --output-on-failure " 
+	srun --partition=cuda-V100,cuda-A100 -N 1 -n 1 -t 08:00:00 bash -c "module load ${compiler_module} cuda/11.5 hwloc && ./build-all.sh Release ${compiler_config} ${cuda_config} without-mpi without-papi without-apex ${kokkos_config} ${simd_config} with-hpx-backend-multipole without-hpx-backend-monopole with-hpx-cuda-polling without-otf2 boost jemalloc hdf5 silo vc hpx cppuddle octotiger && cd build/octotiger/build && ctest --output-on-failure " 
 fi
 
 # Reset buildscripts (in case of failure, the next job will reset it in the checkout step)

--- a/.jenkins/lsu/node-level-tests-entry.sh
+++ b/.jenkins/lsu/node-level-tests-entry.sh
@@ -18,21 +18,16 @@ echo "Loading modules: "
 module load "${compiler_module}" cuda/11.5 hwloc
 
 # Tests with griddim = 8
-if [ "${kokkos_config}" = "with-kokkos" ]; then
-	echo "Running tests with griddim=8"
-	srun --partition=cuda-V100,cuda-A100 -N 1 -n 1 -t 08:00:00 bash -c "module load ${compiler_module} cuda/11.5 hwloc && ./build-all.sh Release ${compiler_config} ${cuda_config} without-mpi without-papi without-apex ${kokkos_config} ${simd_config} with-hpx-backend-multipole without-hpx-backend-monopole with-hpx-cuda-polling without-otf2 boost jemalloc hdf5 silo vc hpx kokkos cppuddle octotiger && cd build/octotiger/build && ctest --output-on-failure " 
+echo "Running tests with griddim=8"
+srun --partition=cuda-V100,cuda-A100 -N 1 -n 1 -t 08:00:00 bash -c "module load ${compiler_module} cuda/11.5 hwloc && ./build-all.sh Release ${compiler_config} ${cuda_config} without-mpi without-papi without-apex ${kokkos_config} ${simd_config} with-hpx-backend-multipole without-hpx-backend-monopole with-hpx-cuda-polling without-otf2 boost jemalloc hdf5 silo vc hpx kokkos cppuddle octotiger && cd build/octotiger/build && ctest --output-on-failure " 
 
-	# Tests with griddim = 16 - only test in full kokkos + cuda build
-	if [ "${cuda_config}" = "with-cuda" ]; then
-		sed -i 's/GRIDDIM=8/GRIDDIM=16/' build-octotiger.sh
-		echo "Running tests with griddim=16 on diablo"
-		rm -rf build # in case we end up on a different cuda node we need to rebuild with its architecture
-		srun --partition=cuda-V100,cuda-A100 -N 1 -n 1 -t 08:00:00 bash -c "module load ${compiler_module} cuda/11.5 hwloc && ./build-all.sh Release ${compiler_config} ${cuda_config} without-mpi without-papi without-apex ${kokkos_config} ${simd_config} with-hpx-backend-multipole without-hpx-backend-monopole with-hpx-cuda-polling without-otf2 boost jemalloc hdf5 silo vc hpx kokkos cppuddle octotiger && cd build/octotiger/build && ctest --output-on-failure " 
-		sed -i 's/GRIDDIM=16/GRIDDIM=8/' build-octotiger.sh
-	fi
-else
-	echo "Running tests with griddim=8"
-	srun --partition=cuda-V100,cuda-A100 -N 1 -n 1 -t 08:00:00 bash -c "module load ${compiler_module} cuda/11.5 hwloc && ./build-all.sh Release ${compiler_config} ${cuda_config} without-mpi without-papi without-apex ${kokkos_config} ${simd_config} with-hpx-backend-multipole without-hpx-backend-monopole with-hpx-cuda-polling without-otf2 boost jemalloc hdf5 silo vc hpx cppuddle octotiger && cd build/octotiger/build && ctest --output-on-failure " 
+# Tests with griddim = 16 - only test in full kokkos + cuda build
+if [ "${cuda_config}" = "with-cuda" ] && [ "${kokkos_config}" = "with-kokkos" ]; then
+	sed -i 's/GRIDDIM=8/GRIDDIM=16/' build-octotiger.sh
+	echo "Running tests with griddim=16 on diablo"
+	rm -rf build # in case we end up on a different cuda node we need to rebuild with its architecture
+	srun --partition=cuda-V100,cuda-A100 -N 1 -n 1 -t 08:00:00 bash -c "module load ${compiler_module} cuda/11.5 hwloc && ./build-all.sh Release ${compiler_config} ${cuda_config} without-mpi without-papi without-apex ${kokkos_config} ${simd_config} with-hpx-backend-multipole without-hpx-backend-monopole with-hpx-cuda-polling without-otf2 boost jemalloc hdf5 silo vc hpx kokkos cppuddle octotiger && cd build/octotiger/build && ctest --output-on-failure " 
+	sed -i 's/GRIDDIM=16/GRIDDIM=8/' build-octotiger.sh
 fi
 
 # Reset buildscripts (in case of failure, the next job will reset it in the checkout step)


### PR DESCRIPTION
As we updated the toolchain to new versions of Kokkos and HPX in STEllAR-GROUP/octotigerbuildchain#12, this PR updates the compilers in the Jenkins tests to gcc 11 and clang 13 to properly build the dependencies.