### PR TITLE
Limit jenkins to jenkins partitions

### DIFF
--- a/.jenkins/lsu/hip-tests-entry.sh
+++ b/.jenkins/lsu/hip-tests-entry.sh
@@ -3,10 +3,10 @@
 set -eux
 
 # Tests with griddim = 8
-srun -p jenkins-amdgpu -N 1 -n 1 -t 02:00:00 bash -c "module load gcc/9.4.0 rocm/4.3.1 hwloc && module list && hipcc --version && ./build-all.sh Release with-CC-clang without-cuda without-mpi without-papi without-apex with-kokkos with-simd without-hpx-backend-multipole without-hpx-backend-monopole with-hpx-cuda-polling without-otf2 boost jemalloc hdf5 silo vc hpx kokkos cppuddle octotiger && cd build/octotiger/build && ctest --output-on-failure " 
+srun -p jenkins-amdgpu -N 1 -n 1 -t 02:00:00 bash -c "module load gcc/9.4.0 rocm/4.3.1 hwloc && module list && hipcc --version && rocminfo && ./build-all.sh Release with-CC-clang without-cuda without-mpi without-papi without-apex with-kokkos with-simd without-hpx-backend-multipole without-hpx-backend-monopole with-hpx-cuda-polling without-otf2 boost jemalloc hdf5 silo vc hpx kokkos cppuddle octotiger && cd build/octotiger/build && ctest --output-on-failure " 
 
 # Tests with griddim = 16
 sed -i 's/GRIDDIM=8/GRIDDIM=16/' build-octotiger.sh
-srun -p jenkins-amdgpu -N 1 -n 1 -t 02:00:00 bash -c "module load gcc/9.4.0 rocm/4.3.1 hwloc && module list && hipcc --version && ./build-all.sh Release with-CC-clang without-cuda without-mpi without-papi without-apex with-kokkos with-simd without-hpx-backend-multipole without-hpx-backend-monopole with-hpx-cuda-polling without-otf2 octotiger && cd build/octotiger/build && ctest --output-on-failure " 
+srun -p jenkins-amdgpu -N 1 -n 1 -t 02:00:00 bash -c "module load gcc/9.4.0 rocm/4.3.1 hwloc && module list && hipcc --version && rocminfo && ./build-all.sh Release with-CC-clang without-cuda without-mpi without-papi without-apex with-kokkos with-simd without-hpx-backend-multipole without-hpx-backend-monopole with-hpx-cuda-polling without-otf2 octotiger && cd build/octotiger/build && ctest --output-on-failure " 
 sed -i 's/GRIDDIM=16/GRIDDIM=8/' build-octotiger.sh
 

--- a/.jenkins/lsu/hip-tests-entry.sh
+++ b/.jenkins/lsu/hip-tests-entry.sh
@@ -3,10 +3,10 @@
 set -eux
 
 # Tests with griddim = 8
-srun -p mi100 -N 1 -n 1 -t 01:00:00 bash -c "module load gcc/9.4.0 rocm/4.3.1 hwloc && ./build-all.sh Release with-CC-clang without-cuda without-mpi without-papi without-apex with-kokkos with-simd without-hpx-backend-multipole without-hpx-backend-monopole with-hpx-cuda-polling without-otf2 boost jemalloc hdf5 silo vc hpx kokkos cppuddle octotiger && cd build/octotiger/build && ctest --output-on-failure " 
+srun -p jenkins-amdgpu -N 1 -n 1 -t 01:00:00 bash -c "module load gcc/9.4.0 rocm/4.3.1 hwloc && ./build-all.sh Release with-CC-clang without-cuda without-mpi without-papi without-apex with-kokkos with-simd without-hpx-backend-multipole without-hpx-backend-monopole with-hpx-cuda-polling without-otf2 boost jemalloc hdf5 silo vc hpx kokkos cppuddle octotiger && cd build/octotiger/build && ctest --output-on-failure " 
 
 # Tests with griddim = 16
 sed -i 's/GRIDDIM=8/GRIDDIM=16/' build-octotiger.sh
-srun -p mi100 -N 1 -n 1 -t 01:00:00 bash -c "module load gcc/9.4.0 rocm/4.3.1 hwloc && ./build-all.sh Release with-CC-clang without-cuda without-mpi without-papi without-apex with-kokkos with-simd without-hpx-backend-multipole without-hpx-backend-monopole with-hpx-cuda-polling without-otf2 octotiger && cd build/octotiger/build && ctest --output-on-failure " 
+srun -p jenkins-amdgpu -N 1 -n 1 -t 01:00:00 bash -c "module load gcc/9.4.0 rocm/4.3.1 hwloc && ./build-all.sh Release with-CC-clang without-cuda without-mpi without-papi without-apex with-kokkos with-simd without-hpx-backend-multipole without-hpx-backend-monopole with-hpx-cuda-polling without-otf2 octotiger && cd build/octotiger/build && ctest --output-on-failure " 
 sed -i 's/GRIDDIM=16/GRIDDIM=8/' build-octotiger.sh
 

