### PR TITLE
Fix local communication

### DIFF
--- a/.jenkins/lsu/hip-tests-entry.sh
+++ b/.jenkins/lsu/hip-tests-entry.sh
@@ -10,10 +10,10 @@ set -eux
 
 # Tests with griddim = 8
 # we need the gcc module for the silo fortran compilation...
-srun -p jenkins-amdgpu -N 1 -n 1 -t 02:00:00 bash -lc "module load gcc/12 rocm/5 hwloc && module list && hipcc --version && rocminfo && ./build-all.sh Release with-CC-clang without-cuda without-mpi without-papi without-apex with-kokkos with-simd without-hpx-backend-multipole without-hpx-backend-monopole with-hpx-cuda-polling without-otf2 boost jemalloc hdf5 silo vc hpx kokkos cppuddle octotiger && cd build/octotiger/build && ctest --output-on-failure " 
+srun -p mi100 -N 1 -n 1 -t 04:00:00 bash -lc "module load gcc/12 rocm/5 hwloc && module list && hipcc --version && rocminfo && ./build-all.sh Release with-CC-clang without-cuda without-mpi without-papi without-apex with-kokkos with-simd without-hpx-backend-multipole without-hpx-backend-monopole with-hpx-cuda-polling without-otf2 boost jemalloc hdf5 silo vc hpx kokkos cppuddle octotiger && cd build/octotiger/build && ctest --output-on-failure " 
 
 # Tests with griddim = 16
 sed -i 's/GRIDDIM=8/GRIDDIM=16/' build-octotiger.sh
-srun -p jenkins-amdgpu -N 1 -n 1 -t 02:00:00 bash -lc "module load gcc/12 rocm/5 hwloc && module list && hipcc --version && rocminfo && ./build-all.sh Release with-CC-clang without-cuda without-mpi without-papi without-apex with-kokkos with-simd without-hpx-backend-multipole without-hpx-backend-monopole with-hpx-cuda-polling without-otf2 octotiger && cd build/octotiger/build && ctest --output-on-failure -E legacy " 
+srun -p mi100 -N 1 -n 1 -t 04:00:00 bash -lc "module load gcc/12 rocm/5 hwloc && module list && hipcc --version && rocminfo && ./build-all.sh Release with-CC-clang without-cuda without-mpi without-papi without-apex with-kokkos with-simd without-hpx-backend-multipole without-hpx-backend-monopole with-hpx-cuda-polling without-otf2 octotiger && cd build/octotiger/build && ctest --output-on-failure -E legacy " 
 sed -i 's/GRIDDIM=16/GRIDDIM=8/' build-octotiger.sh
 

--- a/octotiger/node_client.hpp
+++ b/octotiger/node_client.hpp
@@ -46,10 +46,7 @@ private:
     bool local;
 
 public:
-    const std::vector<std::vector<double>> *u_local = nullptr;
-    std::vector<hpx::lcos::local::promise<void>> *hydro_ready_vec = nullptr;
-    std::vector<hpx::lcos::local::promise<void>> *amr_hydro_ready_vec = nullptr;
-    std::vector<hpx::lcos::local::promise<void>> *ready_for_hydro_update = nullptr;
+    std::shared_ptr<node_server> local_access{nullptr};
 
     bool is_local() const;
     template <class Arc>
@@ -111,10 +108,6 @@ public:
         std::size_t cycle) const;
     void send_hydro_boundary(std::vector<real>&&, const geo::direction& dir,
         std::size_t cycle) const;
