### PR TITLE
Fix jenkins stuttgart

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ cmake-build-*
 cmake-cuda-*
 .spack-env/*
 .clangd/*
+.cache
+compile_commands.json

--- a/.jenkins/stuttgart/Jenkinsfile-DEV-NODE
+++ b/.jenkins/stuttgart/Jenkinsfile-DEV-NODE
@@ -77,6 +77,7 @@ pipeline {
                 // Build with preinstalled gcc on this machine 
                 dir('octotiger') {
                     sh '''
+                    module load gcc/9.2.0
                     module load cuda/11.2.2 
 		    cd OctoTigerBuildChain
 		    sed -i 's/OCTOTIGER_WITH_BLAST_TEST=OFF/OCTOTIGER_WITH_BLAST_TEST=ON/' build-octotiger.sh
@@ -91,6 +92,7 @@ pipeline {
                 // Basic gcc test - only GRIDDIM=8 and hydro-off rotating star tests
                 dir('octotiger') {
                     sh '''
+                    module load gcc/9.2.0
                     module load cuda/11.2.2 
 		    cd OctoTigerBuildChain/build/octotiger/build
 		    ctest --output-on-failure -R cpu

--- a/.jenkins/stuttgart/Jenkinsfile-KNL
+++ b/.jenkins/stuttgart/Jenkinsfile-KNL
@@ -56,7 +56,7 @@ pipeline {
                     mkdir -p jenkins && cd jenkins && \
                     mkdir -p octotiger-${JOB_BASE_NAME} && cd octotiger-${JOB_BASE_NAME} && \
                     rm -rf octotiger && \
-                    rm -rf OctoTigerBuildChain/build/octotiger && \
+                    rm -rf OctoTigerBuildChain/build && \
                     rm -rf OctoTigerBuildChain/src/boost && \
                     rm -rf OctoTigerBuildChain/src/octotiger && \
                     rm -rf OctoTigerBuildChain/src/silo && \

--- a/frontend/init_methods.cpp
+++ b/frontend/init_methods.cpp
@@ -160,14 +160,18 @@ void init_executors(void) {
     std::cout << "CUDA is enabled!" << std::endl;
 #if HPX_KOKKOS_CUDA_FUTURE_TYPE == 0 
     std::cout << "CUDA with polling futures enabled!" << std::endl;
+
+    /* stream_pool::init<hpx::cuda::experimental::cuda_executor, pool_strategy>( */
+    /*     opts().cuda_streams_per_gpu, opts().cuda_number_gpus, true); */
     stream_pool::init<hpx::cuda::experimental::cuda_executor, pool_strategy>(
-        opts().cuda_streams_per_gpu, opts().cuda_number_gpus, true);
+        opts().cuda_streams_per_gpu, 0, true);
 #else
     std::cout << "CUDA with callback futures enabled!" << std::endl;
     stream_pool::init<hpx::cuda::experimental::cuda_executor, pool_strategy>(
-        opts().cuda_streams_per_gpu, opts().cuda_number_gpus, false);
+        opts().cuda_streams_per_gpu, 0, false);
 #endif
     octotiger::fmm::kernel_scheduler::init_constants();
+
 #endif
 
 #if defined(OCTOTIGER_HAVE_HIP)

--- a/octotiger/cuda_util/cuda_helper.hpp
+++ b/octotiger/cuda_util/cuda_helper.hpp
@@ -25,7 +25,9 @@
 #include <vector>
 
 #include <stream_manager.hpp>
-using pool_strategy = multi_gpu_round_robin_pool<hpx::cuda::experimental::cuda_executor, round_robin_pool<hpx::cuda::experimental::cuda_executor>>;
+//using pool_strategy = multi_gpu_round_robin_pool<hpx::cuda::experimental::cuda_executor, round_robin_pool<hpx::cuda::experimental::cuda_executor>>;
+
+using pool_strategy = round_robin_pool<hpx::cuda::experimental::cuda_executor>;
 using kokkos_strategy = round_robin_pool<hpx::cuda::experimental::cuda_executor>;
 
 

--- a/octotiger/unitiger/hydro_impl/flux_kernel_interface.hpp
+++ b/octotiger/unitiger/hydro_impl/flux_kernel_interface.hpp
@@ -35,25 +35,29 @@ timestep_t flux_unified_cpu_kernel(const hydro::recon_type<NDIM>& Q, hydro::flux
     hydro::x_type& X, safe_real omega, const size_t nf_);
 #endif
 
+#if defined(OCTOTIGER_HAVE_CUDA) || defined(OCTOTIGER_HAVE_CUDA)
+#include <aggregation_manager.hpp>
+using aggregated_executor_t = Aggregated_Executor<hpx::cuda::experimental::cuda_executor>::Executor_Slice;
+#endif
 #if defined(OCTOTIGER_HAVE_CUDA) 
-timestep_t launch_flux_cuda(
-    stream_interface<hpx::cuda::experimental::cuda_executor, pool_strategy>& executor,
-    double* device_q,
-    std::vector<double, recycler::recycle_allocator_cuda_host<double>>& combined_f,
-    std::vector<double, recycler::recycle_allocator_cuda_host<double>> &combined_x, double* device_x,
-    safe_real omega, const size_t nf_, double dx, size_t device_id);
-void launch_flux_cuda_kernel_post(stream_interface<hpx::cuda::experimental::cuda_executor, pool_strategy>& executor,
+/* timestep_t launch_flux_cuda( */
+/*     stream_interface<hpx::cuda::experimental::cuda_executor, pool_strategy>& executor, */
+/*     double* device_q, */
+/*     std::vector<double, recycler::recycle_allocator_cuda_host<double>>& combined_f, */
+/*     std::vector<double, recycler::recycle_allocator_cuda_host<double>> &combined_x, double* device_x, */
+/*     safe_real omega, const size_t nf_, double dx, size_t device_id); */
+void launch_flux_cuda_kernel_post(aggregated_executor_t& executor,
     dim3 const grid_spec, dim3 const threads_per_block, void *args[]);
 #endif
 #if defined(OCTOTIGER_HAVE_HIP) 
-timestep_t launch_flux_cuda(
-    stream_interface<hpx::cuda::experimental::cuda_executor, pool_strategy>& executor,
-    double* device_q,
-    std::vector<double, recycler::recycle_allocator_hip_host<double>>& combined_f,
-    std::vector<double, recycler::recycle_allocator_hip_host<double>> &combined_x, double* device_x,
-    safe_real omega, const size_t nf_, double dx, size_t device_id);
+/* timestep_t launch_flux_cuda( */
+/*     stream_interface<hpx::cuda::experimental::cuda_executor, pool_strategy>& executor, */
+/*     double* device_q, */
+/*     std::vector<double, recycler::recycle_allocator_hip_host<double>>& combined_f, */
+/*     std::vector<double, recycler::recycle_allocator_hip_host<double>> &combined_x, double* device_x, */
+/*     safe_real omega, const size_t nf_, double dx, size_t device_id); */
 void launch_flux_hip_kernel_post(
-    stream_interface<hpx::cuda::experimental::cuda_executor, pool_strategy>& executor,
+    aggregated_executor_t& executor,
     dim3 const grid_spec, dim3 const threads_per_block, double* device_q, double* device_x,
     double* device_f, double* device_amax, int* device_amax_indices, int* device_amax_d,
     const bool* masks, const double omega, const double dx, const double A_, const double B_,

--- a/octotiger/unitiger/hydro_impl/hydro_kokkos_kernel.hpp
+++ b/octotiger/unitiger/hydro_impl/hydro_kokkos_kernel.hpp
@@ -351,12 +351,12 @@ void reconstruct_impl(hpx::kokkos::executor<kokkos_backend_t>& executor, const d
                 }
                 for (int d = 0; d < ndir; d++) {
                     cell_reconstruct_inner_loop_p1(nf_, angmom_index_, smooth_field_, disc_detect_,
-                        combined_q, combined_u, AM, dx, cdiscs, d, i, q_i, ndir, nangmom);
+                        combined_q, combined_u, AM, dx, cdiscs, d, i, q_i, ndir, nangmom, 0);
                 }
                 // Phase 2
                 for (int d = 0; d < ndir; d++) {
                     cell_reconstruct_inner_loop_p2(omega, angmom_index_, combined_q, combined_x,
-                        combined_u, AM, dx, d, i, q_i, ndir, nangmom, n_species_);
+                        combined_u, AM, dx, d, i, q_i, ndir, nangmom, n_species_, nf_, 0);
                 }
             }
         });
@@ -383,12 +383,12 @@ void reconstruct_no_amc_impl(hpx::kokkos::executor<kokkos_backend_t>& executor, 
             if (q_i < q_inx3) {
                 for (int d = 0; d < ndir; d++) {
                     cell_reconstruct_inner_loop_p1(nf_, angmom_index_, smooth_field_, disc_detect_,
-                        combined_q, combined_u, AM, dx, cdiscs, d, i, q_i, ndir, nangmom);
+                        combined_q, combined_u, AM, dx, cdiscs, d, i, q_i, ndir, nangmom, 0);
                 }
                 // Phase 2
                 for (int d = 0; d < ndir; d++) {
                     cell_reconstruct_inner_loop_p2(omega, angmom_index_, combined_q, combined_x,
-                        combined_u, AM, dx, d, i, q_i, ndir, nangmom, n_species_);
+                        combined_u, AM, dx, d, i, q_i, ndir, nangmom, n_species_, nf_, 0);
                 }
             }
         });