--- a/.jenkins/lsu/hip-tests-entry.sh
+++ b/.jenkins/lsu/hip-tests-entry.sh
@@ -3,10 +3,10 @@
 set -eux
 
 # Tests with griddim = 8
-srun -p jenkins-amdgpu -N 1 -n 1 -t 01:00:00 bash -c "module load gcc/9.4.0 rocm/4.3.1 hwloc && ./build-all.sh Release with-CC-clang without-cuda without-mpi without-papi without-apex with-kokkos with-simd without-hpx-backend-multipole without-hpx-backend-monopole with-hpx-cuda-polling without-otf2 boost jemalloc hdf5 silo vc hpx kokkos cppuddle octotiger && cd build/octotiger/build && ctest --output-on-failure " 
+srun -p jenkins-amdgpu -N 1 -n 1 -t 02:00:00 bash -c "module load gcc/9.4.0 rocm/4.3.1 hwloc && module list && hipcc --version && ./build-all.sh Release with-CC-clang without-cuda without-mpi without-papi without-apex with-kokkos with-simd without-hpx-backend-multipole without-hpx-backend-monopole with-hpx-cuda-polling without-otf2 boost jemalloc hdf5 silo vc hpx kokkos cppuddle octotiger && cd build/octotiger/build && ctest --output-on-failure " 
 
 # Tests with griddim = 16
 sed -i 's/GRIDDIM=8/GRIDDIM=16/' build-octotiger.sh
-srun -p jenkins-amdgpu -N 1 -n 1 -t 01:00:00 bash -c "module load gcc/9.4.0 rocm/4.3.1 hwloc && ./build-all.sh Release with-CC-clang without-cuda without-mpi without-papi without-apex with-kokkos with-simd without-hpx-backend-multipole without-hpx-backend-monopole with-hpx-cuda-polling without-otf2 octotiger && cd build/octotiger/build && ctest --output-on-failure " 
+srun -p jenkins-amdgpu -N 1 -n 1 -t 02:00:00 bash -c "module load gcc/9.4.0 rocm/4.3.1 hwloc && module list && hipcc --version && ./build-all.sh Release with-CC-clang without-cuda without-mpi without-papi without-apex with-kokkos with-simd without-hpx-backend-multipole without-hpx-backend-monopole with-hpx-cuda-polling without-otf2 octotiger && cd build/octotiger/build && ctest --output-on-failure " 
 sed -i 's/GRIDDIM=16/GRIDDIM=8/' build-octotiger.sh
 

--- a/.jenkins/lsu/node-level-tests-entry.sh
+++ b/.jenkins/lsu/node-level-tests-entry.sh
@@ -19,14 +19,14 @@ module load "${compiler_module}" cuda/11.5 hwloc
 
 # Tests with griddim = 8
 echo "Running tests with griddim=8"
-srun --partition=jenkins-cuda -N 1 -n 1 -t 08:00:00 bash -c "module load ${compiler_module} cuda/11.5 hwloc && ./build-all.sh Release ${compiler_config} ${cuda_config} without-mpi without-papi without-apex ${kokkos_config} ${simd_config} with-hpx-backend-multipole without-hpx-backend-monopole with-hpx-cuda-polling without-otf2 boost jemalloc hdf5 silo vc hpx kokkos cppuddle octotiger && cd build/octotiger/build && ctest --output-on-failure " 
+srun --partition=jenkins-cuda -N 1 -n 1 -t 08:00:00 bash -c "module load ${compiler_module} cuda/11.5 hwloc && module list && ./build-all.sh Release ${compiler_config} ${cuda_config} without-mpi without-papi without-apex ${kokkos_config} ${simd_config} with-hpx-backend-multipole without-hpx-backend-monopole with-hpx-cuda-polling without-otf2 boost jemalloc hdf5 silo vc hpx kokkos cppuddle octotiger && cd build/octotiger/build && ctest --output-on-failure " 
 
 # Tests with griddim = 16 - only test in full kokkos + cuda build
 if [ "${cuda_config}" = "with-cuda" ] && [ "${kokkos_config}" = "with-kokkos" ]; then
 	sed -i 's/GRIDDIM=8/GRIDDIM=16/' build-octotiger.sh
 	echo "Running tests with griddim=16 on diablo"
 	rm -rf build # in case we end up on a different cuda node we need to rebuild with its architecture
