### PR TITLE
Switch to id_type::management_type::unmanaged

### DIFF
--- a/octotiger/node_client.hpp
+++ b/octotiger/node_client.hpp
@@ -52,7 +52,7 @@ public:
         arc& id;
         if (!empty())
         {
-            unmanaged = hpx::id_type(id.get_gid(), hpx::id_type::unmanaged);
+            unmanaged = hpx::id_type(id.get_gid(), hpx::id_type::management_type::unmanaged);
         }
     }
 

--- a/src/node_client.cpp
+++ b/src/node_client.cpp
@@ -28,7 +28,7 @@ hpx::id_type node_client::get_unmanaged_gid() const {
 node_client& node_client::operator=(hpx::future<hpx::id_type>&& fut) {
 	id = fut.get();
 	if( !empty() ) {
-        unmanaged = hpx::id_type(id.get_gid(), hpx::id_type::unmanaged);
+        unmanaged = hpx::id_type(id.get_gid(), hpx::id_type::management_type::unmanaged);
         local = hpx::naming::get_locality_from_id(id) == hpx::find_here();
 // 		local = bool(hpx::get_colocation_id(id).get() == hpx::find_here());
 	}
@@ -38,7 +38,7 @@ node_client& node_client::operator=(hpx::future<hpx::id_type>&& fut) {
 node_client& node_client::operator=(const hpx::id_type& _id) {
 	id = _id;
 	if (!empty()) {
-        unmanaged = hpx::id_type(id.get_gid(), hpx::id_type::unmanaged);
+        unmanaged = hpx::id_type(id.get_gid(), hpx::id_type::management_type::unmanaged);
         local = hpx::naming::get_locality_from_id(id) == hpx::find_here();
 // 		local = bool(hpx::get_colocation_id(id).get() == hpx::find_here());
 	}
@@ -48,7 +48,7 @@ node_client& node_client::operator=(const hpx::id_type& _id) {
 node_client::node_client(hpx::future<hpx::id_type>&& fut) {
 	id = fut.get();
 	if( !empty() ) {
-        unmanaged = hpx::id_type(id.get_gid(), hpx::id_type::unmanaged);
+        unmanaged = hpx::id_type(id.get_gid(), hpx::id_type::management_type::unmanaged);
         local = hpx::naming::get_locality_from_id(id) == hpx::find_here();
 // 		local = bool(hpx::get_colocation_id(id).get() == hpx::find_here());
 	}
@@ -57,7 +57,7 @@ node_client::node_client(hpx::future<hpx::id_type>&& fut) {
 node_client::node_client(const hpx::id_type& _id) {
 	id = _id;
 	if (!empty()) {
-        unmanaged = hpx::id_type(id.get_gid(), hpx::id_type::unmanaged);
+        unmanaged = hpx::id_type(id.get_gid(), hpx::id_type::management_type::unmanaged);
         local = hpx::naming::get_locality_from_id(id) == hpx::find_here();
 	}
 }


### PR DESCRIPTION
Using ```hpx::id_type::unmanaged``` does not compile anymore with the current hpx master branch! 
We seem to have to use ```hpx::id_type::management_type::unmanaged``` now! 