### PR TITLE
Print git information during Octo-Tiger startup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -970,6 +970,36 @@ if(OCTOTIGER_WITH_DOCU)
   add_subdirectory(doc)    
 endif()
 
+find_package(Git)
+if(GIT_FOUND)
+  execute_process(
+    COMMAND "${GIT_EXECUTABLE}" "log" "--pretty=%H" "-1"
+            "${PROJECT_SOURCE_DIR}"
+    WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}"
+    OUTPUT_VARIABLE OCTOTIGER_WITH_GIT_COMMIT
+    ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE
+  )
+  execute_process(
+    COMMAND "${GIT_EXECUTABLE}" "log" "--pretty=%s" "-1"
+            "${PROJECT_SOURCE_DIR}"
+    WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}"
+    OUTPUT_VARIABLE OCTOTIGER_WITH_GIT_COMMIT_MESSAGE
+    ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE
+  )
+  execute_process(
+    COMMAND "${GIT_EXECUTABLE}" "status" "-s" 
+            "${PROJECT_SOURCE_DIR}"
+    WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}"
+    OUTPUT_VARIABLE OCTOTIGER_WITH_GIT_REPO_MODIFIED
+    ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE
+  )
+  message(INFO " Used Octo-Tiger commit: ${OCTOTIGER_WITH_GIT_COMMIT}")
+  target_compile_definitions(octotiger PUBLIC -DOCTOTIGER_GIT_COMMIT_HASH="${OCTOTIGER_WITH_GIT_COMMIT}")
+  target_compile_definitions(octotiger PUBLIC -DOCTOTIGER_GIT_COMMIT_MESSAGE="${OCTOTIGER_WITH_GIT_COMMIT_MESSAGE}")
+  if (NOT ("${OCTOTIGER_WITH_GIT_REPO_MODIFIED}" STREQUAL ""))
+    target_compile_definitions(octotiger PUBLIC -DOCTOTIGER_GIT_REPO_DIRTY)
+  endif()
+endif()
 
 ################################################################################
 # Tool targets

--- a/frontend/main.cpp
+++ b/frontend/main.cpp
@@ -33,13 +33,19 @@
 #warning "Experimental HIP Build! Do not (yet) use for production runs"
 #endif
 
+#ifndef OCTOTIGER_GIT_COMMIT_HASH
+#define OCTOTIGER_GIT_COMMIT_HASH "unknown"
+#endif
+#ifndef OCTOTIGER_GIT_COMMIT_MESSAGE
+#define OCTOTIGER_GIT_COMMIT_MESSAGE "unknown"
+#endif
+
 int hpx_main(int argc, char* argv[]) {
 
 #ifdef OCTOTIGER_HAVE_KOKKOS
     // Initialize Kokkos on root
     std::cout << "Initializing Kokkos on Root locality" << std::endl;
     Kokkos::initialize();
-    Kokkos::print_configuration(std::cout);
 #endif
     // The ascii logo was created by combining, modifying and extending the ascii arts from:
     // http://ascii.co.uk/art/octopus (Author "jgs")
@@ -82,6 +88,13 @@ int hpx_main(int argc, char* argv[]) {
 
     )";
     std::cout << logo << std::endl;
+    std::cout << "GIT COMMIT: " << OCTOTIGER_GIT_COMMIT_HASH << std::endl 
+              << "            \""  << OCTOTIGER_GIT_COMMIT_MESSAGE << "\"" << std::endl;
+#ifdef OCTOTIGER_GIT_REPO_DIRTY
+    std::cout << "\nReproducibility Warning: Octo-Tiger source directory contained uncommitted "
+                 "changes during the CMake configuration step! " << std::endl;
+#endif
+    std::cout << std::endl;
 
     // hpx::kokkos::ScopeGuard g(argc, argv);
 
@@ -127,6 +140,12 @@ int hpx_main(int argc, char* argv[]) {
     printf("WARNING: Experimental HIP Build! Do not (yet) use for production runs!\n");
 #endif
     printf("###########################################################\n");
+
+#ifdef OCTOTIGER_HAVE_KOKKOS
+    Kokkos::print_configuration(std::cout);
+#endif
+
+    printf("\n###########################################################\n\n");
 
     printf("Running\n");
 


### PR DESCRIPTION
This commit adds the functionality to store the current git commit hash (and message) from the source directory during into preprocessor macros during the CMake step. These are in turn printed on stdout during the Octo-Tiger startup, easing reproducibility.

This commit also adds a reproducibility warning if the source directory contained uncommitted changes during the CMake step.

This directly addresses the feature request in #435