### PR TITLE
Revert "fix semaphore: hpx has moved semaphore to hpx namespace"

### DIFF
--- a/octotiger/interaction_types.hpp
+++ b/octotiger/interaction_types.hpp
@@ -21,7 +21,7 @@
 
 using multipole_pass_type = std::pair<std::vector<multipole>, std::vector<space_vector>>;
 using expansion_pass_type = std::pair<std::vector<expansion>, std::vector<space_vector>>;
-using semaphore = hpx::counting_semaphore_var<>;
+using semaphore = hpx::lcos::local::counting_semaphore;
 
 struct gravity_boundary_type
 {


### PR DESCRIPTION
This reverts commit 67b5f288c04f1c3e50988941a41ab6d066f8db85 (from PR #417 )

The changes in PR #417 broke all tests, as they made Octo-Tiger incompatible with older HPX versions (notably 1.6 and 1.7.1). Furthermore, the changes are actually no longer necessary as this has been fixed in STEllAR-GROUP/hpx@d026f6d8d3cb19b0e2ddc273fa3668377f0d6ebf. This HPX commit will also be part of 1.8.0, eliminating the need for the semaphore fix (for now).
