### PR TITLE
Add simd pipeline

### DIFF
--- a/.jenkins/lsu/Jenkinsfile-std-simd
+++ b/.jenkins/lsu/Jenkinsfile-std-simd
@@ -92,7 +92,7 @@ pipeline {
 	    	        srun -p medusa -N 1 -n 1 bash -c ' ./build-all.sh RelWithDebInfo with-CC without-cuda without-mpi without-papi without-apex with-kokkos with-simd without-hpx-backend-multipole without-hpx-backend-monopole without-hpx-cuda-polling without-otf2 cmake jemalloc boost hdf5 silo vc hpx kokkos cppuddle octotiger |& tee build-log.txt'
 	   	        if grep -Fx "Using std-experimental-simd SIMD types" build-log.txt
 		        then
-		            echo "Found std-experimental build log output! All goood!"
+		            echo "Found std-experimental build log output! All good!"
 		            exit 0
 	    	        else
 		            echo "Error: Did not find std-experimental output in the build look!"

--- a/.jenkins/lsu/Jenkinsfile-std-simd
+++ b/.jenkins/lsu/Jenkinsfile-std-simd
@@ -87,7 +87,7 @@ pipeline {
                     sh '''
                         #!/bin/bash -l
                         cd "../octo-buildscripts-std-simd"
-                        rm build-log.txt
+                        rm -f build-log.txt
                         sed -i 's/OCTOTIGER_WITH_STD_EXPERIMENTAL_SIMD=OFF/OCTOTIGER_WITH_STD_EXPERIMENTAL_SIMD=ON/' build-octotiger.sh
 	    	        srun -p medusa -N 1 -n1 bash -c './build-all.sh RelWithDebInfo with-CC without-cuda without-mpi without-papi without-apex with-kokkos with-simd without-hpx-backend-multipole without-hpx-backend-monopole without-hpx-cuda-polling without-otf2 cmake jemalloc boost hdf5 silo vc hpx kokkos cppuddle octotiger |& tee build-log.txt'
 	   	        if grep -Fx "Using std-experimental-simd SIMD types" build-log.txt

--- a/.jenkins/lsu/Jenkinsfile-std-simd
+++ b/.jenkins/lsu/Jenkinsfile-std-simd
@@ -89,7 +89,7 @@ pipeline {
                         cd "../octo-buildscripts-std-simd"
                         rm -f build-log.txt
                         sed -i 's/OCTOTIGER_WITH_STD_EXPERIMENTAL_SIMD=OFF/OCTOTIGER_WITH_STD_EXPERIMENTAL_SIMD=ON/' build-octotiger.sh
-	    	        srun -p medusa -N 1 -n1 bash -c './build-all.sh RelWithDebInfo with-CC without-cuda without-mpi without-papi without-apex with-kokkos with-simd without-hpx-backend-multipole without-hpx-backend-monopole without-hpx-cuda-polling without-otf2 cmake jemalloc boost hdf5 silo vc hpx kokkos cppuddle octotiger |& tee build-log.txt'
+	    	        srun -p medusa -N 1 -n 1 bash -c ' module load gcc/11.2.0; ./build-all.sh RelWithDebInfo with-CC without-cuda without-mpi without-papi without-apex with-kokkos with-simd without-hpx-backend-multipole without-hpx-backend-monopole without-hpx-cuda-polling without-otf2 cmake jemalloc boost hdf5 silo vc hpx kokkos cppuddle octotiger |& tee build-log.txt'
 	   	        if grep -Fx "Using std-experimental-simd SIMD types" build-log.txt
 		        then
 		            echo "Found std-experimental build log output! All goood!"
@@ -109,7 +109,7 @@ pipeline {
                     sh '''
                         #!/bin/bash -l
                         cd "../octo-buildscripts-std-simd"
-                        srun -p medusa -N 1 -n1 bash -c 'cd build/octotiger/build && ctest'
+                        srun -p medusa -N 1 -n 1 bash -c 'module load gcc/11.2.0; cd build/octotiger/build && ctest'
                     '''
                 }
             }

--- a/.jenkins/lsu/Jenkinsfile-std-simd
+++ b/.jenkins/lsu/Jenkinsfile-std-simd
@@ -1,0 +1,179 @@
+#!groovy
+
+def buildbadge = addEmbeddableBadgeConfiguration(id: "std-simd", subject: "std-simd Kernel Tests", status: "skipped")
+
+pipeline {
+    agent any
+
+    options {
+        buildDiscarder(
+            logRotator(
+                daysToKeepStr: "28",
+                numToKeepStr: "100",
+                artifactDaysToKeepStr: "28",
+                artifactNumToKeepStr: "100"
+            )
+        )
+        disableConcurrentBuilds()
+    }
+    environment {
+        GITHUB_TOKEN = credentials('GITHUB_TOKEN_OCTOTIGER')
+        MAINTAINER_MAIL = credentials('OCTOTIGER_MAINTAINER_EMAIL')
+    }
+    stages {
+        stage('checkout') {
+            steps {
+                script {
+                    buildbadge.setStatus('running')
+                }
+                dir('octotiger') {
+                    checkout scm
+                    sh '''
+                        cd octotiger
+                        git submodule update --init --recursive
+                        cd ..
+                    '''
+                }
+                dir('octotiger') {
+                    sh '''
+                        github_token=$(echo ${GITHUB_TOKEN} | cut -f2 -d':')
+                        curl --verbose\
+                            --request POST \
+                            --url "https://api.github.com/repos/STEllAR-GROUP/octotiger/statuses/$GIT_COMMIT" \
+                            --header "Content-Type: application/json" \
+                            --header "authorization: Bearer ${github_token}" \
+                            --data "{
+                          \\"state\\": \\"pending\\",
+                          \\"context\\": \\"jenkins-std-simd\\",
+                          \\"description\\": \\"Jenkins CI Job: std-simd\\",
+                          \\"target_url\\": \\"https://rostam.cct.lsu.edu/jenkins/job/Octo-Tiger%20std-simd/job/$JOB_BASE_NAME/$BUILD_NUMBER/console\\"
+                            }"
+                    '''
+                }
+            }
+        }
+        stage('configure') {
+            steps {
+                dir('octotiger') {
+                    sh '''
+                        #!/bin/bash -l
+                        cd ..
+                        #rm -rf octo-buildscripts/src/octotiger
+                        rm -rf "octo-buildscripts-std-simd" #remove line for dependency caching
+                        if [[ -d "octo-buildscripts-std-simd" ]]
+                        then
+                            cd "octo-buildscripts-std-simd"
+                            git reset --hard # reset griddim modification in case of unclean directory
+                            git checkout main
+                            git pull
+                            rm -rf build/octotiger
+                            rm -rf src/octotiger
+                        else
+                            git clone https://github.com/diehlpk/PowerTiger.git "octo-buildscripts-std-simd"
+                            cd "octo-buildscripts-std-simd"
+                            git checkout main
+                            mkdir src
+                        fi
+
+                        cd ..
+                        cp -r octotiger "octo-buildscripts-std-simd/src/octotiger"
+                    '''
+                }
+            }
+        }
+        stage('build') {
+            steps {
+                dir('octotiger') {
+                    sh '''
+                        #!/bin/bash -l
+                        cd "../octo-buildscripts-std-simd"
+                        rm build-log.txt
+                        sed -i 's/OCTOTIGER_WITH_STD_EXPERIMENTAL_SIMD=OFF/OCTOTIGER_WITH_STD_EXPERIMENTAL_SIMD=ON/' build-octotiger.sh
+	    	        srun -p medusa -N 1 -n1 bash -c './build-all.sh RelWithDebInfo with-CC without-cuda without-mpi without-papi without-apex with-kokkos with-simd without-hpx-backend-multipole without-hpx-backend-monopole without-hpx-cuda-polling without-otf2 cmake jemalloc boost hdf5 silo vc hpx kokkos cppuddle octotiger |& tee build-log.txt'
+	   	        if grep -Fx "Using std-experimental-simd SIMD types" build-log.txt
+		        then
+		            echo "Found std-experimental build log output! All goood!"
+		            exit 0
+	    	        else
+		            echo "Error: Did not find std-experimental output in the build look!"
+		            exit 1
+		        fi
+                    '''
+
+                }
+            }
+        }
+        stage('test') {
+            steps {
+                dir('octotiger') {
+                    sh '''
+                        #!/bin/bash -l
+                        cd "../octo-buildscripts-std-simd"
+                        srun -p medusa -N 1 -n1 bash -c 'cd build/octotiger/build && ctest'
+                    '''
+                }
+            }
+        }
+    }
+    post {
+        success {
+            script {
+                buildbadge.setStatus('success')
+            }
+            sh '''
+            github_token=$(echo ${GITHUB_TOKEN} | cut -f2 -d':')
+            curl --verbose\
+                --request POST \
+                --url "https://api.github.com/repos/STEllAR-GROUP/octotiger/statuses/$GIT_COMMIT" \
+                --header "Content-Type: application/json" \
+                --header "authorization: Bearer ${github_token}" \
+                --data "{
+                    \\"state\\": \\"success\\",
+                    \\"context\\": \\"jenkins-std-simd\\",
+                    \\"description\\": \\"Jenkins CI Job: std-simd\\",
+                    \\"target_url\\": \\"https://rostam.cct.lsu.edu/jenkins/job/Octo-Tiger%20std-simd/job/$JOB_BASE_NAME/$BUILD_NUMBER/console\\"
+                }"
+            '''
+        }
+        failure {
+            script {
+                buildbadge.setStatus('failing')
+            }
+            sh '''
+            echo "Build failed! Pipeline ${JOB_BASE_NAME} with build ID ${BUILD_NUMBER} using GIT commit ${GIT_COMMIT}" | mail -s "Jenkins Octo-Tiger std-simd Tests: Build ${JOB_BASE_NAME}/${BUILD_NUMBER} failed" "${MAINTAINER_MAIL}"
+            github_token=$(echo ${GITHUB_TOKEN} | cut -f2 -d':')
+            curl --verbose\
+                --request POST \
+                --url "https://api.github.com/repos/STEllAR-GROUP/octotiger/statuses/$GIT_COMMIT" \
+                --header "Content-Type: application/json" \
+                --header "authorization: Bearer ${github_token}" \
+                --data "{
+                    \\"state\\": \\"failure\\",
+                    \\"context\\": \\"jenkins-std-simd\\",
+                    \\"description\\": \\"Jenkins CI Job: std-simd\\",
+                    \\"target_url\\": \\"https://rostam.cct.lsu.edu/jenkins/job/Octo-Tiger%20std-simd/job/$JOB_BASE_NAME/$BUILD_NUMBER/console\\"
+                }"
+            '''
+        }
+        aborted {
+            script {
+                buildbadge.setStatus('aborted')
+            }
+            sh '''
+            echo "Build aborted on pipeline ${JOB_BASE_NAME} with build ID ${BUILD_NUMBER} using GIT commit ${GIT_COMMIT}" | mail -s "Jenkins Octo-Tiger std-simd Tests: Build ${JOB_BASE_NAME}/${BUILD_NUMBER} aborted" "${MAINTAINER_MAIL}"
+            github_token=$(echo ${GITHUB_TOKEN} | cut -f2 -d':')
+            curl --verbose\
+                --request POST \
+                --url "https://api.github.com/repos/STEllAR-GROUP/octotiger/statuses/$GIT_COMMIT" \
+                --header "Content-Type: application/json" \
+                --header "authorization: Bearer ${github_token}" \
+                --data "{
+                    \\"state\\": \\"error\\",
+                    \\"context\\": \\"jenkins-std-simd\\",
+                    \\"description\\": \\"Jenkins CI Job: std-simd\\",
+                    \\"target_url\\": \\"https://rostam.cct.lsu.edu/jenkins/job/Octo-Tiger%20std-simd/job/$JOB_BASE_NAME/$BUILD_NUMBER/console\\"
+                }"
+            '''
+        }
+    }
+}

--- a/.jenkins/lsu/Jenkinsfile-std-simd
+++ b/.jenkins/lsu/Jenkinsfile-std-simd
@@ -55,8 +55,7 @@ pipeline {
         stage('configure') {
             steps {
                 dir('octotiger') {
-                    sh '''
-                        #!/bin/bash -l
+                    sh '''#!/bin/bash -l
                         cd ..
                         #rm -rf octo-buildscripts/src/octotiger
                         rm -rf "octo-buildscripts-std-simd" #remove line for dependency caching
@@ -84,8 +83,7 @@ pipeline {
         stage('build') {
             steps {
                 dir('octotiger') {
-                    sh '''
-                        #!/bin/bash -l
+                    sh '''#!/bin/bash -l
                         cd "../octo-buildscripts-std-simd"
                         rm -f build-log.txt
                         sed -i 's/OCTOTIGER_WITH_STD_EXPERIMENTAL_SIMD=OFF/OCTOTIGER_WITH_STD_EXPERIMENTAL_SIMD=ON/' build-octotiger.sh
@@ -108,8 +106,7 @@ pipeline {
         stage('test') {
             steps {
                 dir('octotiger') {
-                    sh '''
-                        #!/bin/bash -l
+                    sh '''#!/bin/bash -l
                         cd "../octo-buildscripts-std-simd"
 		        module load gcc/11.2.0
                         g++ --version

--- a/.jenkins/lsu/Jenkinsfile-std-simd
+++ b/.jenkins/lsu/Jenkinsfile-std-simd
@@ -89,7 +89,9 @@ pipeline {
                         cd "../octo-buildscripts-std-simd"
                         rm -f build-log.txt
                         sed -i 's/OCTOTIGER_WITH_STD_EXPERIMENTAL_SIMD=OFF/OCTOTIGER_WITH_STD_EXPERIMENTAL_SIMD=ON/' build-octotiger.sh
-	    	        srun -p medusa -N 1 -n 1 bash -c ' module load gcc/11.2.0; ./build-all.sh RelWithDebInfo with-CC without-cuda without-mpi without-papi without-apex with-kokkos with-simd without-hpx-backend-multipole without-hpx-backend-monopole without-hpx-cuda-polling without-otf2 cmake jemalloc boost hdf5 silo vc hpx kokkos cppuddle octotiger |& tee build-log.txt'
+		        module load gcc/11.2.0
+                        g++ --version
+	    	        srun -p medusa -N 1 -n 1 bash -c ' ./build-all.sh RelWithDebInfo with-CC without-cuda without-mpi without-papi without-apex with-kokkos with-simd without-hpx-backend-multipole without-hpx-backend-monopole without-hpx-cuda-polling without-otf2 cmake jemalloc boost hdf5 silo vc hpx kokkos cppuddle octotiger |& tee build-log.txt'
 	   	        if grep -Fx "Using std-experimental-simd SIMD types" build-log.txt
 		        then
 		            echo "Found std-experimental build log output! All goood!"
@@ -109,7 +111,9 @@ pipeline {
                     sh '''
                         #!/bin/bash -l
                         cd "../octo-buildscripts-std-simd"
