### PR TITLE
Add cppuddle finalize method

### DIFF
--- a/frontend/init_methods.cpp
+++ b/frontend/init_methods.cpp
@@ -67,8 +67,6 @@
 #endif
 
 void cleanup_puddle_on_this_locality(void) {
-    // Cleaning up of cuda buffers before the runtime gets shutdown
-    recycler::force_cleanup();
     // Shutdown stream manager
     if (opts().cuda_streams_per_gpu > 0) {
 #if defined(OCTOTIGER_HAVE_CUDA) 
@@ -92,6 +90,13 @@ void cleanup_puddle_on_this_locality(void) {
 #endif
 #if defined(OCTOTIGER_HAVE_KOKKOS) && defined(KOKKOS_ENABLE_SYCL)
     hpx::sycl::experimental::detail::unregister_polling(hpx::resource::get_thread_pool(0));
+#endif
+#ifdef CPPUDDLE_HAVE_HPX // define added in 0.20 cppuddle version
+    // Use new finalize functionality. This works with a wider range of builds
+    recycler::finalize();
+#else
+    // Use old cleanup method for cppuddle versions < 0.2.0 and certain builds
+    recycler::force_cleanup();
 #endif
 #ifdef OCTOTIGER_HAVE_KOKKOS
     stream_pool::cleanup<hpx::kokkos::hpx_executor, round_robin_pool<hpx::kokkos::hpx_executor>>();

--- a/frontend/init_methods.cpp
+++ b/frontend/init_methods.cpp
@@ -91,11 +91,11 @@ void cleanup_puddle_on_this_locality(void) {
 #if defined(OCTOTIGER_HAVE_KOKKOS) && defined(KOKKOS_ENABLE_SYCL)
     hpx::sycl::experimental::detail::unregister_polling(hpx::resource::get_thread_pool(0));
 #endif
-#ifdef CPPUDDLE_HAVE_HPX // define added in 0.20 cppuddle version
-    // Use new finalize functionality. This works with a wider range of builds
+#ifdef CPPUDDLE_HAVE_HPX // define added in 0.2.0 cppuddle version
+    // Use new finalize functionality. This works with a wider range of cppuddle configurations
     recycler::finalize();
 #else
-    // Use old cleanup method for cppuddle versions < 0.2.0 and certain builds
+    // Use old cleanup method for cppuddle versions < 0.2.0 
     recycler::force_cleanup();
 #endif
 #ifdef OCTOTIGER_HAVE_KOKKOS


### PR DESCRIPTION
The PR SC-SGS/CPPuddle/pull/21 added a finalize method which should be used as it works best with newer cppuddle versions. Hence, this PR adds it to Octo-Tiger (while keeping compatibility to older cppuddle versions).