-	srun --partition=jenkins-cuda -N 1 -n 1 -t 08:00:00 bash -c "module load ${compiler_module} cuda/11.5 hwloc && ./build-all.sh Release ${compiler_config} ${cuda_config} without-mpi without-papi without-apex ${kokkos_config} ${simd_config} with-hpx-backend-multipole without-hpx-backend-monopole with-hpx-cuda-polling without-otf2 boost jemalloc hdf5 silo vc hpx kokkos cppuddle octotiger && cd build/octotiger/build && ctest --output-on-failure " 
+	srun --partition=jenkins-cuda -N 1 -n 1 -t 08:00:00 bash -c "module load ${compiler_module} cuda/11.5 hwloc && module list && ./build-all.sh Release ${compiler_config} ${cuda_config} without-mpi without-papi without-apex ${kokkos_config} ${simd_config} with-hpx-backend-multipole without-hpx-backend-monopole with-hpx-cuda-polling without-otf2 boost jemalloc hdf5 silo vc hpx kokkos cppuddle octotiger && cd build/octotiger/build && ctest --output-on-failure " 
 	sed -i 's/GRIDDIM=16/GRIDDIM=8/' build-octotiger.sh
 fi
 

--- a/.jenkins/lsu/node-level-tests-entry.sh
+++ b/.jenkins/lsu/node-level-tests-entry.sh
@@ -19,14 +19,14 @@ module load "${compiler_module}" cuda/11.5 hwloc
 
 # Tests with griddim = 8
 echo "Running tests with griddim=8"
-srun --partition=cuda-V100,cuda-A100 -N 1 -n 1 -t 08:00:00 bash -c "module load ${compiler_module} cuda/11.5 hwloc && ./build-all.sh Release ${compiler_config} ${cuda_config} without-mpi without-papi without-apex ${kokkos_config} ${simd_config} with-hpx-backend-multipole without-hpx-backend-monopole with-hpx-cuda-polling without-otf2 boost jemalloc hdf5 silo vc hpx kokkos cppuddle octotiger && cd build/octotiger/build && ctest --output-on-failure " 
+srun --partition=jenkins-cuda -N 1 -n 1 -t 08:00:00 bash -c "module load ${compiler_module} cuda/11.5 hwloc && ./build-all.sh Release ${compiler_config} ${cuda_config} without-mpi without-papi without-apex ${kokkos_config} ${simd_config} with-hpx-backend-multipole without-hpx-backend-monopole with-hpx-cuda-polling without-otf2 boost jemalloc hdf5 silo vc hpx kokkos cppuddle octotiger && cd build/octotiger/build && ctest --output-on-failure " 
 
 # Tests with griddim = 16 - only test in full kokkos + cuda build
 if [ "${cuda_config}" = "with-cuda" ] && [ "${kokkos_config}" = "with-kokkos" ]; then
 	sed -i 's/GRIDDIM=8/GRIDDIM=16/' build-octotiger.sh
 	echo "Running tests with griddim=16 on diablo"
 	rm -rf build # in case we end up on a different cuda node we need to rebuild with its architecture
-	srun --partition=cuda-V100,cuda-A100 -N 1 -n 1 -t 08:00:00 bash -c "module load ${compiler_module} cuda/11.5 hwloc && ./build-all.sh Release ${compiler_config} ${cuda_config} without-mpi without-papi without-apex ${kokkos_config} ${simd_config} with-hpx-backend-multipole without-hpx-backend-monopole with-hpx-cuda-polling without-otf2 boost jemalloc hdf5 silo vc hpx kokkos cppuddle octotiger && cd build/octotiger/build && ctest --output-on-failure " 
+	srun --partition=jenkins-cuda -N 1 -n 1 -t 08:00:00 bash -c "module load ${compiler_module} cuda/11.5 hwloc && ./build-all.sh Release ${compiler_config} ${cuda_config} without-mpi without-papi without-apex ${kokkos_config} ${simd_config} with-hpx-backend-multipole without-hpx-backend-monopole with-hpx-cuda-polling without-otf2 boost jemalloc hdf5 silo vc hpx kokkos cppuddle octotiger && cd build/octotiger/build && ctest --output-on-failure " 
 	sed -i 's/GRIDDIM=16/GRIDDIM=8/' build-octotiger.sh
 fi
 

--- a/.jenkins/stuttgart/Jenkinsfile-POWER9
+++ b/.jenkins/stuttgart/Jenkinsfile-POWER9
@@ -8,10 +8,10 @@ pipeline {
     options {
         buildDiscarder(
             logRotator(
-                daysToKeepStr: "28",
-                numToKeepStr: "100",
-                artifactDaysToKeepStr: "28",
-                artifactNumToKeepStr: "100"
+                daysToKeepStr: "7",
+                numToKeepStr: "5",
+                artifactDaysToKeepStr: "7",
+                artifactNumToKeepStr: "5"
             )
         )
 	disableConcurrentBuilds()


### PR DESCRIPTION
Rostam introduced new machine partitions specifically for Jenkins jobs with the intend of keeping some machines free for actual users. This PR changes our pipelines to use those machines.

Overall, it'll make testing slower (using 2 nodes instead of 4), yet less frustrating for other users of the system! 