### PR TITLE
Fix jenkins pipelines

### DIFF
--- a/.jenkins-performance-tests/lsu/Jenkinsfile-Aggregation-Test-Hip
+++ b/.jenkins-performance-tests/lsu/Jenkinsfile-Aggregation-Test-Hip
@@ -68,6 +68,7 @@ pipeline {
                 cd "octo-buildscripts-aggregation-test-HIP"
                 sbatch --wait src/octotiger/.jenkins-performance-tests/lsu/hip-aggregation-test.sbatch
                 cat aggregation_test_hip.out
+                cat performance_results.log
                 '''
             }
         }
@@ -84,11 +85,15 @@ pipeline {
         failure {
             sh '''
             echo "HIP Aggregation Performance Test failed! Pipeline ${JOB_BASE_NAME} with build ID ${BUILD_NUMBER} using GIT commit ${GIT_COMMIT}" | mail -s "Jenkins Octo-Tiger HIP Aggregation Performance Tests: Build ${JOB_BASE_NAME}/${BUILD_NUMBER} failed" "${MAINTAINER_MAIL}"
+            cat aggregation_test_hip.out
+            cat performance_results.log
             '''
         }
         aborted {
             sh '''
             echo "HIP Aggregation Performance Test aborted on pipeline ${JOB_BASE_NAME} with build ID ${BUILD_NUMBER} using GIT commit ${GIT_COMMIT}" | mail -s "Jenkins Octo-Tiger HIP Tests: Build ${JOB_BASE_NAME}/${BUILD_NUMBER} aborted" "${MAINTAINER_MAIL}"
+            cat aggregation_test_hip.out
+            cat performance_results.log
             '''
         }
     }

--- a/.jenkins-performance-tests/lsu/cuda-aggregation-test.sbatch
+++ b/.jenkins-performance-tests/lsu/cuda-aggregation-test.sbatch
@@ -9,7 +9,7 @@
 #SBATCH -o aggregation_test_cuda.out
 
 module load llvm/12.0.1 cuda hwloc
+./build-all.sh Release with-CC-clang with-cuda without-mpi without-papi without-apex with-kokkos with-simd without-hpx-backend-multipole without-hpx-backend-monopole with-hpx-cuda-polling without-otf2 boost jemalloc hdf5 silo vc hpx kokkos cppuddle octotiger 
+./src/octotiger/octotiger-performance-tests/rostam/aggregation-test/blast_aggregation_performance_cuda.sh 
 pip3 install --upgrade matplotlib pandas 
-srun ./build-all.sh Release with-CC-clang with-cuda without-mpi without-papi without-apex with-kokkos with-simd without-hpx-backend-multipole without-hpx-backend-monopole with-hpx-cuda-polling without-otf2 boost jemalloc hdf5 silo vc hpx kokkos cppuddle octotiger 
-srun ./src/octotiger/octotiger-performance-tests/rostam/aggregation-test/blast_aggregation_performance_cuda.sh 
 python3 ./src/octotiger/octotiger-performance-tests/rostam/aggregation-test/plot_blast_aggregation_performance.py --filename=performance_results.log --gpu-name='NVIDIA A100' | tee plot.log

--- a/.jenkins-performance-tests/lsu/hip-aggregation-test.sbatch
+++ b/.jenkins-performance-tests/lsu/hip-aggregation-test.sbatch
@@ -4,7 +4,7 @@
 #SBATCH --nodes=1
 #SBATCH --ntasks=1
 #SBATCH --partition=mi100
-#SBATCH --nodelist=kamand1
+#SBATCH --nodelist=kamand0
 #SBATCH -e aggregation_test_hip.out
 #SBATCH -o aggregation_test_hip.out
 

--- a/.jenkins-performance-tests/lsu/hip-aggregation-test.sbatch
+++ b/.jenkins-performance-tests/lsu/hip-aggregation-test.sbatch
@@ -8,7 +8,7 @@
 #SBATCH -e aggregation_test_hip.out
 #SBATCH -o aggregation_test_hip.out
 
-module load gcc/9.4.0 rocm/4.3.1 hwloc
+module load gcc/12 rocm/5 hwloc
 pip3 install --upgrade matplotlib pandas
 srun ./build-all.sh Release with-CC-clang without-cuda without-mpi without-papi without-apex without-kokkos with-simd without-hpx-backend-multipole without-hpx-backend-monopole with-hpx-cuda-polling without-otf2 boost jemalloc hdf5 silo vc hpx kokkos cppuddle octotiger 
 srun ./src/octotiger/octotiger-performance-tests/rostam/aggregation-test/blast_aggregation_performance_hip.sh 

--- a/.jenkins-performance-tests/lsu/hip-aggregation-test.sbatch
+++ b/.jenkins-performance-tests/lsu/hip-aggregation-test.sbatch
@@ -1,6 +1,6 @@
 #!/bin/bash -l
 #SBATCH --job-name="Octo-Tiger Aggregation Performance Test HIP"
-#SBATCH --time=24:00:00
+#SBATCH --time=12:00:00
 #SBATCH --nodes=1
 #SBATCH --ntasks=1
 #SBATCH --partition=mi100
@@ -8,8 +8,16 @@
 #SBATCH -e aggregation_test_hip.out
 #SBATCH -o aggregation_test_hip.out
 
-module load gcc/12 rocm/5 hwloc
-pip3 install --upgrade matplotlib pandas
+echo "Aggregation Test running on $(hostname):"
+echo "Loading modules..."
+module load llvm/14 rocm/5 hwloc cmake
+module list
+echo "Building Octo-Tiger and toolchain..."
+echo ""
 srun ./build-all.sh Release with-CC-clang without-cuda without-mpi without-papi without-apex without-kokkos with-simd without-hpx-backend-multipole without-hpx-backend-monopole with-hpx-cuda-polling without-otf2 boost jemalloc hdf5 silo vc hpx kokkos cppuddle octotiger 
+echo "Running aggregation performance test..."
 srun ./src/octotiger/octotiger-performance-tests/rostam/aggregation-test/blast_aggregation_performance_hip.sh 
+echo "Upgrading required python modules..."
+pip3 install --upgrade matplotlib pandas
+echo "Creating plots..."
 python3 ./src/octotiger/octotiger-performance-tests/rostam/aggregation-test/plot_blast_aggregation_performance.py --filename=performance_results.log --gpu-name='AMD MI100' | tee plot.log

--- a/.jenkins-performance-tests/lsu/hip-aggregation-test.sbatch
+++ b/.jenkins-performance-tests/lsu/hip-aggregation-test.sbatch
@@ -18,6 +18,6 @@ srun ./build-all.sh Release with-CC-clang without-cuda without-mpi without-papi 
 echo "Running aggregation performance test..."
 srun ./src/octotiger/octotiger-performance-tests/rostam/aggregation-test/blast_aggregation_performance_hip.sh 
 echo "Upgrading required python modules..."
-pip3 install --upgrade matplotlib pandas
+pip3 install --upgrade matplotlib pandas numpy
 echo "Creating plots..."
 python3 ./src/octotiger/octotiger-performance-tests/rostam/aggregation-test/plot_blast_aggregation_performance.py --filename=performance_results.log --gpu-name='AMD MI100' | tee plot.log

--- a/.jenkins-performance-tests/lsu/hip-aggregation-test.sbatch
+++ b/.jenkins-performance-tests/lsu/hip-aggregation-test.sbatch
@@ -14,9 +14,9 @@ module load llvm/14 rocm/5 hwloc cmake
 module list
 echo "Building Octo-Tiger and toolchain..."
 echo ""
-srun ./build-all.sh Release with-CC-clang without-cuda without-mpi without-papi without-apex without-kokkos with-simd without-hpx-backend-multipole without-hpx-backend-monopole with-hpx-cuda-polling without-otf2 boost jemalloc hdf5 silo vc hpx kokkos cppuddle octotiger 
+./build-all.sh Release with-CC-clang without-cuda without-mpi without-papi without-apex without-kokkos with-simd without-hpx-backend-multipole without-hpx-backend-monopole with-hpx-cuda-polling without-otf2 boost jemalloc hdf5 silo vc hpx kokkos cppuddle octotiger 
 echo "Running aggregation performance test..."
-srun ./src/octotiger/octotiger-performance-tests/rostam/aggregation-test/blast_aggregation_performance_hip.sh 
+./src/octotiger/octotiger-performance-tests/rostam/aggregation-test/blast_aggregation_performance_hip.sh 
 echo "Upgrading required python modules..."
 pip3 install --upgrade matplotlib pandas numpy
 echo "Creating plots..."

--- a/.jenkins/lsu/Jenkinsfile-std-simd
+++ b/.jenkins/lsu/Jenkinsfile-std-simd
@@ -112,7 +112,7 @@ pipeline {
                 dir('octotiger') {
                     sh '''#!/bin/bash -l
                         cd "../octo-buildscripts-std-simd"
-                        srun -p medusa -N 1 -n 1 bash -c 'module load gcc/11 && cd build/octotiger/build && ctest'
+                        srun -p medusa -N 1 -n 1 bash -lc 'module load gcc/11 && cd build/octotiger/build && ctest'
                     '''
                 }
             }

--- a/.jenkins/lsu/Jenkinsfile-std-simd
+++ b/.jenkins/lsu/Jenkinsfile-std-simd
@@ -93,7 +93,7 @@ pipeline {
                         rm -f build-log.txt
                         sed -i 's/OCTOTIGER_WITH_STD_EXPERIMENTAL_SIMD=OFF/OCTOTIGER_WITH_STD_EXPERIMENTAL_SIMD=ON/' build-octotiger.sh
 		        
-	    	        srun -p medusa -N 1 -n 1 bash -c 'module load gcc/11 && ./build-all.sh RelWithDebInfo with-CC without-cuda without-mpi without-papi without-apex with-kokkos with-simd without-hpx-backend-multipole without-hpx-backend-monopole without-hpx-cuda-polling without-otf2 cmake jemalloc boost hdf5 silo vc hpx kokkos cppuddle octotiger |& tee build-log.txt'
+	    	        srun -p medusa -N 1 -n 1 bash -lc 'module load gcc/11 && ./build-all.sh RelWithDebInfo with-CC without-cuda without-mpi without-papi without-apex with-kokkos with-simd without-hpx-backend-multipole without-hpx-backend-monopole without-hpx-cuda-polling without-otf2 cmake jemalloc boost hdf5 silo vc hpx kokkos cppuddle octotiger |& tee build-log.txt'
 	   	        if grep "Using std-experimental-simd SIMD types" build-log.txt
 		        then
 		            echo "Found std-experimental build log output! All good!"

--- a/.jenkins/lsu/hip-tests-entry.sh
+++ b/.jenkins/lsu/hip-tests-entry.sh
@@ -10,10 +10,10 @@ set -eux
 
 # Tests with griddim = 8
 # we need the gcc module for the silo fortran compilation...
-srun -p jenkins-amdgpu -N 1 -n 1 -t 02:00:00 bash -c "module load gcc/12 rocm/5 hwloc && module list && hipcc --version && rocminfo && ./build-all.sh Release with-CC-clang without-cuda without-mpi without-papi without-apex with-kokkos with-simd without-hpx-backend-multipole without-hpx-backend-monopole with-hpx-cuda-polling without-otf2 boost jemalloc hdf5 silo vc hpx kokkos cppuddle octotiger && cd build/octotiger/build && ctest --output-on-failure " 
+srun -p jenkins-amdgpu -N 1 -n 1 -t 02:00:00 bash -lc "module load gcc/12 rocm/5 hwloc && module list && hipcc --version && rocminfo && ./build-all.sh Release with-CC-clang without-cuda without-mpi without-papi without-apex with-kokkos with-simd without-hpx-backend-multipole without-hpx-backend-monopole with-hpx-cuda-polling without-otf2 boost jemalloc hdf5 silo vc hpx kokkos cppuddle octotiger && cd build/octotiger/build && ctest --output-on-failure " 
 
 # Tests with griddim = 16
 sed -i 's/GRIDDIM=8/GRIDDIM=16/' build-octotiger.sh
-srun -p jenkins-amdgpu -N 1 -n 1 -t 02:00:00 bash -c "module load gcc/12 rocm/5 hwloc && module list && hipcc --version && rocminfo && ./build-all.sh Release with-CC-clang without-cuda without-mpi without-papi without-apex with-kokkos with-simd without-hpx-backend-multipole without-hpx-backend-monopole with-hpx-cuda-polling without-otf2 octotiger && cd build/octotiger/build && ctest --output-on-failure -E legacy " 
+srun -p jenkins-amdgpu -N 1 -n 1 -t 02:00:00 bash -lc "module load gcc/12 rocm/5 hwloc && module list && hipcc --version && rocminfo && ./build-all.sh Release with-CC-clang without-cuda without-mpi without-papi without-apex with-kokkos with-simd without-hpx-backend-multipole without-hpx-backend-monopole with-hpx-cuda-polling without-otf2 octotiger && cd build/octotiger/build && ctest --output-on-failure -E legacy " 
 sed -i 's/GRIDDIM=16/GRIDDIM=8/' build-octotiger.sh
 

--- a/.jenkins/lsu/node-level-tests-entry.sh
+++ b/.jenkins/lsu/node-level-tests-entry.sh
@@ -20,13 +20,13 @@ fi
 
 # Tests with griddim = 8
 echo "Running tests with griddim=8"
-srun --partition=jenkins-cuda --nodelist=geev -N 1 -n 1 -t 08:00:00 bash -lc "module load ${compiler_module} cuda/11.5 hwloc && module list && ./build-all.sh Release ${compiler_config} ${cuda_config} without-mpi without-papi without-apex ${kokkos_config} ${simd_config} with-hpx-backend-multipole without-hpx-backend-monopole with-hpx-cuda-polling without-otf2 boost jemalloc hdf5 silo vc hpx kokkos cppuddle octotiger && cd build/octotiger/build && ctest --output-on-failure " 
+srun --partition=jenkins-cuda -N 1 -n 1 -t 08:00:00 bash -lc "module load ${compiler_module} cuda/11.5 hwloc && module list && ./build-all.sh Release ${compiler_config} ${cuda_config} without-mpi without-papi without-apex ${kokkos_config} ${simd_config} with-hpx-backend-multipole without-hpx-backend-monopole with-hpx-cuda-polling without-otf2 boost jemalloc hdf5 silo vc hpx kokkos cppuddle octotiger && cd build/octotiger/build && ctest --output-on-failure " 
 
 # Tests with griddim = 16 - only test in full kokkos + cuda build
 if [ "${cuda_config}" = "with-cuda" ] && [ "${kokkos_config}" = "with-kokkos" ]; then
 	sed -i 's/GRIDDIM=8/GRIDDIM=16/' build-octotiger.sh
 	rm -rf build # in case we end up on a different cuda node we need to rebuild with its architecture
-	srun --partition=jenkins-cuda --nodelist=geev -N 1 -n 1 -t 08:00:00 bash -lc "module load ${compiler_module} cuda/11.5 hwloc && module list && ./build-all.sh Release ${compiler_config} ${cuda_config} without-mpi without-papi without-apex ${kokkos_config} ${simd_config} with-hpx-backend-multipole without-hpx-backend-monopole with-hpx-cuda-polling without-otf2 boost jemalloc hdf5 silo vc hpx kokkos cppuddle octotiger && cd build/octotiger/build && ctest --output-on-failure " 
+	srun --partition=jenkins-cuda -N 1 -n 1 -t 08:00:00 bash -lc "module load ${compiler_module} cuda/11.5 hwloc && module list && ./build-all.sh Release ${compiler_config} ${cuda_config} without-mpi without-papi without-apex ${kokkos_config} ${simd_config} with-hpx-backend-multipole without-hpx-backend-monopole with-hpx-cuda-polling without-otf2 boost jemalloc hdf5 silo vc hpx kokkos cppuddle octotiger && cd build/octotiger/build && ctest --output-on-failure " 
 	sed -i 's/GRIDDIM=16/GRIDDIM=8/' build-octotiger.sh
 fi
 

--- a/.jenkins/lsu/node-level-tests-entry.sh
+++ b/.jenkins/lsu/node-level-tests-entry.sh
@@ -20,13 +20,13 @@ fi
 
 # Tests with griddim = 8
 echo "Running tests with griddim=8"
-srun --partition=jenkins-cuda -N 1 -n 1 -t 08:00:00 bash -lc "module load ${compiler_module} cuda/11.5 hwloc && module list && ./build-all.sh Release ${compiler_config} ${cuda_config} without-mpi without-papi without-apex ${kokkos_config} ${simd_config} with-hpx-backend-multipole without-hpx-backend-monopole with-hpx-cuda-polling without-otf2 boost jemalloc hdf5 silo vc hpx kokkos cppuddle octotiger && cd build/octotiger/build && ctest --output-on-failure " 
+srun --partition=geev -N 1 -n 1 -t 08:00:00 bash -lc "module load ${compiler_module} cuda/11.5 hwloc && module list && ./build-all.sh Release ${compiler_config} ${cuda_config} without-mpi without-papi without-apex ${kokkos_config} ${simd_config} with-hpx-backend-multipole without-hpx-backend-monopole with-hpx-cuda-polling without-otf2 boost jemalloc hdf5 silo vc hpx kokkos cppuddle octotiger && cd build/octotiger/build && ctest --output-on-failure " 
 
 # Tests with griddim = 16 - only test in full kokkos + cuda build
 if [ "${cuda_config}" = "with-cuda" ] && [ "${kokkos_config}" = "with-kokkos" ]; then
 	sed -i 's/GRIDDIM=8/GRIDDIM=16/' build-octotiger.sh
 	rm -rf build # in case we end up on a different cuda node we need to rebuild with its architecture
-	srun --partition=jenkins-cuda -N 1 -n 1 -t 08:00:00 bash -lc "module load ${compiler_module} cuda/11.5 hwloc && module list && ./build-all.sh Release ${compiler_config} ${cuda_config} without-mpi without-papi without-apex ${kokkos_config} ${simd_config} with-hpx-backend-multipole without-hpx-backend-monopole with-hpx-cuda-polling without-otf2 boost jemalloc hdf5 silo vc hpx kokkos cppuddle octotiger && cd build/octotiger/build && ctest --output-on-failure " 
+	srun --partition=geev -N 1 -n 1 -t 08:00:00 bash -lc "module load ${compiler_module} cuda/11.5 hwloc && module list && ./build-all.sh Release ${compiler_config} ${cuda_config} without-mpi without-papi without-apex ${kokkos_config} ${simd_config} with-hpx-backend-multipole without-hpx-backend-monopole with-hpx-cuda-polling without-otf2 boost jemalloc hdf5 silo vc hpx kokkos cppuddle octotiger && cd build/octotiger/build && ctest --output-on-failure " 
 	sed -i 's/GRIDDIM=16/GRIDDIM=8/' build-octotiger.sh
 fi
 

--- a/.jenkins/lsu/node-level-tests-entry.sh
+++ b/.jenkins/lsu/node-level-tests-entry.sh
@@ -20,13 +20,13 @@ fi
 
 # Tests with griddim = 8
 echo "Running tests with griddim=8"
-srun --partition=geev -N 1 -n 1 -t 08:00:00 bash -lc "module load ${compiler_module} cuda/11.5 hwloc && module list && ./build-all.sh Release ${compiler_config} ${cuda_config} without-mpi without-papi without-apex ${kokkos_config} ${simd_config} with-hpx-backend-multipole without-hpx-backend-monopole with-hpx-cuda-polling without-otf2 boost jemalloc hdf5 silo vc hpx kokkos cppuddle octotiger && cd build/octotiger/build && ctest --output-on-failure " 
+srun --partition=jenkins-cuda --nodelist=geev -N 1 -n 1 -t 08:00:00 bash -lc "module load ${compiler_module} cuda/11.5 hwloc && module list && ./build-all.sh Release ${compiler_config} ${cuda_config} without-mpi without-papi without-apex ${kokkos_config} ${simd_config} with-hpx-backend-multipole without-hpx-backend-monopole with-hpx-cuda-polling without-otf2 boost jemalloc hdf5 silo vc hpx kokkos cppuddle octotiger && cd build/octotiger/build && ctest --output-on-failure " 
 
 # Tests with griddim = 16 - only test in full kokkos + cuda build
 if [ "${cuda_config}" = "with-cuda" ] && [ "${kokkos_config}" = "with-kokkos" ]; then
 	sed -i 's/GRIDDIM=8/GRIDDIM=16/' build-octotiger.sh
 	rm -rf build # in case we end up on a different cuda node we need to rebuild with its architecture
-	srun --partition=geev -N 1 -n 1 -t 08:00:00 bash -lc "module load ${compiler_module} cuda/11.5 hwloc && module list && ./build-all.sh Release ${compiler_config} ${cuda_config} without-mpi without-papi without-apex ${kokkos_config} ${simd_config} with-hpx-backend-multipole without-hpx-backend-monopole with-hpx-cuda-polling without-otf2 boost jemalloc hdf5 silo vc hpx kokkos cppuddle octotiger && cd build/octotiger/build && ctest --output-on-failure " 
+	srun --partition=jenkins-cuda --nodelist=geev -N 1 -n 1 -t 08:00:00 bash -lc "module load ${compiler_module} cuda/11.5 hwloc && module list && ./build-all.sh Release ${compiler_config} ${cuda_config} without-mpi without-papi without-apex ${kokkos_config} ${simd_config} with-hpx-backend-multipole without-hpx-backend-monopole with-hpx-cuda-polling without-otf2 boost jemalloc hdf5 silo vc hpx kokkos cppuddle octotiger && cd build/octotiger/build && ctest --output-on-failure " 
 	sed -i 's/GRIDDIM=16/GRIDDIM=8/' build-octotiger.sh
 fi
 

--- a/.jenkins/lsu/node-level-tests-entry.sh
+++ b/.jenkins/lsu/node-level-tests-entry.sh
@@ -18,20 +18,15 @@ if [ "${compiler_config}" = "with-CC-clang" ]; then
   sed -i 's/OCTOTIGER_WITH_BLAST_TEST=ON/OCTOTIGER_WITH_BLAST_TEST=OFF/' build-octotiger.sh
 fi
 
-
-# Load everything
-echo "Loading modules: "
-module load "${compiler_module}" cuda/11.5 hwloc
-
 # Tests with griddim = 8
 echo "Running tests with griddim=8"
-srun --partition=jenkins-cuda -N 1 -n 1 -t 08:00:00 bash -c "module load ${compiler_module} cuda/11.5 hwloc && module list && ./build-all.sh Release ${compiler_config} ${cuda_config} without-mpi without-papi without-apex ${kokkos_config} ${simd_config} with-hpx-backend-multipole without-hpx-backend-monopole with-hpx-cuda-polling without-otf2 boost jemalloc hdf5 silo vc hpx kokkos cppuddle octotiger && cd build/octotiger/build && ctest --output-on-failure " 
+srun --partition=jenkins-cuda -N 1 -n 1 -t 08:00:00 bash -lc "module load ${compiler_module} cuda/11.5 hwloc && module list && ./build-all.sh Release ${compiler_config} ${cuda_config} without-mpi without-papi without-apex ${kokkos_config} ${simd_config} with-hpx-backend-multipole without-hpx-backend-monopole with-hpx-cuda-polling without-otf2 boost jemalloc hdf5 silo vc hpx kokkos cppuddle octotiger && cd build/octotiger/build && ctest --output-on-failure " 
 
 # Tests with griddim = 16 - only test in full kokkos + cuda build
 if [ "${cuda_config}" = "with-cuda" ] && [ "${kokkos_config}" = "with-kokkos" ]; then
 	sed -i 's/GRIDDIM=8/GRIDDIM=16/' build-octotiger.sh
 	rm -rf build # in case we end up on a different cuda node we need to rebuild with its architecture
-	srun --partition=jenkins-cuda -N 1 -n 1 -t 08:00:00 bash -c "module load ${compiler_module} cuda/11.5 hwloc && module list && ./build-all.sh Release ${compiler_config} ${cuda_config} without-mpi without-papi without-apex ${kokkos_config} ${simd_config} with-hpx-backend-multipole without-hpx-backend-monopole with-hpx-cuda-polling without-otf2 boost jemalloc hdf5 silo vc hpx kokkos cppuddle octotiger && cd build/octotiger/build && ctest --output-on-failure " 
+	srun --partition=jenkins-cuda -N 1 -n 1 -t 08:00:00 bash -lc "module load ${compiler_module} cuda/11.5 hwloc && module list && ./build-all.sh Release ${compiler_config} ${cuda_config} without-mpi without-papi without-apex ${kokkos_config} ${simd_config} with-hpx-backend-multipole without-hpx-backend-monopole with-hpx-cuda-polling without-otf2 boost jemalloc hdf5 silo vc hpx kokkos cppuddle octotiger && cd build/octotiger/build && ctest --output-on-failure " 
 	sed -i 's/GRIDDIM=16/GRIDDIM=8/' build-octotiger.sh
 fi
 


### PR DESCRIPTION
This PR adapts the Jenkins pipelines to the module changes (per-machine module configuration) on the LSU cluster.

Overall this PR should fix:
- All LSU Jenkins test pipelines (CUDA, Kokkos, HIP and std::simd tests)
- All LSU Jenkins performance test pipelines (aggregation test with HIP / CUDA)
- An unrelated bug which caused HIP builds without Kokkos enabled to deadlock. (see changes init_methods.cpp)