### PR TITLE
Replace hpx::util::unwrap with hpx::unwrap

### DIFF
--- a/src/node_server_actions_2.cpp
+++ b/src/node_server_actions_2.cpp
@@ -358,7 +358,7 @@ diagnostics_t node_server::child_diagnostics(const diagnostics_t &diags) {
 	for (integer ci = 0; ci != NCHILD; ++ci) {
 		futs[index++] = children[ci].diagnostics(diags);
 	}
-	auto child_sums = hpx::util::unwrap(futs);
+	auto child_sums = hpx::unwrap(futs);
 	return std::accumulate(child_sums.begin(), child_sums.end(), sums);
 }
 

--- a/src/node_server_actions_3.cpp
+++ b/src/node_server_actions_3.cpp
@@ -746,7 +746,7 @@ future<void> node_server::timestep_driver_descend() {
 
 		return hpx::dataflow(hpx::launch::sync, /*hpx::util::annotated_function(*/[this](std::array<future<timestep_t>, NCHILD + 1> dts_fut) {
 
-			auto dts = hpx::util::unwrap(dts_fut);
+			auto dts = hpx::unwrap(dts_fut);
 			timestep_t dt;
 			dt.dt = 1.0e+99;
 			for (const auto &this_dt : dts) {


### PR DESCRIPTION
HPX master branch has moved to `hpx::unwrap`. Using `hpx::util::unwrap` will result in a compilation error.