-                        srun -p medusa -N 1 -n 1 bash -c 'module load gcc/11.2.0; cd build/octotiger/build && ctest'
+		        module load gcc/11.2.0
+                        g++ --version
+                        srun -p medusa -N 1 -n 1 bash -c 'cd build/octotiger/build && ctest'
                     '''
                 }
             }

--- a/.jenkins/lsu/Jenkinsfile-std-simd
+++ b/.jenkins/lsu/Jenkinsfile-std-simd
@@ -90,7 +90,7 @@ pipeline {
 		        module load gcc/11.2.0
                         g++ --version
 	    	        srun -p medusa -N 1 -n 1 bash -c ' ./build-all.sh RelWithDebInfo with-CC without-cuda without-mpi without-papi without-apex with-kokkos with-simd without-hpx-backend-multipole without-hpx-backend-monopole without-hpx-cuda-polling without-otf2 cmake jemalloc boost hdf5 silo vc hpx kokkos cppuddle octotiger |& tee build-log.txt'
-	   	        if grep -Fx "Using std-experimental-simd SIMD types" build-log.txt
+	   	        if grep "Using std-experimental-simd SIMD types" build-log.txt
 		        then
 		            echo "Found std-experimental build log output! All good!"
 		            exit 0

--- a/octotiger/common_kernel/kokkos_util.hpp
+++ b/octotiger/common_kernel/kokkos_util.hpp
@@ -155,7 +155,7 @@ using normal_device_buffer = kokkos_device_array<T>;
 // SIMD settings
 #if defined(OCTOTIGER_HAVE_STD_EXPERIMENTAL_SIMD)
 #include "octotiger/common_kernel/std_simd.hpp"
-#warning "Using std-experimental-simd SIMD types"
+#pragma message "Using std-experimental-simd SIMD types"
 #else
 #include <simd.hpp>
 using device_simd_t = SIMD_NAMESPACE::simd<double, SIMD_NAMESPACE::simd_abi::scalar>;


### PR DESCRIPTION
This PR adds the Jenkins pipeline for testing the new std-simd types in the Kokkos kernels as added in #403 

The test includes a check that the std-simd types are actually used in the build, and then the usual ctest suite being run by said build.

The test does not add a build badge in the README just yet (we can still add that if we choose std-simd as a default backend). Instead, it merely reports the test results via commit status (as the other tests do as well).