@@ -404,7 +404,7 @@ void hydro_pre_recon_impl(hpx::kokkos::executor<kokkos_backend_t>& executor,
         Kokkos::Experimental::WorkItemProperty::HintLightWeight);
     Kokkos::parallel_for(
         "kernel hydro pre recon", policy, KOKKOS_LAMBDA(int idx, int idy, int idz) {
-            cell_hydro_pre_recon(large_x, omega, angmom, u, nf, n_species, idx, idy, idz, 1); // TODO add slice id
+            cell_hydro_pre_recon(large_x, omega, angmom, u, nf, n_species, idx, idy, idz, 0); // TODO add slice id
         });
 }
 
@@ -420,7 +420,7 @@ void find_contact_discs_impl(hpx::kokkos::executor<kokkos_backend_t>& executor,
         Kokkos::Experimental::WorkItemProperty::HintLightWeight);
     Kokkos::parallel_for(
         "kernel find contact discs 1", policy_phase_1, KOKKOS_LAMBDA(int idx, int idy, int idz) {
-            cell_find_contact_discs_phase1(P, u, A_, B_, fgamma_, de_switch_1, nf, idx, idy, idz, 1); // TODO add slice id
+            cell_find_contact_discs_phase1(P, u, A_, B_, fgamma_, de_switch_1, nf, idx, idy, idz, 0); // TODO add slice id
         });
 
     auto policy_phase_2 = Kokkos::Experimental::require(
@@ -429,7 +429,7 @@ void find_contact_discs_impl(hpx::kokkos::executor<kokkos_backend_t>& executor,
         Kokkos::Experimental::WorkItemProperty::HintLightWeight);
     Kokkos::parallel_for(
         "kernel find contact discs 2", policy_phase_2, KOKKOS_LAMBDA(int idx, int idy, int idz) {
-            cell_find_contact_discs_phase2(disc, P, fgamma_, ndir, idx, idy, idz, 1); // TODO add slice id
+            cell_find_contact_discs_phase2(disc, P, fgamma_, ndir, idx, idy, idz, 0); // TODO add slice id
         });
 }
 

--- a/octotiger/unitiger/hydro_impl/hydro_kokkos_kernel.hpp
+++ b/octotiger/unitiger/hydro_impl/hydro_kokkos_kernel.hpp
@@ -404,7 +404,7 @@ void hydro_pre_recon_impl(hpx::kokkos::executor<kokkos_backend_t>& executor,
         Kokkos::Experimental::WorkItemProperty::HintLightWeight);
     Kokkos::parallel_for(
         "kernel hydro pre recon", policy, KOKKOS_LAMBDA(int idx, int idy, int idz) {
-            cell_hydro_pre_recon(large_x, omega, angmom, u, nf, n_species, idx, idy, idz);
+            cell_hydro_pre_recon(large_x, omega, angmom, u, nf, n_species, idx, idy, idz, 1); // TODO add slice id
         });
 }
 

--- a/octotiger/unitiger/hydro_impl/reconstruct_kernel_interface.hpp
+++ b/octotiger/unitiger/hydro_impl/reconstruct_kernel_interface.hpp
@@ -55,15 +55,25 @@ void reconstruct_cpu_kernel(const safe_real omega, const size_t nf_, const int a
     const std::vector<std::vector<safe_real>>& cdiscs);
 #endif
 #if defined(OCTOTIGER_HAVE_CUDA) || defined(OCTOTIGER_HAVE_HIP)
+__global__ void discs_phase1(double* __restrict__ P, double* __restrict__ combined_u,
+    const double A_, const double B_, const double fgamma_, const double
+    de_switch_1);
+__global__ void discs_phase2(
+    double* __restrict__ disc, double* __restrict__ P, const double
+    fgamma_, const int ndir);
+
+#include <aggregation_manager.hpp>
+using aggregated_executor_t = Aggregated_Executor<hpx::cuda::experimental::cuda_executor>::Executor_Slice;
+
 void launch_reconstruct_cuda(
-    stream_interface<hpx::cuda::experimental::cuda_executor, pool_strategy>& executor,
+    aggregated_executor_t& executor,
     double omega, int nf_, int angmom_index_,
     int* smooth_field_, int* disc_detect_ ,
     double* combined_q, double* combined_x,
     double* combined_u, double* AM, double dx,
     double* cdiscs, int n_species_);
 void convert_find_contact_discs(const double* __restrict__ combined_u, double* __restrict__ disc, const double A_, const double B_, const double fgamma_, const double de_switch_1);
