### PR TITLE
fix semaphore: hpx has moved semaphore to hpx namespace

### DIFF
--- a/octotiger/interaction_types.hpp
+++ b/octotiger/interaction_types.hpp
@@ -21,7 +21,7 @@
 
 using multipole_pass_type = std::pair<std::vector<multipole>, std::vector<space_vector>>;
 using expansion_pass_type = std::pair<std::vector<expansion>, std::vector<space_vector>>;
-using semaphore = hpx::lcos::local::counting_semaphore;
+using semaphore = hpx::counting_semaphore_var<>;
 
 struct gravity_boundary_type
 {


### PR DESCRIPTION
This pull request is to accommodate Octotiger to a recent change in HPX master https://github.com/STEllAR-GROUP/hpx/pull/5839

It moves counting_semaphore to hpx namespace.