### PR TITLE
Added flag to disable to last compare_analytic step

### DIFF
--- a/octotiger/options.hpp
+++ b/octotiger/options.hpp
@@ -38,6 +38,7 @@ public:
 	bool disable_diagnostics;
 	bool bench;
 	bool disable_output;
+	bool disable_analytic;
 	bool core_refine;
 	bool gravity;
 	bool hydro;
@@ -237,6 +238,7 @@ public:
 		arc & stop_step;
 		arc & disable_diagnostics;
 		arc & disable_output;
+	  arc & disable_analytic;
 		arc & theta;
 		arc & core_refine;
 		arc & donor_refine;

--- a/src/node_server_actions_3.cpp
+++ b/src/node_server_actions_3.cpp
@@ -271,9 +271,10 @@ void node_server::execute_solver(bool scf, node_count_type ngrids) {
 			output_all(this, "final", output_cnt, true);
 		}
 		if (get_analytic() != nullptr) {
-      if (!(opts().stop_step > 1) && !opts().disable_analytic) // Pure performance measurements - skip analytics 
+      if (!opts().disable_analytic) { // Pure performance measurements - skip analytics 
           compare_analytic();
-			if (opts().gravity) {
+      }
+      if (opts().gravity) {
         auto start_all_gravity = std::chrono::high_resolution_clock::now(); 
         auto min_duration = std::chrono::milliseconds::max();
         auto max_duration = std::chrono::milliseconds::min();

--- a/src/node_server_actions_3.cpp
+++ b/src/node_server_actions_3.cpp
@@ -271,7 +271,7 @@ void node_server::execute_solver(bool scf, node_count_type ngrids) {
 			output_all(this, "final", output_cnt, true);
 		}
 		if (get_analytic() != nullptr) {
-      if (!(opts().stop_step > 1)) // Pure performance measurements - skip analytics 
+      if (!(opts().stop_step > 1) && !opts().disable_analytic) // Pure performance measurements - skip analytics 
           compare_analytic();
 			if (opts().gravity) {
         auto start_all_gravity = std::chrono::high_resolution_clock::now(); 
@@ -481,7 +481,7 @@ void node_server::execute_solver(bool scf, node_count_type ngrids) {
 			output_all(this, "final", output_cnt, true);
 		}
 
-		if (get_analytic() != nullptr) {
+		if (!opts().disable_analytic && get_analytic() != nullptr) {
 			compare_analytic();
 			if (opts().gravity) {
 				solve_gravity(true, false);

--- a/src/options_processing.cpp
+++ b/src/options_processing.cpp
@@ -137,6 +137,7 @@ bool options::process_options(int argc, char *argv[]) {
 	("reflect_bc", po::value<bool>(&(opts().reflect_bc))->default_value(false), "Reflecting Boundary Conditions") //
 	("cdisc_detect", po::value<bool>(&(opts().cdisc_detect))->default_value(true), "PPM contact discontinuity detection") //
 	("disable_output", po::value<bool>(&(opts().disable_output))->default_value(false), "disable silo output") //
+	("disable_analytic", po::value<bool>(&(opts().disable_analytic))->default_value(false), "disable analytic step") //
 	("disable_diagnostics", po::value<bool>(&(opts().disable_diagnostics))->default_value(false), "disable diagnostics") //
 	("problem", po::value<problem_type>(&(opts().problem))->default_value(NONE), "problem type")                            //
 	("restart_filename", po::value<std::string>(&(opts().restart_filename))->default_value(""), "restart filename")         //


### PR DESCRIPTION
This PR adds a flag that makes Octo-Tiger skip the compare_analytics step. The intended purpose is for distributed performance measurements (especially on Summit where this step can take a long while, skewing runtime percentages of other methods). By default the flag is off and the compare_analytics step is performed, hence the default behavior of Octo-Tiger will not change!