-void launch_find_contact_discs_cuda(stream_interface<hpx::cuda::experimental::cuda_executor, pool_strategy>& executor, double* combined_u, double *device_P, double* disc, double A_, double B_, double fgamma_, double de_switch_1);
-void launch_hydro_pre_recon_cuda(stream_interface<hpx::cuda::experimental::cuda_executor, pool_strategy>& executor, 
+void launch_find_contact_discs_cuda(aggregated_executor_t& executor, double* combined_u, double *device_P, double* disc, double A_, double B_, double fgamma_, double de_switch_1);
+void launch_hydro_pre_recon_cuda(aggregated_executor_t& executor, 
     double* device_X, double omega, bool angmom, double* device_u, int nf, int n_species_);
 #endif

--- a/octotiger/unitiger/hydro_impl/reconstruct_kernel_interface.hpp
+++ b/octotiger/unitiger/hydro_impl/reconstruct_kernel_interface.hpp
@@ -57,7 +57,7 @@ void reconstruct_cpu_kernel(const safe_real omega, const size_t nf_, const int a
 #if defined(OCTOTIGER_HAVE_CUDA) || defined(OCTOTIGER_HAVE_HIP)
 __global__ void discs_phase1(double* __restrict__ P, double* __restrict__ combined_u,
     const double A_, const double B_, const double fgamma_, const double
-    de_switch_1);
+    de_switch_1, const int nf);
 __global__ void discs_phase2(
     double* __restrict__ disc, double* __restrict__ P, const double
     fgamma_, const int ndir);
@@ -73,7 +73,7 @@ void launch_reconstruct_cuda(
     double* combined_u, double* AM, double dx,
     double* cdiscs, int n_species_);
 void convert_find_contact_discs(const double* __restrict__ combined_u, double* __restrict__ disc, const double A_, const double B_, const double fgamma_, const double de_switch_1);
-void launch_find_contact_discs_cuda(aggregated_executor_t& executor, double* combined_u, double *device_P, double* disc, double A_, double B_, double fgamma_, double de_switch_1);
+void launch_find_contact_discs_cuda(aggregated_executor_t& executor, double* combined_u, double *device_P, double* disc, double A_, double B_, double fgamma_, double de_switch_1, const int nf);
 void launch_hydro_pre_recon_cuda(aggregated_executor_t& executor, 
     double* device_X, double omega, bool angmom, double* device_u, int nf, int n_species_);
 #endif

--- a/src/unitiger/hydro_impl/flux_cuda_kernel.cpp
+++ b/src/unitiger/hydro_impl/flux_cuda_kernel.cpp
@@ -188,20 +188,22 @@ void flux_hip_kernel_ggl_wrapper(dim3 const grid_spec, dim3 const threads_per_bl
 }
 
 void launch_flux_hip_kernel_post(
-    stream_interface<hpx::cuda::experimental::cuda_executor, pool_strategy>& executor,
+    aggregated_executor_t& executor,
     dim3 const grid_spec, dim3 const threads_per_block, double* device_q, double* device_x,
     double* device_f, double* device_amax, int* device_amax_indices, int* device_amax_d,
     const bool* masks, const double omega, const double dx, const double A_, const double B_,
     const size_t nf_, const double fgamma, const double de_switch_1) {
-    executor.post(flux_hip_kernel_ggl_wrapper, grid_spec, threads_per_block, device_q, device_x,
+    auto fut = executor.async(flux_hip_kernel_ggl_wrapper, grid_spec, threads_per_block, device_q, device_x,
         device_f, device_amax, device_amax_indices, device_amax_d, masks, omega, dx, A_, B_, nf_, fgamma, de_switch_1);
+    fut.get();
 }
 #else
 void launch_flux_cuda_kernel_post(
-    stream_interface<hpx::cuda::experimental::cuda_executor, pool_strategy>& executor,
+    aggregated_executor_t& executor,
     dim3 const grid_spec, dim3 const threads_per_block, void* args[]) {
-    executor.post(cudaLaunchKernel<decltype(flux_cuda_kernel)>, flux_cuda_kernel, grid_spec,
+    auto fut =executor.async(cudaLaunchKernel<decltype(flux_cuda_kernel)>, flux_cuda_kernel, grid_spec,
         threads_per_block, args, 0);
+    fut.get();
 }
 #endif
 

--- a/src/unitiger/hydro_impl/flux_cuda_kernel.cpp
+++ b/src/unitiger/hydro_impl/flux_cuda_kernel.cpp
@@ -36,8 +36,8 @@ __global__ void __launch_bounds__(128, 2) flux_cuda_kernel(const double* __restr
     __shared__ int sm_i[128];
 
     const int slice_id = blockIdx.x;
-    const int q_slice_offset = (nf * 27 * H_N3 + 128) * slice_id;
-    const int f_slice_offset = (nf * q_inx3 + 128) * slice_id;
+    const int q_slice_offset = (nf * 27 * q_inx3 + 128) * slice_id;
+    const int f_slice_offset = (NDIM * nf * q_inx3 + 128) * slice_id;
     const int x_slice_offset = (NDIM * q_inx3 + 128) * slice_id;
     const int amax_slice_offset = NDIM * (1 + 2 * nf) * number_blocks * slice_id;
     const int max_indices_slice_offset = NDIM * number_blocks * slice_id;
@@ -168,7 +168,7 @@ __global__ void __launch_bounds__(128, 2) flux_cuda_kernel(const double* __restr
 
     if (tid == 0) {
         const int block_id = blockIdx.y + dim * blocks_per_dim;
-        amax[block_id + max_indices_slice_offset] = sm_amax[0];
+        amax[block_id + amax_slice_offset] = sm_amax[0];
         amax_indices[block_id + max_indices_slice_offset] = sm_i[0];
         amax_d[block_id + max_indices_slice_offset] = sm_d[0];
 

--- a/src/unitiger/hydro_impl/flux_cuda_kernel.cpp
+++ b/src/unitiger/hydro_impl/flux_cuda_kernel.cpp
@@ -201,17 +201,15 @@ void launch_flux_hip_kernel_post(
     double* device_f, double* device_amax, int* device_amax_indices, int* device_amax_d,
     const bool* masks, const double omega, const double dx, const double A_, const double B_,
     const size_t nf_, const double fgamma, const double de_switch_1) {
-    auto fut = executor.async(flux_hip_kernel_ggl_wrapper, grid_spec, threads_per_block, device_q, device_x,
+    executor.post(flux_hip_kernel_ggl_wrapper, grid_spec, threads_per_block, device_q, device_x,
         device_f, device_amax, device_amax_indices, device_amax_d, masks, omega, dx, A_, B_, nf_, fgamma, de_switch_1);
-    fut.get();
 }
 #else
 void launch_flux_cuda_kernel_post(
     aggregated_executor_t& executor,
     dim3 const grid_spec, dim3 const threads_per_block, void* args[]) {
-    auto fut =executor.async(cudaLaunchKernel<decltype(flux_cuda_kernel)>, flux_cuda_kernel, grid_spec,
+    executor.post(cudaLaunchKernel<decltype(flux_cuda_kernel)>, flux_cuda_kernel, grid_spec,
         threads_per_block, args, 0);
-    fut.get();
 }
 #endif
 

--- a/src/unitiger/hydro_impl/hydro_cuda_interface.cpp
+++ b/src/unitiger/hydro_impl/hydro_cuda_interface.cpp
@@ -10,7 +10,6 @@
 #endif
 #include <stream_manager.hpp>
 #undef NDEBUG
-#include <aggregation_manager.hpp>
 
 #include <hpx/apply.hpp>
 #include <hpx/synchronization/once.hpp>
@@ -81,102 +80,103 @@ __host__ const bool* get_gpu_masks(void) {
 }
 
 
-timestep_t launch_flux_cuda(
-    stream_interface<hpx::cuda::experimental::cuda_executor, pool_strategy>& executor,
-    double* device_q, host_buffer_t<double>& combined_f, host_buffer_t<double>& combined_x,
-    double* device_x, safe_real omega, const size_t nf_, double dx, size_t device_id) {
-    timestep_t ts;
-    const cell_geometry<3, 8> geo;
-    constexpr int number_blocks = (q_inx3 / 128 + 1);
+/* timestep_t launch_flux_cuda( */
+/*     stream_interface<hpx::cuda::experimental::cuda_executor, pool_strategy>& executor, */
+/*     double* device_q, host_buffer_t<double>& combined_f, host_buffer_t<double>& combined_x, */
+/*     double* device_x, safe_real omega, const size_t nf_, double dx, size_t device_id) { */
+/*     timestep_t ts; */
+/*     const cell_geometry<3, 8> geo; */
+/*     constexpr int number_blocks = (q_inx3 / 128 + 1); */
 
-      // TODO Add slice alloc
-    device_buffer_t<double> device_f(NDIM * nf_ * q_inx3 + 128, device_id);
-    const bool* masks = get_gpu_masks();
-    device_buffer_t<double> device_amax(number_blocks * NDIM * (1 + 2 * nf_));
-    device_buffer_t<int> device_amax_indices(number_blocks * NDIM);
-    device_buffer_t<int> device_amax_d(number_blocks * NDIM);
-    double A_ = physics<NDIM>::A_;
-    double B_ = physics<NDIM>::B_;
-    double fgamma = physics<NDIM>::fgamma_;
-    double de_switch_1 = physics<NDIM>::de_switch_1;
-    int nf_local = physics<NDIM>::nf_;
+/*       // TODO Add slice alloc */
+/*     device_buffer_t<double> device_f(NDIM * nf_ * q_inx3 + 128, device_id); */
+/*     const bool* masks = get_gpu_masks(); */
+/*     device_buffer_t<double> device_amax(number_blocks * NDIM * (1 + 2 * nf_)); */
+/*     device_buffer_t<int> device_amax_indices(number_blocks * NDIM); */
+/*     device_buffer_t<int> device_amax_d(number_blocks * NDIM); */
+/*     double A_ = physics<NDIM>::A_; */
+/*     double B_ = physics<NDIM>::B_; */
+/*     double fgamma = physics<NDIM>::fgamma_; */
+/*     double de_switch_1 = physics<NDIM>::de_switch_1; */
+/*     int nf_local = physics<NDIM>::nf_; */
 
-    assert(NDIM == 3);
-    dim3 const grid_spec(1, number_blocks, 3);
-    dim3 const threads_per_block(2, 8, 8);
-#if defined(OCTOTIGER_HAVE_CUDA)
-    void* args[] = {&(device_q), &(device_x), &(device_f.device_side_buffer),
-        &(device_amax.device_side_buffer), &(device_amax_indices.device_side_buffer),
-        &(device_amax_d.device_side_buffer), &masks, &omega, &dx, &A_, &B_, &nf_local, &fgamma,
-        &de_switch_1};
-      // TODO Wrap in slice executor
-    launch_flux_cuda_kernel_post(executor, grid_spec, threads_per_block, args);
-#elif defined(OCTOTIGER_HAVE_HIP)
-      // TODO Wrap in slice executor
-    launch_flux_hip_kernel_post(executor, grid_spec, threads_per_block, device_q, device_x,
-        device_f.device_side_buffer, device_amax.device_side_buffer,
-        device_amax_indices.device_side_buffer, device_amax_d.device_side_buffer, masks, omega, dx,
-        A_, B_, nf_local, fgamma, de_switch_1);
-#endif
+/*     assert(NDIM == 3); */
+/*     dim3 const grid_spec(1, number_blocks, 3); */
+/*     dim3 const threads_per_block(2, 8, 8); */
+/* #if defined(OCTOTIGER_HAVE_CUDA) */
+/*     void* args[] = {&(device_q), &(device_x), &(device_f.device_side_buffer), */
+/*         &(device_amax.device_side_buffer), &(device_amax_indices.device_side_buffer), */
+/*         &(device_amax_d.device_side_buffer), &masks, &omega, &dx, &A_, &B_, &nf_local, &fgamma, */
+/*         &de_switch_1}; */
+/*       // TODO Wrap in slice executor */
+/*     launch_flux_cuda_kernel_post(executor, grid_spec, threads_per_block, args); */
+/* #elif defined(OCTOTIGER_HAVE_HIP) */
+/*       // TODO Wrap in slice executor */
+/*     launch_flux_hip_kernel_post(executor, grid_spec, threads_per_block, device_q, device_x, */
+/*         device_f.device_side_buffer, device_amax.device_side_buffer, */
+/*         device_amax_indices.device_side_buffer, device_amax_d.device_side_buffer, masks, omega, dx, */
+/*         A_, B_, nf_local, fgamma, de_switch_1); */
+/* #endif */
 
-    // Move data to host
-      // TODO Add slice alloc
-    host_buffer_t<double> amax(number_blocks * NDIM * (1 + 2 * nf_));
-    host_buffer_t<int> amax_indices(number_blocks * NDIM);
-    host_buffer_t<int> amax_d(number_blocks * NDIM);
+/*     // Move data to host */
+/*       // TODO Add slice alloc */
+/*     host_buffer_t<double> amax(number_blocks * NDIM * (1 + 2 * nf_)); */
+/*     host_buffer_t<int> amax_indices(number_blocks * NDIM); */
+/*     host_buffer_t<int> amax_d(number_blocks * NDIM); */
 
-      // TODO Wrap in slice executor
-    hpx::apply(static_cast<hpx::cuda::experimental::cuda_executor>(executor), cudaMemcpyAsync,
-        amax.data(), device_amax.device_side_buffer,
-        (number_blocks * NDIM * (1 + 2 * nf_)) * sizeof(double), cudaMemcpyDeviceToHost);
-    hpx::apply(static_cast<hpx::cuda::experimental::cuda_executor>(executor), cudaMemcpyAsync,
-        amax_indices.data(), device_amax_indices.device_side_buffer,
-        number_blocks * NDIM * sizeof(int), cudaMemcpyDeviceToHost);
-    hpx::apply(static_cast<hpx::cuda::experimental::cuda_executor>(executor), cudaMemcpyAsync,
-        amax_d.data(), device_amax_d.device_side_buffer, number_blocks * NDIM * sizeof(int),
-        cudaMemcpyDeviceToHost);
-    auto fut = hpx::async(static_cast<hpx::cuda::experimental::cuda_executor>(executor),
-        cudaMemcpyAsync, combined_f.data(), device_f.device_side_buffer,
-        (NDIM * nf_ * q_inx3 + 128) * sizeof(double), cudaMemcpyDeviceToHost);
-    fut.get();
+/*       // TODO Wrap in slice executor */
+/*     hpx::apply(static_cast<hpx::cuda::experimental::cuda_executor>(executor), cudaMemcpyAsync, */
+/*         amax.data(), device_amax.device_side_buffer, */
+/*         (number_blocks * NDIM * (1 + 2 * nf_)) * sizeof(double), cudaMemcpyDeviceToHost); */
+/*     hpx::apply(static_cast<hpx::cuda::experimental::cuda_executor>(executor), cudaMemcpyAsync, */
+/*         amax_indices.data(), device_amax_indices.device_side_buffer, */
+/*         number_blocks * NDIM * sizeof(int), cudaMemcpyDeviceToHost); */
+/*     hpx::apply(static_cast<hpx::cuda::experimental::cuda_executor>(executor), cudaMemcpyAsync, */
+/*         amax_d.data(), device_amax_d.device_side_buffer, number_blocks * NDIM * sizeof(int), */
+/*         cudaMemcpyDeviceToHost); */
+/*     auto fut = hpx::async(static_cast<hpx::cuda::experimental::cuda_executor>(executor), */
+/*         cudaMemcpyAsync, combined_f.data(), device_f.device_side_buffer, */
+/*         (NDIM * nf_ * q_inx3 + 128) * sizeof(double), cudaMemcpyDeviceToHost); */
+/*     fut.get(); */
 
-    // Find Maximum
-    size_t current_dim = 0;
-    for (size_t dim_i = 1; dim_i < number_blocks * NDIM; dim_i++) {
-      if (amax[dim_i] > amax[current_dim]) { 
-        current_dim = dim_i;
-      } else if (amax[dim_i] == amax[current_dim]) {
-        if (amax_indices[dim_i] < amax_indices[current_dim]) {
-          current_dim = dim_i;
-        }
-      }
-    }
-    std::vector<double> URs(nf_), ULs(nf_);
-    const size_t current_max_index = amax_indices[current_dim];
-    // const size_t current_d = amax_d[current_dim];
-    ts.a = amax[current_dim];
-    ts.x = combined_x[current_max_index];
-    ts.y = combined_x[current_max_index + q_inx3];
-    ts.z = combined_x[current_max_index + 2 * q_inx3];
+/*     // Find Maximum */
+/*     size_t current_dim = 0; */
+/*     for (size_t dim_i = 1; dim_i < number_blocks * NDIM; dim_i++) { */
+/*       if (amax[dim_i] > amax[current_dim]) { */ 
+/*         current_dim = dim_i; */
+/*       } else if (amax[dim_i] == amax[current_dim]) { */
+/*         if (amax_indices[dim_i] < amax_indices[current_dim]) { */
+/*           current_dim = dim_i; */
+/*         } */
+/*       } */
+/*     } */
+/*     std::vector<double> URs(nf_), ULs(nf_); */
+/*     const size_t current_max_index = amax_indices[current_dim]; */
+/*     // const size_t current_d = amax_d[current_dim]; */
+/*     ts.a = amax[current_dim]; */
+/*     ts.x = combined_x[current_max_index]; */
+/*     ts.y = combined_x[current_max_index + q_inx3]; */
+/*     ts.z = combined_x[current_max_index + 2 * q_inx3]; */
     
-    const size_t current_i = current_dim;
-    current_dim = current_dim / number_blocks;
-    for (int f = 0; f < nf_; f++) {
-        URs[f] = amax[NDIM * number_blocks + current_i * 2 * nf_ + f];
-        ULs[f] = amax[NDIM * number_blocks + current_i * 2 * nf_ + nf_ + f];
-    }
-    ts.ul = std::move(URs);
-    ts.ur = std::move(ULs);
-    ts.dim = current_dim;
-    return ts;
-}
+/*     const size_t current_i = current_dim; */
+/*     current_dim = current_dim / number_blocks; */
+/*     for (int f = 0; f < nf_; f++) { */
+/*         URs[f] = amax[NDIM * number_blocks + current_i * 2 * nf_ + f]; */
+/*         ULs[f] = amax[NDIM * number_blocks + current_i * 2 * nf_ + nf_ + f]; */
+/*     } */
+/*     ts.ul = std::move(URs); */
+/*     ts.ur = std::move(ULs); */
+/*     ts.dim = current_dim; */
+/*     return ts; */
+/* } */
 
 // Input U, X, omega, executor, device_id
 // Output F
+// TODO remove obsolete executor
 timestep_t launch_hydro_cuda_kernels(const hydro_computer<NDIM, INX, physics<NDIM>>& hydro,
     const std::vector<std::vector<safe_real>>& U, const std::vector<std::vector<safe_real>>& X,
     const double omega, const size_t device_id,
-    stream_interface<hpx::cuda::experimental::cuda_executor, pool_strategy>& executor,
+    stream_interface<hpx::cuda::experimental::cuda_executor, pool_strategy>& executor_obsolete,
     std::vector<hydro_state_t<std::vector<safe_real>>>& F) {
 
     // Init local kernel pool if not done already
@@ -186,7 +186,7 @@ timestep_t launch_hydro_cuda_kernels(const hydro_computer<NDIM, INX, physics<NDI
     // Add continuation to executor future to execute the hydro kernels as soon as it's ready
     auto ret_fut = executor_slice_fut.value().then([&](auto && fut) {
       // Unwrap executor from ready future
-      auto exec_slice = fut.get();
+      aggregated_executor_t exec_slice = fut.get();
       // How many executor slices are working together and what's our ID?
       const size_t slice_id = exec_slice.id;
       const size_t number_slices = exec_slice.number_slices;
@@ -260,25 +260,23 @@ timestep_t launch_hydro_cuda_kernels(const hydro_computer<NDIM, INX, physics<NDI
           smooth_field[f] = smooth_bool[f];
       }
 
-      // TODO Wrap function calls in exec_slice
       // Move input to device
-      hpx::apply(static_cast<hpx::cuda::experimental::cuda_executor>(executor), cudaMemcpyAsync,
+      exec_slice.post(cudaMemcpyAsync,
           device_u.device_side_buffer, combined_u.data(),
           (hydro.get_nf() * H_N3 + 128) * sizeof(double), cudaMemcpyHostToDevice);
-      hpx::apply(static_cast<hpx::cuda::experimental::cuda_executor>(executor), cudaMemcpyAsync,
+      exec_slice.post(cudaMemcpyAsync,
           device_x.device_side_buffer, combined_x.data(), (NDIM * q_inx3 + 128) * sizeof(double),
           cudaMemcpyHostToDevice);
-      hpx::apply(static_cast<hpx::cuda::experimental::cuda_executor>(executor), cudaMemcpyAsync,
+      exec_slice.post(cudaMemcpyAsync,
           device_disc_detect.device_side_buffer, disc_detect.data(), (hydro.get_nf()) * sizeof(int),
           cudaMemcpyHostToDevice);
-      hpx::apply(static_cast<hpx::cuda::experimental::cuda_executor>(executor), cudaMemcpyAsync,
+      exec_slice.post(cudaMemcpyAsync,
           device_smooth_field.device_side_buffer, smooth_field.data(), (hydro.get_nf()) * sizeof(int),
           cudaMemcpyHostToDevice);
 
 
-      // TODO Wrap function calls in exec_slice
       // get discs
-      launch_find_contact_discs_cuda(executor, device_u.device_side_buffer,
+      launch_find_contact_discs_cuda(exec_slice, device_u.device_side_buffer,
           device_P.device_side_buffer, device_unified_discs.device_side_buffer, physics<NDIM>::A_,
           physics<NDIM>::B_, physics<NDIM>::fgamma_, physics<NDIM>::de_switch_1);
 
@@ -286,18 +284,15 @@ timestep_t launch_hydro_cuda_kernels(const hydro_computer<NDIM, INX, physics<NDI
       for (int n = 0; n < NDIM; n++) {
           std::copy(X[n].begin(), X[n].end(), combined_large_x.data() + n * H_N3);
       }
-      // TODO Wrap function calls in exec_slice
-      hpx::apply(static_cast<hpx::cuda::experimental::cuda_executor>(executor), cudaMemcpyAsync,
+      exec_slice.post(cudaMemcpyAsync,
           device_large_x.device_side_buffer, combined_large_x.data(),
           (NDIM * H_N3 + 128) * sizeof(double), cudaMemcpyHostToDevice);
 
-      // TODO Wrap function calls in exec_slice
-      launch_hydro_pre_recon_cuda(executor, device_large_x.device_side_buffer, omega,
+      launch_hydro_pre_recon_cuda(exec_slice, device_large_x.device_side_buffer, omega,
           hydro.get_angmom_index() != -1, device_u.device_side_buffer, hydro.get_nf(),
           opts().n_species);
 
-      // TODO Wrap function calls in exec_slice
-      launch_reconstruct_cuda(executor, omega, hydro.get_nf(), hydro.get_angmom_index(),
+      launch_reconstruct_cuda(exec_slice, omega, hydro.get_nf(), hydro.get_angmom_index(),
           device_smooth_field.device_side_buffer, device_disc_detect.device_side_buffer,
           device_q.device_side_buffer, device_x.device_side_buffer, device_u.device_side_buffer,
           device_AM.device_side_buffer, X[0][geo.H_DNX] - X[0][0],
@@ -334,11 +329,11 @@ timestep_t launch_hydro_cuda_kernels(const hydro_computer<NDIM, INX, physics<NDI
           &(device_amax_indices.device_side_buffer), &(device_amax_d.device_side_buffer), &masks,
           &omega_local, &dx, &A_, &B_, &nf_local, &fgamma, &de_switch_1};
       // TODO Wrap in slice executor
-      launch_flux_cuda_kernel_post(executor, grid_spec, threads_per_block,
+      launch_flux_cuda_kernel_post(exec_slice, grid_spec, threads_per_block,
           args);
 #elif defined(OCTOTIGER_HAVE_HIP)
         // TODO Wrap in slice executor
-      launch_flux_hip_kernel_post(executor, grid_spec, threads_per_block,
+      launch_flux_hip_kernel_post(exec_slice, grid_spec, threads_per_block,
           device_q.device_side_buffer, device_x.device_side_buffer, device_f.device_side_buffer,
           device_amax.device_side_buffer, device_amax_indices.device_side_buffer,
           device_amax_d.device_side_buffer, masks, omega_local, dx, A_, B_,
@@ -353,17 +348,16 @@ timestep_t launch_hydro_cuda_kernels(const hydro_computer<NDIM, INX, physics<NDI
       aggregated_host_buffer_t<int, decltype(alloc_host_int)> amax_d(number_blocks * NDIM, int{}, alloc_host_int);
 
         // TODO Wrap in slice executor
-      hpx::apply(static_cast<hpx::cuda::experimental::cuda_executor>(executor), cudaMemcpyAsync,
+      exec_slice.post(cudaMemcpyAsync,
           amax.data(), device_amax.device_side_buffer,
           (number_blocks * NDIM * (1 + 2 * nf_local)) * sizeof(double), cudaMemcpyDeviceToHost);
-      hpx::apply(static_cast<hpx::cuda::experimental::cuda_executor>(executor), cudaMemcpyAsync,
+      exec_slice.post(cudaMemcpyAsync,
           amax_indices.data(), device_amax_indices.device_side_buffer,
           number_blocks * NDIM * sizeof(int), cudaMemcpyDeviceToHost);
-      hpx::apply(static_cast<hpx::cuda::experimental::cuda_executor>(executor), cudaMemcpyAsync,
+      exec_slice.post(cudaMemcpyAsync,
           amax_d.data(), device_amax_d.device_side_buffer, number_blocks * NDIM * sizeof(int),
           cudaMemcpyDeviceToHost);
-      auto flux_kernel_fut = hpx::async(static_cast<hpx::cuda::experimental::cuda_executor>(executor),
-          cudaMemcpyAsync, f.data(), device_f.device_side_buffer,
+      auto flux_kernel_fut = exec_slice.async(cudaMemcpyAsync, f.data(), device_f.device_side_buffer,
           (NDIM * nf_local * q_inx3 + 128) * sizeof(double), cudaMemcpyDeviceToHost);
       flux_kernel_fut.get();
 

--- a/src/unitiger/hydro_impl/hydro_cuda_interface.cpp
+++ b/src/unitiger/hydro_impl/hydro_cuda_interface.cpp
@@ -35,9 +35,13 @@ hpx::lcos::local::once_flag init_pool_flag;
 #if defined(OCTOTIGER_HAVE_CUDA)
 template <typename T>
 using device_buffer_t = recycler::cuda_device_buffer<T>;
+template <typename T, typename Alloc>
+using aggregated_device_buffer_t = recycler::cuda_aggregated_device_buffer<T, Alloc>;
 template <typename T>
 using host_buffer_t = std::vector<T, recycler::recycle_allocator_cuda_host<T>>;
 using executor_t = hpx::cuda::experimental::cuda_executor;
+template <typename T, typename Alloc>
+using aggregated_host_buffer_t = std::vector<T, Alloc>;
 #elif defined(OCTOTIGER_HAVE_HIP)
 template <typename T>
 using device_buffer_t = recycler::hip_device_buffer<T>;
@@ -54,8 +58,8 @@ using executor_t = hpx::cuda::experimental::cuda_executor;
 #endif
 
 void init_aggregation_pool(void) {
-    constexpr size_t number_aggregation_executors = 16;
-    constexpr size_t max_slices = 8;
+    constexpr size_t number_aggregation_executors = 1;
+    constexpr size_t max_slices = 1;
     constexpr Aggregated_Executor_Modes executor_mode = Aggregated_Executor_Modes::EAGER;
     hydro_cuda_agg_executor_pool::init(number_aggregation_executors, max_slices, executor_mode);
 }
@@ -76,12 +80,12 @@ __host__ const bool* get_gpu_masks(void) {
     return masks;
 }
 
+
 timestep_t launch_flux_cuda(
     stream_interface<hpx::cuda::experimental::cuda_executor, pool_strategy>& executor,
     double* device_q, host_buffer_t<double>& combined_f, host_buffer_t<double>& combined_x,
     double* device_x, safe_real omega, const size_t nf_, double dx, size_t device_id) {
     timestep_t ts;
-
     const cell_geometry<3, 8> geo;
     constexpr int number_blocks = (q_inx3 / 128 + 1);
 
@@ -154,34 +158,9 @@ timestep_t launch_flux_cuda(
     ts.x = combined_x[current_max_index];
     ts.y = combined_x[current_max_index + q_inx3];
     ts.z = combined_x[current_max_index + 2 * q_inx3];
- /* int x = current_max_index / (10 * 10);
-  int y = (current_max_index % (10 * 10)) / 10;
-  int z = (current_max_index % (10 * 10)) % 10;
-  std::cout << "xzy" << x << " " << y << " " << z << std::endl;
-    std::cout << "Max index: " << current_max_index << " Max dim: " << current_dim / number_blocks <<
-      std::endl;
-    std::cout << ts.x << " " << ts.y << " " << ts.z << std::endl;
-    std::cin.get();
-    std::cout << "start output x!" << std::endl;
-    for(int i = 0; i < q_inx3; i++)
-      std::cout << combined_x[i + 0 * q_inx3] << " ";
-    std::cout << "finish output x!" << std::endl;
-    std::cout << "start output x!" << std::endl;
-    for(int i = 0; i < q_inx3; i++)
-      std::cout << combined_x[i + 1 * q_inx3] << " ";
-    std::cout << "finish output x!" << std::endl;
-    std::cout << "start output z!" << std::endl;
-    for(int i = 0; i < q_inx3; i++)
-      std::cout << combined_x[i + 2 * q_inx3] << " ";
-    std::cout << "finish output z!" << std::endl;
-    std::cin.get();*/
-
-
     
     const size_t current_i = current_dim;
     current_dim = current_dim / number_blocks;
-    // const auto flipped_dim = geo.flip_dim(current_d, current_dim);
-    // constexpr int compressedH_DN[3] = {q_inx2, q_inx, 1};
     for (int f = 0; f < nf_; f++) {
         URs[f] = amax[NDIM * number_blocks + current_i * 2 * nf_ + f];
         ULs[f] = amax[NDIM * number_blocks + current_i * 2 * nf_ + nf_ + f];
@@ -200,13 +179,19 @@ timestep_t launch_hydro_cuda_kernels(const hydro_computer<NDIM, INX, physics<NDI
     stream_interface<hpx::cuda::experimental::cuda_executor, pool_strategy>& executor,
     std::vector<hydro_state_t<std::vector<safe_real>>>& F) {
 
+    // Init local kernel pool if not done already
     hpx::lcos::local::call_once(init_pool_flag, init_aggregation_pool);
+    // Get executor (-slice if aggregated with max_slices > 1) future
     auto executor_slice_fut = hydro_cuda_agg_executor_pool::request_executor_slice();
+    // Add continuation to executor future to execute the hydro kernels as soon as it's ready
     auto ret_fut = executor_slice_fut.value().then([&](auto && fut) {
+      // Unwrap executor from ready future
       auto exec_slice = fut.get();
+      // How many executor slices are working together and what's our ID?
       const size_t slice_id = exec_slice.id;
       const size_t number_slices = exec_slice.number_slices;
 
+      // Get allocators of all the executors working together
       auto alloc_host_double =
           exec_slice
               .template make_allocator<double, recycler::detail::cuda_pinned_allocator<double>>();
@@ -222,27 +207,43 @@ timestep_t launch_hydro_cuda_kernels(const hydro_computer<NDIM, INX, physics<NDI
 
       static const cell_geometry<NDIM, INX> geo;
 
-      // TODO Turn into aggegregated buffers
       // Device buffers
-      device_buffer_t<double> device_q(hydro.get_nf() * 27 * q_inx * q_inx * q_inx + 128, device_id);
-      device_buffer_t<double> device_x(NDIM * q_inx3 + 128, device_id);
-      device_buffer_t<double> device_large_x(NDIM * H_N3 + 128, device_id);
-      device_buffer_t<double> device_f(NDIM * hydro.get_nf() * q_inx3 + 128, device_id);
-      device_buffer_t<double> device_u(hydro.get_nf() * H_N3 + 128);
-      device_buffer_t<double> device_unified_discs(geo.NDIR / 2 * H_N3 + 128);
-      device_buffer_t<double> device_P(H_N3 + 128);
-      device_buffer_t<int> device_disc_detect(hydro.get_nf());
-      device_buffer_t<int> device_smooth_field(hydro.get_nf());
-      device_buffer_t<double> device_AM(NDIM * q_inx * q_inx * q_inx + 128);
+      aggregated_device_buffer_t<double, decltype(alloc_device_double)>
+        device_q(
+          hydro.get_nf() * 27 * q_inx * q_inx * q_inx + 128, device_id, alloc_device_double);
+      aggregated_device_buffer_t<double, decltype(alloc_device_double)> device_x(
+          NDIM * q_inx3 + 128, device_id, alloc_device_double);
+      aggregated_device_buffer_t<double, decltype(alloc_device_double)> device_large_x(
+          NDIM * H_N3 + 128, device_id, alloc_device_double);
+      aggregated_device_buffer_t<double, decltype(alloc_device_double)> device_f(
+          NDIM * hydro.get_nf() * q_inx3 + 128, device_id, alloc_device_double);
+      aggregated_device_buffer_t<double, decltype(alloc_device_double)> device_u(
+          hydro.get_nf() * H_N3 + 128, device_id, alloc_device_double);
+      aggregated_device_buffer_t<double, decltype(alloc_device_double)>
+        device_unified_discs(
+          geo.NDIR / 2 * H_N3 + 128, device_id, alloc_device_double);
+      aggregated_device_buffer_t<double, decltype(alloc_device_double)> device_P(
+          H_N3 + 128, device_id, alloc_device_double);
+      aggregated_device_buffer_t<int, decltype(alloc_device_int)> device_disc_detect(
+          hydro.get_nf(), device_id, alloc_device_int);
+      aggregated_device_buffer_t<int, decltype(alloc_device_int)> device_smooth_field(
+          hydro.get_nf(), device_id, alloc_device_int);
+      aggregated_device_buffer_t<double, decltype(alloc_device_double)> device_AM(
+          NDIM * q_inx * q_inx * q_inx + 128, device_id, alloc_device_double);
 
-      // TODO Turn into aggegregated buffers
       // Host buffers
-      host_buffer_t<double> combined_x(NDIM * q_inx3 + 128);
-      host_buffer_t<double> combined_large_x(NDIM * H_N3 + 128);
-      host_buffer_t<double> combined_u(hydro.get_nf() * H_N3 + 128);
-      host_buffer_t<int> disc_detect(hydro.get_nf());
-      host_buffer_t<int> smooth_field(hydro.get_nf());
-      host_buffer_t<double> f(NDIM * hydro.get_nf() * q_inx3 + 128);
+      aggregated_host_buffer_t<double, decltype(alloc_host_double)> combined_x(
+          NDIM * q_inx3 + 128, double{}, alloc_host_double);
+      aggregated_host_buffer_t<double, decltype(alloc_host_double)> combined_large_x(
+          NDIM * H_N3 + 128, double{}, alloc_host_double);
+      aggregated_host_buffer_t<double, decltype(alloc_host_double)> combined_u(
+          hydro.get_nf() * H_N3 + 128, double{}, alloc_host_double);
+      aggregated_host_buffer_t<double, decltype(alloc_host_double)> f(
+          NDIM * hydro.get_nf() * q_inx3 + 128, double{}, alloc_host_double);
+      aggregated_host_buffer_t<int, decltype(alloc_host_int)> disc_detect(
+          hydro.get_nf(), int{}, alloc_host_int);
+      aggregated_host_buffer_t<int, decltype(alloc_host_int)> smooth_field(
+          hydro.get_nf(), int{}, alloc_host_int);
 
       // TODO Adapt indexing for aggregated buffer
       // Convert input
@@ -302,10 +303,102 @@ timestep_t launch_hydro_cuda_kernels(const hydro_computer<NDIM, INX, physics<NDI
           device_AM.device_side_buffer, X[0][geo.H_DNX] - X[0][0],
           device_unified_discs.device_side_buffer, opts().n_species);
 
-      // TODO Pass slice_exec AND allocs 
       // Call Flux kernel
-      auto max_lambda = launch_flux_cuda(executor, device_q.device_side_buffer, f, combined_x,
-          device_x.device_side_buffer, omega, hydro.get_nf(), X[0][geo.H_DNX] - X[0][0], device_id);
+      timestep_t ts;
+      size_t nf_ = hydro.get_nf();
+      double dx = X[0][geo.H_DNX] - X[0][0];
+      constexpr int number_blocks = (q_inx3 / 128 + 1);
+
+      const bool* masks = get_gpu_masks();
+      aggregated_device_buffer_t<double, decltype(alloc_device_double)> device_amax(
+          number_blocks * NDIM * (1 + 2 * nf_), device_id, alloc_device_double);
+      aggregated_device_buffer_t<int, decltype(alloc_device_int)>
+        device_amax_indices(
+          number_blocks * NDIM, device_id, alloc_device_int);
+      aggregated_device_buffer_t<int, decltype(alloc_device_int)> device_amax_d(
+          number_blocks * NDIM, device_id, alloc_device_int);
+
+      double A_ = physics<NDIM>::A_;
+      double B_ = physics<NDIM>::B_;
+      double fgamma = physics<NDIM>::fgamma_;
+      double de_switch_1 = physics<NDIM>::de_switch_1;
+      int nf_local = physics<NDIM>::nf_;
+
+      assert(NDIM == 3);
+      dim3 const grid_spec(1, number_blocks, 3);
+      dim3 const threads_per_block(2, 8, 8);
+      double omega_local = omega;
+#if defined(OCTOTIGER_HAVE_CUDA)
+      void* args[] = {&(device_q.device_side_buffer), &(device_x.device_side_buffer),
+          &(device_f.device_side_buffer), &(device_amax.device_side_buffer),
+          &(device_amax_indices.device_side_buffer), &(device_amax_d.device_side_buffer), &masks,
+          &omega_local, &dx, &A_, &B_, &nf_local, &fgamma, &de_switch_1};
+      // TODO Wrap in slice executor
+      launch_flux_cuda_kernel_post(executor, grid_spec, threads_per_block,
+          args);
+#elif defined(OCTOTIGER_HAVE_HIP)
+        // TODO Wrap in slice executor
+      launch_flux_hip_kernel_post(executor, grid_spec, threads_per_block,
+          device_q.device_side_buffer, device_x.device_side_buffer, device_f.device_side_buffer,
+          device_amax.device_side_buffer, device_amax_indices.device_side_buffer,
+          device_amax_d.device_side_buffer, masks, omega_local, dx, A_, B_,
+          nf_local, fgamma,
+          de_switch_1);
+#endif
+
+      // Move data to host
+      aggregated_host_buffer_t<double, decltype(alloc_host_double)> amax(
+          number_blocks * NDIM * (1 + 2 * nf_local), double{}, alloc_host_double);
+      aggregated_host_buffer_t<int, decltype(alloc_host_int)> amax_indices(number_blocks * NDIM, int{}, alloc_host_int);
+      aggregated_host_buffer_t<int, decltype(alloc_host_int)> amax_d(number_blocks * NDIM, int{}, alloc_host_int);
+
+        // TODO Wrap in slice executor
+      hpx::apply(static_cast<hpx::cuda::experimental::cuda_executor>(executor), cudaMemcpyAsync,
+          amax.data(), device_amax.device_side_buffer,
+          (number_blocks * NDIM * (1 + 2 * nf_local)) * sizeof(double), cudaMemcpyDeviceToHost);
+      hpx::apply(static_cast<hpx::cuda::experimental::cuda_executor>(executor), cudaMemcpyAsync,
+          amax_indices.data(), device_amax_indices.device_side_buffer,
+          number_blocks * NDIM * sizeof(int), cudaMemcpyDeviceToHost);
+      hpx::apply(static_cast<hpx::cuda::experimental::cuda_executor>(executor), cudaMemcpyAsync,
+          amax_d.data(), device_amax_d.device_side_buffer, number_blocks * NDIM * sizeof(int),
+          cudaMemcpyDeviceToHost);
+      auto flux_kernel_fut = hpx::async(static_cast<hpx::cuda::experimental::cuda_executor>(executor),
+          cudaMemcpyAsync, f.data(), device_f.device_side_buffer,
+          (NDIM * nf_local * q_inx3 + 128) * sizeof(double), cudaMemcpyDeviceToHost);
+      flux_kernel_fut.get();
+
+      // Find Maximum
+      size_t current_dim = 0;
+      for (size_t dim_i = 1; dim_i < number_blocks * NDIM; dim_i++) {
+        if (amax[dim_i] > amax[current_dim]) { 
+          current_dim = dim_i;
+        } else if (amax[dim_i] == amax[current_dim]) {
+          if (amax_indices[dim_i] < amax_indices[current_dim]) {
+            current_dim = dim_i;
+          }
+        }
+      }
+      std::vector<double> URs(nf_local), ULs(nf_local);
+      const size_t current_max_index = amax_indices[current_dim];
+      // const size_t current_d = amax_d[current_dim];
+      ts.a = amax[current_dim];
+      ts.x = combined_x[current_max_index];
+      ts.y = combined_x[current_max_index + q_inx3];
+      ts.z = combined_x[current_max_index + 2 * q_inx3];
+      
+      const size_t current_i = current_dim;
+      current_dim = current_dim / number_blocks;
+      for (int f = 0; f < nf_local; f++) {
+          URs[f] = amax[NDIM * number_blocks + current_i * 2 * nf_local + f];
+          ULs[f] = amax[NDIM * number_blocks + current_i * 2 * nf_local + nf_local + f];
+      }
+      ts.ul = std::move(URs);
+      ts.ur = std::move(ULs);
+      ts.dim = current_dim;
+      auto max_lambda = ts;
+
+      /* auto max_lambda = launch_flux_cuda(executor, device_q.device_side_buffer, f, combined_x, */
+      /*     device_x.device_side_buffer, omega, hydro.get_nf(), X[0][geo.H_DNX] - X[0][0], device_id); */
 
       // TODO Update indexing to slice indexing
       // Convert output

--- a/src/unitiger/hydro_impl/hydro_cuda_interface.cpp
+++ b/src/unitiger/hydro_impl/hydro_cuda_interface.cpp
@@ -58,7 +58,7 @@ using executor_t = hpx::cuda::experimental::cuda_executor;
 
 void init_aggregation_pool(void) {
     constexpr size_t number_aggregation_executors = 16;
-    constexpr size_t max_slices = 1;
+    constexpr size_t max_slices = 2;
     constexpr Aggregated_Executor_Modes executor_mode = Aggregated_Executor_Modes::EAGER;
     hydro_cuda_agg_executor_pool::init(number_aggregation_executors, max_slices, executor_mode);
 }
@@ -231,6 +231,11 @@ timestep_t launch_hydro_cuda_kernels(const hydro_computer<NDIM, INX, physics<NDI
       aggregated_device_buffer_t<double, decltype(alloc_device_double)> device_AM(
           (NDIM * q_inx * q_inx * q_inx + 128) * number_slices, device_id, alloc_device_double);
 
+
+      // TODO remove
+      aggregated_host_buffer_t<double, decltype(alloc_host_double)>
+        host_q(
+          (hydro.get_nf() * 27 * q_inx * q_inx * q_inx + 128) * number_slices, double{}, alloc_host_double);
       // Host buffers
       aggregated_host_buffer_t<double, decltype(alloc_host_double)> combined_x(
           (NDIM * q_inx3 + 128) * number_slices, double{}, alloc_host_double);
@@ -252,7 +257,8 @@ timestep_t launch_hydro_cuda_kernels(const hydro_computer<NDIM, INX, physics<NDI
       const int smooth_slice_offset = hydro.get_nf();
       constexpr int large_x_slice_offset = (H_N3 * NDIM + 128); 
       //const int q_slice_offset = (nf_ * 27 * H_N3 + 128) 
-      const int f_slice_offset = (hydro.get_nf() *  q_inx3 + 128);
+      const int f_slice_offset = (NDIM* hydro.get_nf() *  q_inx3 + 128);
+      constexpr int disc_offset = geo.NDIR / 2 * H_N3 + 128;
 
       // Convert input
       convert_x_structure(X, combined_x.data() + x_slice_offset * slice_id);
@@ -282,6 +288,7 @@ timestep_t launch_hydro_cuda_kernels(const hydro_computer<NDIM, INX, physics<NDI
           cudaMemcpyHostToDevice);
 
 
+
       // get discs
       launch_find_contact_discs_cuda(exec_slice, device_u.device_side_buffer,
           device_P.device_side_buffer, device_unified_discs.device_side_buffer, physics<NDIM>::A_,
@@ -304,6 +311,14 @@ timestep_t launch_hydro_cuda_kernels(const hydro_computer<NDIM, INX, physics<NDI
           device_AM.device_side_buffer, X[0][geo.H_DNX] - X[0][0],
           device_unified_discs.device_side_buffer, opts().n_species);
 
+      // TODO Remove
+      auto flux_kernel_fut2 = exec_slice.async(cudaMemcpyAsync, host_q.data(), device_q.device_side_buffer,
+          number_slices * (hydro.get_nf() * 27 * q_inx * q_inx * q_inx + 128) * sizeof(double), cudaMemcpyDeviceToHost);
+      flux_kernel_fut2.get();
+      std::cerr << "\nQSlice id:" << slice_id << std::endl;
+      for (auto bla = 0; bla < 1000; bla++) {
+        std::cerr << host_q[bla + (hydro.get_nf() * 27 * q_inx * q_inx * q_inx + 128) * slice_id] << " ";
+      }
       // Call Flux kernel
       timestep_t ts;
       size_t nf_ = hydro.get_nf();
@@ -370,7 +385,9 @@ timestep_t launch_hydro_cuda_kernels(const hydro_computer<NDIM, INX, physics<NDI
       const int amax_slice_offset = NDIM * (1 + 2 * nf_local) * number_blocks * slice_id;
       const int max_indices_slice_offset = NDIM * number_blocks * slice_id;
       size_t current_dim = 0;
+        std::cerr << "\nSlice id:" << slice_id << std::endl;
       for (size_t dim_i = 1; dim_i < number_blocks * NDIM; dim_i++) {
+        std::cerr << amax[dim_i + amax_slice_offset] << " ";
         if (amax[dim_i + amax_slice_offset] > amax[current_dim + amax_slice_offset]) { 
           current_dim = dim_i;
         } else if (amax[dim_i + amax_slice_offset] == amax[current_dim + amax_slice_offset]) {
@@ -378,6 +395,10 @@ timestep_t launch_hydro_cuda_kernels(const hydro_computer<NDIM, INX, physics<NDI
             current_dim = dim_i;
           }
         }
+      }
+      std::cerr << "\nSlice id:" << slice_id << std::endl;
+      for (auto bla = 0; bla < 1000; bla++) {
+        std::cerr << f[bla + f_slice_offset * slice_id] << " ";
       }
       std::vector<double> URs(nf_local), ULs(nf_local);
       const size_t current_max_index = amax_indices[current_dim + max_indices_slice_offset];
@@ -419,6 +440,7 @@ timestep_t launch_hydro_cuda_kernels(const hydro_computer<NDIM, INX, physics<NDI
               }
           }
       }
+      std::cerr << "\nTimestep result for slice id " << slice_id << ": " << max_lambda.a << std::endl;
       return max_lambda;
     });
     return ret_fut.get();

--- a/src/unitiger/hydro_impl/hydro_cuda_interface.cpp
+++ b/src/unitiger/hydro_impl/hydro_cuda_interface.cpp
@@ -251,6 +251,8 @@ timestep_t launch_hydro_cuda_kernels(const hydro_computer<NDIM, INX, physics<NDI
       const int disc_detect_slice_offset = hydro.get_nf();
       const int smooth_slice_offset = hydro.get_nf();
       constexpr int large_x_slice_offset = (H_N3 * NDIM + 128); 
+      //const int q_slice_offset = (nf_ * 27 * H_N3 + 128) 
+      const int f_slice_offset = (hydro.get_nf() *  q_inx3 + 128);
 
       // Convert input
       convert_x_structure(X, combined_x.data() + x_slice_offset * slice_id);
@@ -306,16 +308,16 @@ timestep_t launch_hydro_cuda_kernels(const hydro_computer<NDIM, INX, physics<NDI
       timestep_t ts;
       size_t nf_ = hydro.get_nf();
       double dx = X[0][geo.H_DNX] - X[0][0];
-      constexpr int number_blocks = (q_inx3 / 128 + 1);
+      int number_blocks = (q_inx3 / 128 + 1);
 
       const bool* masks = get_gpu_masks();
       aggregated_device_buffer_t<double, decltype(alloc_device_double)> device_amax(
-          number_blocks * NDIM * (1 + 2 * nf_), device_id, alloc_device_double);
+          number_slices * number_blocks * NDIM * (1 + 2 * nf_), device_id, alloc_device_double);
       aggregated_device_buffer_t<int, decltype(alloc_device_int)>
         device_amax_indices(
-          number_blocks * NDIM, device_id, alloc_device_int);
+          number_slices * number_blocks * NDIM, device_id, alloc_device_int);
       aggregated_device_buffer_t<int, decltype(alloc_device_int)> device_amax_d(
-          number_blocks * NDIM, device_id, alloc_device_int);
+          number_slices * number_blocks * NDIM, device_id, alloc_device_int);
 
       double A_ = physics<NDIM>::A_;
       double B_ = physics<NDIM>::B_;
@@ -324,71 +326,72 @@ timestep_t launch_hydro_cuda_kernels(const hydro_computer<NDIM, INX, physics<NDI
       int nf_local = physics<NDIM>::nf_;
 
       assert(NDIM == 3);
-      dim3 const grid_spec(1, number_blocks, 3);
+      dim3 const grid_spec(number_slices, number_blocks, 3);
       dim3 const threads_per_block(2, 8, 8);
       double omega_local = omega;
 #if defined(OCTOTIGER_HAVE_CUDA)
       void* args[] = {&(device_q.device_side_buffer), &(device_x.device_side_buffer),
           &(device_f.device_side_buffer), &(device_amax.device_side_buffer),
           &(device_amax_indices.device_side_buffer), &(device_amax_d.device_side_buffer), &masks,
-          &omega_local, &dx, &A_, &B_, &nf_local, &fgamma, &de_switch_1};
-      // TODO Wrap in slice executor
+          &omega_local, &dx, &A_, &B_, &nf_local, &fgamma, &de_switch_1, &number_blocks};
       launch_flux_cuda_kernel_post(exec_slice, grid_spec, threads_per_block,
           args);
 #elif defined(OCTOTIGER_HAVE_HIP)
-        // TODO Wrap in slice executor
+      // TODO Probably won't compile..
       launch_flux_hip_kernel_post(exec_slice, grid_spec, threads_per_block,
           device_q.device_side_buffer, device_x.device_side_buffer, device_f.device_side_buffer,
           device_amax.device_side_buffer, device_amax_indices.device_side_buffer,
           device_amax_d.device_side_buffer, masks, omega_local, dx, A_, B_,
           nf_local, fgamma,
-          de_switch_1);
+          de_switch_1, number_blocks);
 #endif
 
       // Move data to host
       aggregated_host_buffer_t<double, decltype(alloc_host_double)> amax(
-          number_blocks * NDIM * (1 + 2 * nf_local), double{}, alloc_host_double);
-      aggregated_host_buffer_t<int, decltype(alloc_host_int)> amax_indices(number_blocks * NDIM, int{}, alloc_host_int);
-      aggregated_host_buffer_t<int, decltype(alloc_host_int)> amax_d(number_blocks * NDIM, int{}, alloc_host_int);
+          number_slices * number_blocks * NDIM * (1 + 2 * nf_local), double{}, alloc_host_double);
+      aggregated_host_buffer_t<int, decltype(alloc_host_int)> amax_indices(
+          number_slices * number_blocks * NDIM, int{}, alloc_host_int);
+      aggregated_host_buffer_t<int, decltype(alloc_host_int)> amax_d(
+          number_slices * number_blocks * NDIM, int{}, alloc_host_int);
 
-        // TODO Wrap in slice executor
-      exec_slice.post(cudaMemcpyAsync,
-          amax.data(), device_amax.device_side_buffer,
-          (number_blocks * NDIM * (1 + 2 * nf_local)) * sizeof(double), cudaMemcpyDeviceToHost);
+      exec_slice.post(cudaMemcpyAsync, amax.data(), device_amax.device_side_buffer,
+          (number_slices * number_blocks * NDIM * (1 + 2 * nf_local)) * sizeof(double), cudaMemcpyDeviceToHost);
       exec_slice.post(cudaMemcpyAsync,
           amax_indices.data(), device_amax_indices.device_side_buffer,
-          number_blocks * NDIM * sizeof(int), cudaMemcpyDeviceToHost);
+          number_slices * number_blocks * NDIM * sizeof(int), cudaMemcpyDeviceToHost);
       exec_slice.post(cudaMemcpyAsync,
-          amax_d.data(), device_amax_d.device_side_buffer, number_blocks * NDIM * sizeof(int),
+          amax_d.data(), device_amax_d.device_side_buffer, number_slices * number_blocks * NDIM * sizeof(int),
           cudaMemcpyDeviceToHost);
       auto flux_kernel_fut = exec_slice.async(cudaMemcpyAsync, f.data(), device_f.device_side_buffer,
-          (NDIM * nf_local * q_inx3 + 128) * sizeof(double), cudaMemcpyDeviceToHost);
+          number_slices * (NDIM * nf_local * q_inx3 + 128) * sizeof(double), cudaMemcpyDeviceToHost);
       flux_kernel_fut.get();
 
       // Find Maximum
+      const int amax_slice_offset = NDIM * (1 + 2 * nf_local) * number_blocks * slice_id;
+      const int max_indices_slice_offset = NDIM * number_blocks * slice_id;
       size_t current_dim = 0;
       for (size_t dim_i = 1; dim_i < number_blocks * NDIM; dim_i++) {
-        if (amax[dim_i] > amax[current_dim]) { 
+        if (amax[dim_i + amax_slice_offset] > amax[current_dim + amax_slice_offset]) { 
           current_dim = dim_i;
-        } else if (amax[dim_i] == amax[current_dim]) {
-          if (amax_indices[dim_i] < amax_indices[current_dim]) {
+        } else if (amax[dim_i + amax_slice_offset] == amax[current_dim + amax_slice_offset]) {
+          if (amax_indices[dim_i + max_indices_slice_offset] < amax_indices[current_dim + max_indices_slice_offset]) {
             current_dim = dim_i;
           }
         }
       }
       std::vector<double> URs(nf_local), ULs(nf_local);
-      const size_t current_max_index = amax_indices[current_dim];
+      const size_t current_max_index = amax_indices[current_dim + max_indices_slice_offset];
       // const size_t current_d = amax_d[current_dim];
-      ts.a = amax[current_dim];
-      ts.x = combined_x[current_max_index];
-      ts.y = combined_x[current_max_index + q_inx3];
-      ts.z = combined_x[current_max_index + 2 * q_inx3];
+      ts.a = amax[current_dim + amax_slice_offset];
+      ts.x = combined_x[current_max_index + x_slice_offset * slice_id];
+      ts.y = combined_x[current_max_index + q_inx3 + x_slice_offset * slice_id];
+      ts.z = combined_x[current_max_index + 2 * q_inx3 + x_slice_offset * slice_id];
       
       const size_t current_i = current_dim;
       current_dim = current_dim / number_blocks;
       for (int f = 0; f < nf_local; f++) {
-          URs[f] = amax[NDIM * number_blocks + current_i * 2 * nf_local + f];
-          ULs[f] = amax[NDIM * number_blocks + current_i * 2 * nf_local + nf_local + f];
+          URs[f] = amax[NDIM * number_blocks + current_i * 2 * nf_local + f + amax_slice_offset];
+          ULs[f] = amax[NDIM * number_blocks + current_i * 2 * nf_local + nf_local + f + amax_slice_offset];
       }
       ts.ul = std::move(URs);
       ts.ur = std::move(ULs);
@@ -409,7 +412,7 @@ timestep_t launch_hydro_cuda_kernels(const hydro_computer<NDIM, INX, physics<NDI
                           const auto i0 = findex(i, j, k);
                           const auto input_index =
                               (i + 1) * q_inx * q_inx + (j + 1) * q_inx + (k + 1);
-                          F[dim][field][i0] = f[dim_offset + input_index];
+                          F[dim][field][i0] = f[dim_offset + input_index + f_slice_offset * slice_id];
                           // std::cout << F[dim][field][i0] << " ";
                       }
                   }

--- a/src/unitiger/hydro_impl/reconstruct_cuda_kernel.cpp
+++ b/src/unitiger/hydro_impl/reconstruct_cuda_kernel.cpp
@@ -109,17 +109,16 @@ void launch_reconstruct_cuda(
     void* args[] = {&omega, &nf_, &angmom_index_, &(smooth_field_), &(disc_detect_), &(combined_q),
         &(combined_x), &(combined_u), &(AM), &dx, &(cdiscs), &n_species_, &ndir, &nangmom};
     if (angmom_index_ > -1) {
-        fut = executor.async(cudaLaunchKernel<decltype(reconstruct_cuda_kernel)>, reconstruct_cuda_kernel,
+        executor.post(cudaLaunchKernel<decltype(reconstruct_cuda_kernel)>, reconstruct_cuda_kernel,
             grid_spec, threads_per_block, args, 0);
     } else {
-        fut = executor.async(cudaLaunchKernel<decltype(reconstruct_cuda_kernel_no_amc)>,
+        executor.post(cudaLaunchKernel<decltype(reconstruct_cuda_kernel_no_amc)>,
             reconstruct_cuda_kernel_no_amc, grid_spec, threads_per_block, args, 0);
     }
 #elif defined(OCTOTIGER_HAVE_HIP)
-		fut = executor.async(reconstruct_hip_kernel_ggl_wrapper, grid_spec, threads_per_block, omega, nf_, angmom_index_, smooth_field_,
+		executor.post(reconstruct_hip_kernel_ggl_wrapper, grid_spec, threads_per_block, omega, nf_, angmom_index_, smooth_field_,
          disc_detect_, combined_q, combined_x, combined_u, AM, dx, cdiscs, n_species_, ndir, nangmom);
 #endif
-    fut.get();
 }
 
 // TODO Launch bounds do not work with larger subgrid size (>8)
@@ -191,13 +190,12 @@ void launch_find_contact_discs_cuda(
     dim3 const threads_per_block_phase2(1, 8, 8);
 #if defined(OCTOTIGER_HAVE_CUDA)
     void* args_phase2[] = {&device_disc, &device_P, &fgamma_, &ndir};
-    auto disc_fut = executor.async(cudaLaunchKernel<decltype(discs_phase2)>, discs_phase2, grid_spec_phase2,
+    executor.post(cudaLaunchKernel<decltype(discs_phase2)>, discs_phase2, grid_spec_phase2,
         threads_per_block_phase2, args_phase2, 0);
 #elif defined(OCTOTIGER_HAVE_HIP)
-    auto disc_fut = executor.post(disc2_hip_kernel_ggl_wrapper, grid_spec_phase2, threads_per_block_phase2,
+    executor.post(disc2_hip_kernel_ggl_wrapper, grid_spec_phase2, threads_per_block_phase2,
         device_disc, device_P, fgamma_, ndir);
 #endif
-    disc_fut.get();
 }
 
 __global__ void __launch_bounds__(64, 4)
@@ -231,13 +229,12 @@ void launch_hydro_pre_recon_cuda(
     dim3 const threads_per_block(1, 8, 8);
 #if defined(OCTOTIGER_HAVE_CUDA)
     void* args[] = {&(device_X), &omega, &angmom, &(device_u), &nf, &n_species_};
-    auto fut = executor.async(cudaLaunchKernel<decltype(hydro_pre_recon_cuda)>, hydro_pre_recon_cuda, grid_spec,
+    executor.post(cudaLaunchKernel<decltype(hydro_pre_recon_cuda)>, hydro_pre_recon_cuda, grid_spec,
         threads_per_block, args, 0);
 #elif defined(OCTOTIGER_HAVE_HIP)
-    auto fut = executor.async(pre_recon_hip_kernel_ggl_wrapper, grid_spec, threads_per_block, device_X, omega,
+    executor.post(pre_recon_hip_kernel_ggl_wrapper, grid_spec, threads_per_block, device_X, omega,
         angmom, device_u, nf, n_species_);
 #endif
-    fut.get();
 }
 
 #endif


### PR DESCRIPTION
The machines in Stuttgart have been updated - the compiler to gcc/9.4 update seems to have broke the KNL and DEV-Node tests due to either dependency caching (KNL) or incompatibility (DEV-NODE)

This PR fixes those Jenkins pipelines!