-    const std::vector<std::vector<safe_real>>* recv_hydro_boundary_local() const;
-    std::vector<hpx::lcos::local::promise<void>>* recv_hydro_boundary_promises_local() const;
-    std::vector<hpx::lcos::local::promise<void>>* recv_amr_hydro_boundary_promises_local() const;
-    std::vector<hpx::lcos::local::promise<void>>* recv_hydro_update_ready_promises_local() const;
     void send_hydro_amr_boundary(std::vector<real>&&, const geo::direction& dir,
         std::size_t cycle) const;
     void send_rad_amr_boundary(std::vector<real>&&, const geo::direction& dir,

--- a/octotiger/node_client.hpp
+++ b/octotiger/node_client.hpp
@@ -46,8 +46,6 @@ private:
     bool local;
 
 public:
-    std::shared_ptr<node_server> local_access{nullptr};
-
     bool is_local() const;
     template <class Arc>
     void load(Arc& arc, unsigned)

--- a/octotiger/node_server.hpp
+++ b/octotiger/node_server.hpp
@@ -203,21 +203,6 @@ public:
 	void recv_hydro_boundary(std::vector<real>&&, const geo::direction&, std::size_t cycle);
 	/**/HPX_DEFINE_COMPONENT_DIRECT_ACTION(node_server, recv_hydro_boundary, send_hydro_boundary_action);
 
-	const std::vector<std::vector<safe_real>>* send_hydro_boundary_local();
-	/**/HPX_DEFINE_COMPONENT_DIRECT_ACTION(node_server, send_hydro_boundary_local, send_hydro_boundary_action_local);
-
-	std::vector<hpx::lcos::local::promise<void>>* send_hydro_boundary_promises_local();
-	/**/HPX_DEFINE_COMPONENT_DIRECT_ACTION(node_server, send_hydro_boundary_promises_local,
-      send_hydro_boundary_promises_action_local);
-
-	std::vector<hpx::lcos::local::promise<void>>* send_amr_hydro_boundary_promises_local();
-	/**/HPX_DEFINE_COMPONENT_DIRECT_ACTION(node_server, send_amr_hydro_boundary_promises_local,
-      send_amr_hydro_boundary_promises_action_local);
-	std::vector<hpx::lcos::local::promise<void>>* send_hydro_update_ready_promises_local();
-	/**/HPX_DEFINE_COMPONENT_DIRECT_ACTION(node_server, send_hydro_update_ready_promises_local,
-      send_hydro_update_ready_promises_action_local);
-
-
 	void recv_hydro_amr_boundary(std::vector<real>&&, const geo::direction&, std::size_t cycle);
 	/**/HPX_DEFINE_COMPONENT_DIRECT_ACTION(node_server, recv_hydro_amr_boundary, send_hydro_amr_boundary_action);
 
@@ -386,10 +371,6 @@ HPX_REGISTER_ACTION_DECLARATION(node_server::regrid_gather_action);
 HPX_REGISTER_ACTION_DECLARATION(node_server::regrid_scatter_action);
 HPX_REGISTER_ACTION_DECLARATION(node_server::send_flux_check_action);
 HPX_REGISTER_ACTION_DECLARATION(node_server::send_hydro_boundary_action);
-HPX_REGISTER_ACTION_DECLARATION(node_server::send_hydro_boundary_action_local);
-HPX_REGISTER_ACTION_DECLARATION(node_server::send_hydro_boundary_promises_action_local);
-HPX_REGISTER_ACTION_DECLARATION(node_server::send_amr_hydro_boundary_promises_action_local);
-HPX_REGISTER_ACTION_DECLARATION(node_server::send_hydro_update_ready_promises_action_local);
 HPX_REGISTER_ACTION_DECLARATION(node_server::send_hydro_amr_boundary_action);
 HPX_REGISTER_ACTION_DECLARATION(node_server::send_rad_amr_boundary_action);
 HPX_REGISTER_ACTION_DECLARATION(node_server::send_gravity_boundary_action);

--- a/src/node_client.cpp
+++ b/src/node_client.cpp
@@ -30,10 +30,6 @@ node_client& node_client::operator=(hpx::future<hpx::id_type>&& fut) {
 	if( !empty() ) {
         unmanaged = hpx::id_type(id.get_gid(), hpx::id_type::management_type::unmanaged);
         local = hpx::naming::get_locality_from_id(id) == hpx::find_here();
-        if (local) {
-          hpx::future<std::shared_ptr<node_server>> pf = hpx::get_ptr<node_server>(id);
-          local_access = pf.get();
-        }
 
 // 		local = bool(hpx::get_colocation_id(id).get() == hpx::find_here());
 	}
@@ -45,11 +41,6 @@ node_client& node_client::operator=(const hpx::id_type& _id) {
 	if (!empty()) {
         unmanaged = hpx::id_type(id.get_gid(), hpx::id_type::management_type::unmanaged);
         local = hpx::naming::get_locality_from_id(id) == hpx::find_here();
-        if (local) {
-          hpx::future<std::shared_ptr<node_server>> pf = hpx::get_ptr<node_server>(id);
-          local_access = pf.get();
-
-        }
 // 		local = bool(hpx::get_colocation_id(id).get() == hpx::find_here());
 	}
 	return *this;
@@ -60,10 +51,6 @@ node_client::node_client(hpx::future<hpx::id_type>&& fut) {
 	if( !empty() ) {
         unmanaged = hpx::id_type(id.get_gid(), hpx::id_type::management_type::unmanaged);
         local = hpx::naming::get_locality_from_id(id) == hpx::find_here();
-        if (local) {
-          hpx::future<std::shared_ptr<node_server>> pf = hpx::get_ptr<node_server>(id);
-          local_access = pf.get();
-        }
     }
 }
 
@@ -72,10 +59,6 @@ node_client::node_client(const hpx::id_type& _id) {
 	if (!empty()) {
         unmanaged = hpx::id_type(id.get_gid(), hpx::id_type::management_type::unmanaged);
         local = hpx::naming::get_locality_from_id(id) == hpx::find_here();
-        if (local) {
-          hpx::future<std::shared_ptr<node_server>> pf = hpx::get_ptr<node_server>(id);
-          local_access = pf.get();
-        }
 	}
 }
 

--- a/src/node_client.cpp
+++ b/src/node_client.cpp
@@ -31,16 +31,8 @@ node_client& node_client::operator=(hpx::future<hpx::id_type>&& fut) {
         unmanaged = hpx::id_type(id.get_gid(), hpx::id_type::management_type::unmanaged);
         local = hpx::naming::get_locality_from_id(id) == hpx::find_here();
         if (local) {
-          node_server::send_hydro_boundary_action_local action_instance;
-          u_local = action_instance(get_unmanaged_gid());
-          node_server::send_hydro_boundary_promises_action_local action_instance_promises;
-          hydro_ready_vec = action_instance_promises(get_unmanaged_gid());
-          node_server::send_amr_hydro_boundary_promises_action_local action_instance_amr_promises;
-          amr_hydro_ready_vec = action_instance_amr_promises(get_unmanaged_gid());
-          if (!opts().gravity) {
-            node_server::send_hydro_update_ready_promises_action_local action_instance_hydro_ready_promises;
-            ready_for_hydro_update = action_instance_hydro_ready_promises(get_unmanaged_gid());
-          }
+          hpx::future<std::shared_ptr<node_server>> pf = hpx::get_ptr<node_server>(id);
+          local_access = pf.get();
         }
 
 // 		local = bool(hpx::get_colocation_id(id).get() == hpx::find_here());
@@ -54,16 +46,9 @@ node_client& node_client::operator=(const hpx::id_type& _id) {
         unmanaged = hpx::id_type(id.get_gid(), hpx::id_type::management_type::unmanaged);
         local = hpx::naming::get_locality_from_id(id) == hpx::find_here();
         if (local) {
-          node_server::send_hydro_boundary_action_local action_instance;
-          u_local = action_instance(get_unmanaged_gid());
-          node_server::send_hydro_boundary_promises_action_local action_instance_promises;
-          hydro_ready_vec = action_instance_promises(get_unmanaged_gid());
-          node_server::send_amr_hydro_boundary_promises_action_local action_instance_amr_promises;
-          amr_hydro_ready_vec = action_instance_amr_promises(get_unmanaged_gid());
-          if (!opts().gravity) {
-            node_server::send_hydro_update_ready_promises_action_local action_instance_hydro_ready_promises;
-            ready_for_hydro_update = action_instance_hydro_ready_promises(get_unmanaged_gid());
-          }
+          hpx::future<std::shared_ptr<node_server>> pf = hpx::get_ptr<node_server>(id);
+          local_access = pf.get();
+
         }
 // 		local = bool(hpx::get_colocation_id(id).get() == hpx::find_here());
 	}
@@ -76,19 +61,10 @@ node_client::node_client(hpx::future<hpx::id_type>&& fut) {
         unmanaged = hpx::id_type(id.get_gid(), hpx::id_type::management_type::unmanaged);
         local = hpx::naming::get_locality_from_id(id) == hpx::find_here();
         if (local) {
-          node_server::send_hydro_boundary_action_local action_instance;
-          u_local = action_instance(get_unmanaged_gid());
-          node_server::send_hydro_boundary_promises_action_local action_instance_promises;
-          hydro_ready_vec = action_instance_promises(get_unmanaged_gid());
-          node_server::send_amr_hydro_boundary_promises_action_local action_instance_amr_promises;
-          amr_hydro_ready_vec = action_instance_amr_promises(get_unmanaged_gid());
-          if (!opts().gravity) {
-            node_server::send_hydro_update_ready_promises_action_local action_instance_hydro_ready_promises;
-            ready_for_hydro_update = action_instance_hydro_ready_promises(get_unmanaged_gid());
-          }
+          hpx::future<std::shared_ptr<node_server>> pf = hpx::get_ptr<node_server>(id);
+          local_access = pf.get();
         }
-// 		local = bool(hpx::get_colocation_id(id).get() == hpx::find_here());
-	}
+    }
 }
 
 node_client::node_client(const hpx::id_type& _id) {
@@ -97,16 +73,8 @@ node_client::node_client(const hpx::id_type& _id) {
         unmanaged = hpx::id_type(id.get_gid(), hpx::id_type::management_type::unmanaged);
         local = hpx::naming::get_locality_from_id(id) == hpx::find_here();
         if (local) {
-          node_server::send_hydro_boundary_action_local action_instance;
-          u_local = action_instance(get_unmanaged_gid());
-          node_server::send_hydro_boundary_promises_action_local action_instance_promises;
-          hydro_ready_vec = action_instance_promises(get_unmanaged_gid());
-          node_server::send_amr_hydro_boundary_promises_action_local action_instance_amr_promises;
-          amr_hydro_ready_vec = action_instance_amr_promises(get_unmanaged_gid());
-          if (!opts().gravity) {
-            node_server::send_hydro_update_ready_promises_action_local action_instance_hydro_ready_promises;
-            ready_for_hydro_update = action_instance_hydro_ready_promises(get_unmanaged_gid());
-          }
+          hpx::future<std::shared_ptr<node_server>> pf = hpx::get_ptr<node_server>(id);
+          local_access = pf.get();
         }
 	}
 }

--- a/src/node_server_actions_1.cpp
+++ b/src/node_server_actions_1.cpp
@@ -222,20 +222,22 @@ void node_server::regrid_scatter(integer a_, integer total) {
 		}
 	}
 	clear_family();
-  // Renew promises
-  ready_for_hydro_exchange.clear();
-  for (int i = 0; i < number_hydro_exchange_promises; i++)
-    ready_for_hydro_exchange.emplace_back();
-  ready_for_amr_hydro_exchange.clear();
-  for (int i = 0; i < number_hydro_exchange_promises; i++)
-    ready_for_amr_hydro_exchange.emplace_back();
-  if (!opts().gravity) {
-    ready_for_hydro_update.clear();
+  if (opts().optimize_local_communication) {
+    // Renew promises
+    ready_for_hydro_exchange.clear();
     for (int i = 0; i < number_hydro_exchange_promises; i++)
-      ready_for_hydro_update.emplace_back();
-    all_neighbors_got_hydro.clear();
+      ready_for_hydro_exchange.emplace_back();
+    ready_for_amr_hydro_exchange.clear();
     for (int i = 0; i < number_hydro_exchange_promises; i++)
-      all_neighbors_got_hydro.emplace_back(hpx::make_ready_future());
+      ready_for_amr_hydro_exchange.emplace_back();
+    if (!opts().gravity) {
+      ready_for_hydro_update.clear();
+      for (int i = 0; i < number_hydro_exchange_promises; i++)
+        ready_for_hydro_update.emplace_back();
+      all_neighbors_got_hydro.clear();
+      for (int i = 0; i < number_hydro_exchange_promises; i++)
+        all_neighbors_got_hydro.emplace_back(hpx::make_ready_future());
+    }
   }
 }
 

--- a/src/node_server_actions_2.cpp
+++ b/src/node_server_actions_2.cpp
@@ -455,9 +455,6 @@ int node_server::form_tree(hpx::id_type self_gid, hpx::id_type parent_gid, std::
 	int amr_bnd = 0;
 
 	std::fill(nieces.begin(), nieces.end(), 0);
-  auto number_neighbors = neighbors.size();
-	neighbors.clear();
-  neighbors.resize(number_neighbors);
 	for (auto dir : geo::direction::full_set()) {
 		neighbors[dir] = std::move(neighbor_gids[dir]);
 	}

--- a/src/node_server_actions_2.cpp
+++ b/src/node_server_actions_2.cpp
@@ -455,6 +455,9 @@ int node_server::form_tree(hpx::id_type self_gid, hpx::id_type parent_gid, std::
 	int amr_bnd = 0;
 
 	std::fill(nieces.begin(), nieces.end(), 0);
+  auto number_neighbors = neighbors.size();
+	neighbors.clear();
+  neighbors.resize(number_neighbors);
 	for (auto dir : geo::direction::full_set()) {
 		neighbors[dir] = std::move(neighbor_gids[dir]);
 	}

--- a/src/node_server_actions_3.cpp
+++ b/src/node_server_actions_3.cpp
@@ -600,7 +600,7 @@ future<void> node_server::nonrefined_step() {
 					if (rk == 0) {
 						dt_ = GET(dt_fut);
 					}
-          if (!opts().gravity) {
+          if (!opts().gravity && opts().optimize_local_communication) {
             all_neighbors_got_hydro[(hcycle-1)%number_hydro_exchange_promises].get();
           }
 					grid_ptr->next_u(rk, current_time, dt_.dt);

--- a/src/node_server_actions_3.cpp
+++ b/src/node_server_actions_3.cpp
@@ -76,57 +76,6 @@ void node_server::recv_hydro_boundary(std::vector<real> &&bdata, const geo::dire
 	sibling_hydro_channels[dir].set_value(std::move(tmp), cycle);
 }
 
-using send_hydro_boundary_action_local_type = node_server::send_hydro_boundary_action_local;
-HPX_REGISTER_ACTION (send_hydro_boundary_action_local_type);
-
-const std::vector<std::vector<safe_real>>* node_client::recv_hydro_boundary_local() const {
-  node_server::send_hydro_boundary_action_local action_instance;
-	const std::vector<std::vector<safe_real>>* u_p = action_instance(get_unmanaged_gid());
-  return u_p;
-}
-
-const std::vector<std::vector<safe_real>>* node_server::send_hydro_boundary_local() {
-  return &(grid_ptr->U);
-}
-
-using send_hydro_boundary_promises_action_local_type = node_server::send_hydro_boundary_promises_action_local;
-HPX_REGISTER_ACTION (send_hydro_boundary_promises_action_local_type);
-
-std::vector<hpx::lcos::local::promise<void>>* node_client::recv_hydro_boundary_promises_local() const {
-  node_server::send_hydro_boundary_promises_action_local action_instance;
-	std::vector<hpx::lcos::local::promise<void>>* vec = action_instance(get_unmanaged_gid());
-  return vec;
-}
-
-std::vector<hpx::lcos::local::promise<void>>* node_server::send_hydro_boundary_promises_local() {
-  return &(ready_for_hydro_exchange);
-}
-
-using send_amr_hydro_boundary_promises_action_local_type = node_server::send_amr_hydro_boundary_promises_action_local;
-HPX_REGISTER_ACTION (send_amr_hydro_boundary_promises_action_local_type);
-
-std::vector<hpx::lcos::local::promise<void>>* node_client::recv_amr_hydro_boundary_promises_local() const {
-  node_server::send_amr_hydro_boundary_promises_action_local action_instance;
-	std::vector<hpx::lcos::local::promise<void>>* vec = action_instance(get_unmanaged_gid());
-  return vec;
-}
-
-std::vector<hpx::lcos::local::promise<void>>* node_server::send_amr_hydro_boundary_promises_local() {
-  return &(ready_for_amr_hydro_exchange);
-}
-
-using send_hydro_update_ready_promises_action_local_type = node_server::send_hydro_update_ready_promises_action_local;
-HPX_REGISTER_ACTION (send_hydro_update_ready_promises_action_local_type);
-
-std::vector<hpx::lcos::local::promise<void>>* node_client::recv_hydro_update_ready_promises_local() const {
-  node_server::send_hydro_update_ready_promises_action_local action_instance;
-	std::vector<hpx::lcos::local::promise<void>>* vec = action_instance(get_unmanaged_gid());
-  return vec;
-}
-
-std::vector<hpx::lcos::local::promise<void>>* node_server::send_hydro_update_ready_promises_local() {
-  return &(ready_for_hydro_update);
-}
 
 using send_hydro_amr_boundary_action_type = node_server::send_hydro_amr_boundary_action;
 HPX_REGISTER_ACTION (send_hydro_amr_boundary_action_type);


### PR DESCRIPTION
This PR removes the pointer exchange between neighboring sub-grids for the hydro solver! Originally, these were added in #426 to optimize the communication when sub-grids were located on the same locality.

Instead of the raw pointer, hpx::get_ptr is now used to access this data! 

The PR also contains two fixes for this optimization when running the DWD scenario: Here we allocated one promise too little (resulting in trying to set the same promise twice). Further, it could happen that the AMR communication went awry due to a missing check whether the parent is on the same locality. This PR resolves both issues!