### PR TITLE
Fix jenkins stuttgart

### DIFF
--- a/.jenkins/stuttgart/Jenkinsfile-DEV-NODE
+++ b/.jenkins/stuttgart/Jenkinsfile-DEV-NODE
@@ -77,6 +77,7 @@ pipeline {
                 // Build with preinstalled gcc on this machine 
                 dir('octotiger') {
                     sh '''
+                    module load gcc/9.2.0
                     module load cuda/11.2.2 
 		    cd OctoTigerBuildChain
 		    sed -i 's/OCTOTIGER_WITH_BLAST_TEST=OFF/OCTOTIGER_WITH_BLAST_TEST=ON/' build-octotiger.sh
@@ -91,6 +92,7 @@ pipeline {
                 // Basic gcc test - only GRIDDIM=8 and hydro-off rotating star tests
                 dir('octotiger') {
                     sh '''
+                    module load gcc/9.2.0
                     module load cuda/11.2.2 
 		    cd OctoTigerBuildChain/build/octotiger/build
 		    ctest --output-on-failure -R cpu

--- a/.jenkins/stuttgart/Jenkinsfile-DEV-NODE
+++ b/.jenkins/stuttgart/Jenkinsfile-DEV-NODE
@@ -77,12 +77,11 @@ pipeline {
                 // Build with preinstalled gcc on this machine 
                 dir('octotiger') {
                     sh '''
-                    module load gcc/9.2.0
                     module load cuda/11.2.2 
 		    cd OctoTigerBuildChain
 		    sed -i 's/OCTOTIGER_WITH_BLAST_TEST=OFF/OCTOTIGER_WITH_BLAST_TEST=ON/' build-octotiger.sh
 		    sed -i 's/OCTOTIGER_WITH_FAST_FP_CONTRACT=OFF/OCTOTIGER_WITH_FAST_FP_CONTRACT=ON/' build-octotiger.sh
-                    ./build-all.sh Release with-CC with-cuda without-mpi without-papi without-apex with-kokkos with-simd without-hpx-backend-multipole without-hpx-backend-monopole with-hpx-cuda-polling
+                    ./build-all.sh Release with-CC with-cuda without-mpi without-papi without-apex with-kokkos without-simd without-hpx-backend-multipole without-hpx-backend-monopole with-hpx-cuda-polling
                     '''
                 }
             }
@@ -92,7 +91,6 @@ pipeline {
                 // Basic gcc test - only GRIDDIM=8 and hydro-off rotating star tests
                 dir('octotiger') {
                     sh '''
-                    module load gcc/9.2.0
                     module load cuda/11.2.2 
 		    cd OctoTigerBuildChain/build/octotiger/build
 		    ctest --output-on-failure -R cpu

--- a/.jenkins/stuttgart/Jenkinsfile-KNL
+++ b/.jenkins/stuttgart/Jenkinsfile-KNL
@@ -56,7 +56,7 @@ pipeline {
                     mkdir -p jenkins && cd jenkins && \
                     mkdir -p octotiger-${JOB_BASE_NAME} && cd octotiger-${JOB_BASE_NAME} && \
                     rm -rf octotiger && \
-                    rm -rf OctoTigerBuildChain/build/octotiger && \
+                    rm -rf OctoTigerBuildChain/build && \
                     rm -rf OctoTigerBuildChain/src/boost && \
                     rm -rf OctoTigerBuildChain/src/octotiger && \
                     rm -rf OctoTigerBuildChain/src/silo && \


### PR DESCRIPTION
The Jenkins machines in Stuttgart have been updated - the compiler to gcc/9.4 update seems to have broke the KNL and DEV-Node tests due to either dependency caching (KNL) or incompatibility (DEV-NODE)

This PR fixes those issues!
