### PR TITLE
Add MultiGPU Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 newgit
 cmake-build-*
 cmake-cuda-*
+spack-build*
 .spack-env/*
 .clangd/*
 .cache

--- a/.jenkins/lsu/hip-tests-entry.sh
+++ b/.jenkins/lsu/hip-tests-entry.sh
@@ -13,7 +13,7 @@ set -eux
 srun -p mi100 -N 1 -n 1 -t 04:00:00 bash -lc "module load rocm/5.4 hwloc llvm/14 && module list && hipcc --version && rocminfo && ./build-all.sh Release with-CC-clang without-cuda without-mpi without-papi without-apex with-kokkos with-simd without-hpx-backend-multipole without-hpx-backend-monopole with-hpx-cuda-polling without-otf2 boost jemalloc hdf5 silo vc hpx kokkos cppuddle octotiger && cd build/octotiger/build && ctest --output-on-failure " 
 
 # Tests with griddim = 16
-#sed -i 's/GRIDDIM=8/GRIDDIM=16/' build-octotiger.sh
-#srun -p mi100 -N 1 -n 1 -t 04:00:00 bash -lc "module load rocm/5.4 hwloc llvm/14 && module list && hipcc --version && rocminfo && ./build-all.sh Release with-CC-clang without-cuda without-mpi without-papi without-apex with-kokkos with-simd without-hpx-backend-multipole without-hpx-backend-monopole with-hpx-cuda-polling without-otf2 octotiger && cd build/octotiger/build && ctest --output-on-failure -E legacy " 
-#sed -i 's/GRIDDIM=16/GRIDDIM=8/' build-octotiger.sh
+sed -i 's/GRIDDIM=8/GRIDDIM=16/' build-octotiger.sh
+srun -p mi100 -N 1 -n 1 -t 04:00:00 bash -lc "module load rocm/5.4 hwloc llvm/14 && module list && hipcc --version && rocminfo && ./build-all.sh Release with-CC-clang without-cuda without-mpi without-papi without-apex with-kokkos with-simd without-hpx-backend-multipole without-hpx-backend-monopole with-hpx-cuda-polling without-otf2 octotiger && cd build/octotiger/build && ctest --output-on-failure -E legacy " 
+sed -i 's/GRIDDIM=16/GRIDDIM=8/' build-octotiger.sh
 

--- a/.jenkins/lsu/hip-tests-entry.sh
+++ b/.jenkins/lsu/hip-tests-entry.sh
@@ -13,7 +13,7 @@ set -eux
 srun -p mi100 -N 1 -n 1 -t 04:00:00 bash -lc "module load rocm/5.4 hwloc llvm/14 && module list && hipcc --version && rocminfo && ./build-all.sh Release with-CC-clang without-cuda without-mpi without-papi without-apex with-kokkos with-simd without-hpx-backend-multipole without-hpx-backend-monopole with-hpx-cuda-polling without-otf2 boost jemalloc hdf5 silo vc hpx kokkos cppuddle octotiger && cd build/octotiger/build && ctest --output-on-failure " 
 
 # Tests with griddim = 16
-sed -i 's/GRIDDIM=8/GRIDDIM=16/' build-octotiger.sh
-srun -p mi100 -N 1 -n 1 -t 04:00:00 bash -lc "module load rocm/5.4 hwloc llvm/14 && module list && hipcc --version && rocminfo && ./build-all.sh Release with-CC-clang without-cuda without-mpi without-papi without-apex with-kokkos with-simd without-hpx-backend-multipole without-hpx-backend-monopole with-hpx-cuda-polling without-otf2 octotiger && cd build/octotiger/build && ctest --output-on-failure -E legacy " 
-sed -i 's/GRIDDIM=16/GRIDDIM=8/' build-octotiger.sh
+#sed -i 's/GRIDDIM=8/GRIDDIM=16/' build-octotiger.sh
+#srun -p mi100 -N 1 -n 1 -t 04:00:00 bash -lc "module load rocm/5.4 hwloc llvm/14 && module list && hipcc --version && rocminfo && ./build-all.sh Release with-CC-clang without-cuda without-mpi without-papi without-apex with-kokkos with-simd without-hpx-backend-multipole without-hpx-backend-monopole with-hpx-cuda-polling without-otf2 octotiger && cd build/octotiger/build && ctest --output-on-failure -E legacy " 
+#sed -i 's/GRIDDIM=16/GRIDDIM=8/' build-octotiger.sh
 

--- a/.jenkins/lsu/hip-tests-entry.sh
+++ b/.jenkins/lsu/hip-tests-entry.sh
@@ -9,11 +9,11 @@
 set -eux
 
 # Tests with griddim = 8
-# we need the gcc module for the silo fortran compilation...
-srun -p mi100 -N 1 -n 1 -t 04:00:00 bash -lc "module load gcc/12 rocm/5 hwloc && module list && hipcc --version && rocminfo && ./build-all.sh Release with-CC-clang without-cuda without-mpi without-papi without-apex with-kokkos with-simd without-hpx-backend-multipole without-hpx-backend-monopole with-hpx-cuda-polling without-otf2 boost jemalloc hdf5 silo vc hpx kokkos cppuddle octotiger && cd build/octotiger/build && ctest --output-on-failure " 
+# we need the llvm module for the silo fortran compilation...
+srun -p mi100 -N 1 -n 1 -t 04:00:00 bash -lc "module load rocm/5.4 hwloc llvm/14 && module list && hipcc --version && rocminfo && ./build-all.sh Release with-CC-clang without-cuda without-mpi without-papi without-apex with-kokkos with-simd without-hpx-backend-multipole without-hpx-backend-monopole with-hpx-cuda-polling without-otf2 boost jemalloc hdf5 silo vc hpx kokkos cppuddle octotiger && cd build/octotiger/build && ctest --output-on-failure " 
 
 # Tests with griddim = 16
 sed -i 's/GRIDDIM=8/GRIDDIM=16/' build-octotiger.sh
-srun -p mi100 -N 1 -n 1 -t 04:00:00 bash -lc "module load gcc/12 rocm/5 hwloc && module list && hipcc --version && rocminfo && ./build-all.sh Release with-CC-clang without-cuda without-mpi without-papi without-apex with-kokkos with-simd without-hpx-backend-multipole without-hpx-backend-monopole with-hpx-cuda-polling without-otf2 octotiger && cd build/octotiger/build && ctest --output-on-failure -E legacy " 
+srun -p mi100 -N 1 -n 1 -t 04:00:00 bash -lc "module load rocm/5.4 hwloc llvm/14 && module list && hipcc --version && rocminfo && ./build-all.sh Release with-CC-clang without-cuda without-mpi without-papi without-apex with-kokkos with-simd without-hpx-backend-multipole without-hpx-backend-monopole with-hpx-cuda-polling without-otf2 octotiger && cd build/octotiger/build && ctest --output-on-failure -E legacy " 
 sed -i 's/GRIDDIM=16/GRIDDIM=8/' build-octotiger.sh
 

--- a/.jenkins/lsu/hip-tests-entry.sh
+++ b/.jenkins/lsu/hip-tests-entry.sh
@@ -13,7 +13,7 @@ set -eux
 srun -p mi100 -N 1 -n 1 -t 04:00:00 bash -lc "module load rocm/5.4 hwloc llvm/14 && module list && hipcc --version && rocminfo && ./build-all.sh Release with-CC-clang without-cuda without-mpi without-papi without-apex with-kokkos with-simd without-hpx-backend-multipole without-hpx-backend-monopole with-hpx-cuda-polling without-otf2 boost jemalloc hdf5 silo vc hpx kokkos cppuddle octotiger && cd build/octotiger/build && ctest --output-on-failure " 
 
 # Tests with griddim = 16
-sed -i 's/GRIDDIM=8/GRIDDIM=16/' build-octotiger.sh
-srun -p mi100 -N 1 -n 1 -t 04:00:00 bash -lc "module load rocm/5.4 hwloc llvm/14 && module list && hipcc --version && rocminfo && ./build-all.sh Release with-CC-clang without-cuda without-mpi without-papi without-apex with-kokkos with-simd without-hpx-backend-multipole without-hpx-backend-monopole with-hpx-cuda-polling without-otf2 octotiger && cd build/octotiger/build && ctest --output-on-failure -E legacy " 
-sed -i 's/GRIDDIM=16/GRIDDIM=8/' build-octotiger.sh
+# sed -i 's/GRIDDIM=8/GRIDDIM=16/' build-octotiger.sh
+# srun -p mi100 -N 1 -n 1 -t 04:00:00 bash -lc "module load rocm/5.4 hwloc llvm/14 && module list && hipcc --version && rocminfo && ./build-all.sh Release with-CC-clang without-cuda without-mpi without-papi without-apex with-kokkos with-simd without-hpx-backend-multipole without-hpx-backend-monopole with-hpx-cuda-polling without-otf2 octotiger && cd build/octotiger/build && ctest --output-on-failure -E legacy " 
+# sed -i 's/GRIDDIM=16/GRIDDIM=8/' build-octotiger.sh
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -362,6 +362,7 @@ set(hydro_header_files
     octotiger/unitiger/hydro_impl/hydro.hpp
     octotiger/unitiger/hydro_impl/reconstruct.hpp
     octotiger/unitiger/hydro_impl/flux.hpp
+    octotiger/unitiger/hydro_impl/hydro_performance_counters.hpp
     octotiger/unitiger/radiation/radiation_physics.hpp
     octotiger/unitiger/radiation/radiation_physics_impl.hpp
     octotiger/test_problems/exact_sod.hpp
@@ -374,6 +375,7 @@ set(hydro_source_files
    src/unitiger/hydro_impl/reconstruct_cuda_kernel.cpp
    src/unitiger/hydro_impl/hydro_kernel_interface.cpp
    src/unitiger/hydro_impl/hydro_cuda_interface.cpp
+   src/unitiger/hydro_impl/hydro_performance_counters.cpp
    src/test_problems/sod/exact_sod.cpp)
 
 set(cu_source_files

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,7 +59,6 @@ option(OCTOTIGER_WITH_AVX512 "" OFF)
 
 option(OCTOTIGER_WITH_TESTS "Enable tests" ON)
 set(OCTOTIGER_WITH_GRIDDIM "8" CACHE STRING "Grid size")
-set(OCTOTIGER_WITH_GRIDDIM "8" CACHE STRING "Grid size")
 set(OCTOTIGER_WITH_MAX_NUMBER_FIELDS "15" CACHE STRING "Maximum allowed nf_ (number fields)")
 set(OCTOTIGER_THETA_MINIMUM "0.34" CACHE STRING "Minimal allowed theta value - important for optimizations")
 option(OCTOTIGER_WITH_DOCU "Enable the target to build the documentation" OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -211,6 +211,7 @@ set(source_files
     src/taylor.cpp
     src/util.cpp
     src/common_kernel/interactions_iterators.cpp
+    src/common_kernel/gravity_performance_counters.cpp
     src/cuda_util/cuda_scheduler.cpp
     src/monopole_interactions/legacy/cuda_monopole_interaction_interface.cpp
     src/monopole_interactions/legacy/monopole_cuda_kernel.cpp
@@ -287,6 +288,7 @@ set(header_files
     octotiger/common_kernel/struct_of_array_data.hpp
     octotiger/common_kernel/kokkos_util.hpp
     octotiger/common_kernel/std_simd.hpp
+    octotiger/common_kernel/gravity_performance_counters.hpp
     octotiger/compute_factor.hpp
     octotiger/cuda_util/cuda_global_def.hpp
     octotiger/cuda_util/cuda_helper.hpp

--- a/frontend/frontend-helper.cpp
+++ b/frontend/frontend-helper.cpp
@@ -40,6 +40,7 @@
 #include "octotiger/multipole_interactions/util/calculate_stencil.hpp"
 
 #include "octotiger/unitiger/hydro_impl/hydro_performance_counters.hpp"
+#include "octotiger/common_kernel/gravity_performance_counters.hpp"
 
 #include <hpx/collectives/broadcast_direct.hpp>
 #include <hpx/hpx_init.hpp>
@@ -219,6 +220,7 @@ void start_octotiger(int argc, char* argv[]) {
 void register_hpx_functions(void) {
     hpx::register_startup_function(&node_server::register_counters);
     hpx::register_startup_function(&octotiger::hydro::register_performance_counters);
+    hpx::register_startup_function(&octotiger::fmm::register_performance_counters);
     hpx::register_pre_shutdown_function([]() { options::all_localities.clear(); });
 }
 #endif

--- a/frontend/frontend-helper.cpp
+++ b/frontend/frontend-helper.cpp
@@ -39,6 +39,8 @@
 #include "octotiger/multipole_interactions/legacy/multipole_interaction_interface.hpp"
 #include "octotiger/multipole_interactions/util/calculate_stencil.hpp"
 
+#include "octotiger/unitiger/hydro_impl/hydro_performance_counters.hpp"
+
 #include <hpx/collectives/broadcast_direct.hpp>
 #include <hpx/hpx_init.hpp>
 #include <hpx/include/actions.hpp>
@@ -216,6 +218,7 @@ void start_octotiger(int argc, char* argv[]) {
 
 void register_hpx_functions(void) {
     hpx::register_startup_function(&node_server::register_counters);
+    hpx::register_startup_function(&octotiger::hydro::register_performance_counters);
     hpx::register_pre_shutdown_function([]() { options::all_localities.clear(); });
 }
 #endif

--- a/frontend/frontend-helper.hpp
+++ b/frontend/frontend-helper.hpp
@@ -12,6 +12,7 @@
 
 void start_octotiger(int argc, char* argv[]);
 void register_hpx_functions();
+void register_cppuddle_allocator_counters(void);
 
 // Get called once per locality
 void init_executors();

--- a/frontend/init_methods.cpp
+++ b/frontend/init_methods.cpp
@@ -135,13 +135,13 @@ void init_executors(void) {
     std::cout << "Found " << num_devices << " HIP devices! " << std::endl;
 #endif
     if (num_devices > 0) { // some devices were found
-      if (opts().cuda_number_gpus > num_devices) {
-          std::cerr << "ERROR: Requested " << opts().cuda_number_gpus << " GPUs but only "
+      if (opts().number_gpus > num_devices) {
+          std::cerr << "ERROR: Requested " << opts().number_gpus << " GPUs but only "
                     << num_devices << " were found!" << std::endl;
           abort();
       }
-      if (opts().cuda_number_gpus > recycler::max_number_gpus) {
-        std::cerr << "ERROR: Requested " << opts().cuda_number_gpus
+      if (opts().number_gpus > recycler::max_number_gpus) {
+        std::cerr << "ERROR: Requested " << opts().number_gpus
                   << " GPUs but CPPuddle was built with CPPUDDLE_MAX_NUMBER_GPUS="
                   << recycler::max_number_gpus << std::endl;
         abort();
@@ -220,7 +220,7 @@ void init_executors(void) {
               cudaSetDevice(gpu_id);
               });
     // initialize stencils / executor pool in kokkos device
-    for (size_t gpu_id = 0; gpu_id < opts().cuda_number_gpus; gpu_id++) {
+    for (size_t gpu_id = 0; gpu_id < opts().number_gpus; gpu_id++) {
       stream_pool::init_executor_pool<hpx::kokkos::cuda_executor,
           round_robin_pool<hpx::kokkos::cuda_executor>>(
           gpu_id, opts().cuda_streams_per_gpu,
@@ -233,7 +233,7 @@ void init_executors(void) {
           round_robin_pool<hpx::kokkos::hip_executor>>([](size_t gpu_id) {
               hipSetDevice(gpu_id);
               });
-    for (size_t gpu_id = 0; gpu_id < opts().cuda_number_gpus; gpu_id++) {
+    for (size_t gpu_id = 0; gpu_id < opts().number_gpus; gpu_id++) {
       stream_pool::init_executor_pool<hpx::kokkos::hip_executor,
           round_robin_pool<hpx::kokkos::hip_executor>>(
           gpu_id, opts().cuda_streams_per_gpu,
@@ -241,7 +241,7 @@ void init_executors(void) {
     }
     std::cout << "KOKKOS/HIP is enabled!" << std::endl;
 #elif defined(KOKKOS_ENABLE_SYCL)
-    for (size_t gpu_id = 0; gpu_id < opts().cuda_number_gpus; gpu_id++) {
+    for (size_t gpu_id = 0; gpu_id < opts().number_gpus; gpu_id++) {
       stream_pool::init_executor_pool<hpx::kokkos::sycl_executor,
           round_robin_pool<hpx::kokkos::sycl_executor>>(
           gpu_id, opts().cuda_streams_per_gpu,
@@ -276,13 +276,13 @@ void init_executors(void) {
               });
 #if HPX_KOKKOS_CUDA_FUTURE_TYPE == 0 
     std::cout << "CUDA with polling futures enabled!" << std::endl;
-    for (size_t gpu_id = 0; gpu_id < opts().cuda_number_gpus; gpu_id++) {
+    for (size_t gpu_id = 0; gpu_id < opts().number_gpus; gpu_id++) {
       stream_pool::init_executor_pool<hpx::cuda::experimental::cuda_executor, pool_strategy>(gpu_id,
           opts().cuda_streams_per_gpu, gpu_id, true);
     }
 #else
     std::cout << "CUDA with callback futures enabled!" << std::endl;
-    for (size_t gpu_id = 0; gpu_id < opts().cuda_number_gpus; gpu_id++) {
+    for (size_t gpu_id = 0; gpu_id < opts().number_gpus; gpu_id++) {
       stream_pool::init_executor_pool<hpx::cuda::experimental::cuda_executor, pool_strategy>(gpu_id,
           opts().cuda_streams_per_gpu, gpu_id, false);
     }
@@ -300,7 +300,7 @@ void init_executors(void) {
               });
 #if HPX_KOKKOS_CUDA_FUTURE_TYPE == 0  // cuda in the name is correct
     std::cout << "HIP with polling futures enabled!" << std::endl;
-    for (size_t gpu_id = 0; gpu_id < opts().cuda_number_gpus; gpu_id++) {
+    for (size_t gpu_id = 0; gpu_id < opts().number_gpus; gpu_id++) {
       stream_pool::init_executor_pool<hpx::cuda::experimental::cuda_executor, pool_strategy>(gpu_id,
           opts().cuda_streams_per_gpu, gpu_id, true);
       hipDeviceSynchronize();
@@ -308,7 +308,7 @@ void init_executors(void) {
     std::cout << "HIP with polling futures created!" << std::endl;
 #else
     std::cout << "HIP with callback futures enabled!" << std::endl;
-    for (size_t gpu_id = 0; gpu_id < opts().cuda_number_gpus; gpu_id++) {
+    for (size_t gpu_id = 0; gpu_id < opts().number_gpus; gpu_id++) {
       stream_pool::init_executor_pool<hpx::cuda::experimental::cuda_executor, pool_strategy>(gpu_id,
           opts().cuda_streams_per_gpu, gpu_id, false);
       hipDeviceSynchronize();

--- a/frontend/init_methods.cpp
+++ b/frontend/init_methods.cpp
@@ -298,7 +298,6 @@ void init_executors(void) {
     for (size_t gpu_id = 0; gpu_id < opts().number_gpus; gpu_id++) {
       stream_pool::init_executor_pool<hpx::cuda::experimental::cuda_executor, pool_strategy>(gpu_id,
           opts().executors_per_gpu, gpu_id, true);
-      hipDeviceSynchronize();
     }
     std::cout << "HIP with polling futures created!" << std::endl;
 #else
@@ -306,7 +305,6 @@ void init_executors(void) {
     for (size_t gpu_id = 0; gpu_id < opts().number_gpus; gpu_id++) {
       stream_pool::init_executor_pool<hpx::cuda::experimental::cuda_executor, pool_strategy>(gpu_id,
           opts().executors_per_gpu, gpu_id, false);
-      hipDeviceSynchronize();
     }
     std::cout << "HIP with callback futures created!" << std::endl;
 #endif

--- a/frontend/init_methods.cpp
+++ b/frontend/init_methods.cpp
@@ -85,11 +85,22 @@ void cleanup_puddle_on_this_locality(void) {
     }
     // Disable polling
 #if (defined(OCTOTIGER_HAVE_CUDA) || defined(OCTOTIGER_HAVE_HIP)) && HPX_KOKKOS_CUDA_FUTURE_TYPE == 0 
-    std::cout << "Unregistering cuda polling..." << std::endl;
-    hpx::cuda::experimental::detail::unregister_polling(hpx::resource::get_thread_pool(0));
+    if (opts().polling_threads>0) {
+      std::cout << "Unregistering cuda polling on polling pool... " << std::endl;
+      hpx::cuda::experimental::detail::unregister_polling(hpx::resource::get_thread_pool("polling"));
+    } else {
+        std::cout << "Unregistering cuda polling..." << std::endl;
+        hpx::cuda::experimental::detail::unregister_polling(hpx::resource::get_thread_pool(0));
+    }
 #endif
 #if defined(OCTOTIGER_HAVE_KOKKOS) && defined(KOKKOS_ENABLE_SYCL)
-    hpx::sycl::experimental::detail::unregister_polling(hpx::resource::get_thread_pool(0));
+    if (opts().polling_threads>0) {
+      std::cout << "Unregistering sycl polling on polling pool... " << std::endl;
+      hpx::sycl::experimental::detail::unregister_polling(hpx::resource::get_thread_pool("polling"));
+    } else {
+      std::cout << "Unregistering sycl polling..." << std::endl;
+      hpx::sycl::experimental::detail::unregister_polling(hpx::resource::get_thread_pool(0));
+    }
 #endif
 #ifdef CPPUDDLE_HAVE_HPX // define added in 0.2.0 cppuddle version
     // Use new finalize functionality. This works with a wider range of cppuddle configurations
@@ -159,15 +170,25 @@ void init_executors(void) {
 
 #if HPX_KOKKOS_CUDA_FUTURE_TYPE == 0
 #if (defined(OCTOTIGER_HAVE_CUDA) || defined(OCTOTIGER_HAVE_HIP) || defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP))  
-    std::cerr << "Registering HPX CUDA polling..." << std::endl;
-    hpx::cuda::experimental::detail::register_polling(hpx::resource::get_thread_pool(0));
-    std::cerr << "Registered HPX CUDA polling..." << std::endl;
+    if (opts().polling_threads>0) {
+      std::cerr << "Registering HPX CUDA polling on polling pool..." << std::endl;
+      hpx::cuda::experimental::detail::register_polling(hpx::resource::get_thread_pool("polling"));
+    } else {
+      std::cerr << "Registering HPX CUDA polling..." << std::endl;
+      hpx::cuda::experimental::detail::register_polling(hpx::resource::get_thread_pool(0));
+    }
+    std::cerr << "Registered HPX CUDA polling!" << std::endl;
 #endif
 #endif
 #if defined(OCTOTIGER_HAVE_KOKKOS) && defined(KOKKOS_ENABLE_SYCL)
-    std::cerr << "Registering HPX SYCL polling..." << std::endl;
-    hpx::sycl::experimental::detail::register_polling(hpx::resource::get_thread_pool(0));
-    std::cerr << "Registered HPX SYCL polling..." << std::endl;
+    if (opts().polling_threads>0) {
+      std::cerr << "Registering HPX SYCL polling on polling pool..." << std::endl;
+      hpx::sycl::experimental::detail::register_polling(hpx::resource::get_thread_pool("polling"));
+    } else {
+      std::cerr << "Registering HPX SYCL polling..." << std::endl;
+      hpx::sycl::experimental::detail::register_polling(hpx::resource::get_thread_pool(0));
+    }
+    std::cerr << "Registered HPX SYCL polling!" << std::endl;
 #endif
 
 #if defined(OCTOTIGER_HAVE_KOKKOS)

--- a/frontend/init_methods.cpp
+++ b/frontend/init_methods.cpp
@@ -141,7 +141,7 @@ void init_executors(void) {
     if (!Kokkos::is_initialized()) { // gets initialized earlier on root locality
       // TODO SYCL Need args for distributed build...
       Kokkos::initialize();
-      Kokkos::print_configuration(std::cout);
+      /* Kokkos::print_configuration(std::cout); */
       std::cout << "Initialized Kokkos on this locality..." << std::endl;
     } else {
       std::cout << "Kokkos already initialized" << std::endl;

--- a/frontend/init_methods.cpp
+++ b/frontend/init_methods.cpp
@@ -109,13 +109,8 @@ void cleanup_puddle_on_this_locality(void) {
       hpx::sycl::experimental::detail::unregister_polling(hpx::resource::get_thread_pool(0));
     }
 #endif
-#ifdef CPPUDDLE_HAVE_HPX // define added in 0.2.0 cppuddle version
-    // Use new finalize functionality. This works with a wider range of cppuddle configurations
+    // Use finalize functionality. Cleans up all buffers and prevents further use
     recycler::finalize();
-#else
-    // Use old cleanup method for cppuddle versions < 0.2.0 
-    recycler::force_cleanup();
-#endif
 #ifdef OCTOTIGER_HAVE_KOKKOS
     stream_pool::cleanup<hpx::kokkos::hpx_executor, round_robin_pool<hpx::kokkos::hpx_executor>>();
     stream_pool::cleanup<hpx::kokkos::serial_executor, round_robin_pool<hpx::kokkos::serial_executor>>();

--- a/frontend/init_methods.cpp
+++ b/frontend/init_methods.cpp
@@ -425,7 +425,7 @@ void init_problem(void) {
 
 
 void register_cppuddle_allocator_counters(void)  {
-
+#ifdef CPPUDDLE_HAVE_COUNTERS
     // default host allocators
     hpx::register_startup_function(
         &recycler::detail::buffer_recycler::register_allocator_counters_with_hpx<
@@ -484,5 +484,7 @@ void register_cppuddle_allocator_counters(void)  {
     hpx::register_startup_function(
         &recycler::detail::buffer_recycler::register_allocator_counters_with_hpx<
             int, detail::sycl_device_default_allocator<int>>);
+#endif
+
 #endif
 }

--- a/frontend/init_methods.cpp
+++ b/frontend/init_methods.cpp
@@ -214,7 +214,7 @@ void init_executors(void) {
               cudaSetDevice(gpu_id);
               });
     // initialize stencils / executor pool in kokkos device
-    for (size_t gpu_id = 0; gpu_id < max_number_gpus; gpu_id++) {
+    for (size_t gpu_id = 0; gpu_id < opts().cuda_number_gpus; gpu_id++) {
       stream_pool::init_executor_pool<hpx::kokkos::cuda_executor,
           round_robin_pool<hpx::kokkos::cuda_executor>>(
           gpu_id, opts().cuda_streams_per_gpu,
@@ -226,7 +226,7 @@ void init_executors(void) {
           round_robin_pool<hpx::kokkos::hip_executor>>([](size_t gpu_id) {
               hipSetDevice(gpu_id);
               });
-    for (size_t gpu_id = 0; gpu_id < max_number_gpus; gpu_id++) {
+    for (size_t gpu_id = 0; gpu_id < opts().cuda_number_gpus; gpu_id++) {
       stream_pool::init_executor_pool<hpx::kokkos::hip_executor,
           round_robin_pool<hpx::kokkos::hip_executor>>(
           gpu_id, opts().cuda_streams_per_gpu,
@@ -234,7 +234,7 @@ void init_executors(void) {
     }
     std::cout << "KOKKOS/HIP is enabled!" << std::endl;
 #elif defined(KOKKOS_ENABLE_SYCL)
-    for (size_t gpu_id = 0; gpu_id < max_number_gpus; gpu_id++) {
+    for (size_t gpu_id = 0; gpu_id < opts().cuda_number_gpus; gpu_id++) {
       stream_pool::init_executor_pool<hpx::kokkos::sycl_executor,
           round_robin_pool<hpx::kokkos::sycl_executor>>(
           gpu_id, opts().cuda_streams_per_gpu,
@@ -269,12 +269,12 @@ void init_executors(void) {
               });
 #if HPX_KOKKOS_CUDA_FUTURE_TYPE == 0 
     std::cout << "CUDA with polling futures enabled!" << std::endl;
-    for (size_t gpu_id = 0; gpu_id < max_number_gpus; gpu_id++)
+    for (size_t gpu_id = 0; gpu_id < opts().cuda_number_gpus; gpu_id++)
       stream_pool::init_executor_pool<hpx::cuda::experimental::cuda_executor, pool_strategy>(gpu_id,
           opts().cuda_streams_per_gpu, gpu_id, true);
 #else
     std::cout << "CUDA with callback futures enabled!" << std::endl;
-    for (size_t gpu_id = 0; gpu_id < max_number_gpus; gpu_id++)
+    for (size_t gpu_id = 0; gpu_id < opts().cuda_number_gpus; gpu_id++)
       stream_pool::init_executor_pool<hpx::cuda::experimental::cuda_executor, pool_strategy>(gpu_id,
           opts().cuda_streams_per_gpu, gpu_id, false);
 #endif
@@ -290,13 +290,13 @@ void init_executors(void) {
               });
 #if HPX_KOKKOS_CUDA_FUTURE_TYPE == 0  // cuda in the name is correct
     std::cout << "HIP with polling futures enabled!" << std::endl;
-    for (size_t gpu_id = 0; gpu_id < max_number_gpus; gpu_id++)
+    for (size_t gpu_id = 0; gpu_id < opts().cuda_number_gpus; gpu_id++)
       stream_pool::init<hpx::cuda::experimental::cuda_executor, pool_strategy>(gpu_id,
           opts().cuda_streams_per_gpu, gpu_id, true);
     std::cout << "HIP with polling futures created!" << std::endl;
 #else
     std::cout << "HIP with callback futures enabled!" << std::endl;
-    for (size_t gpu_id = 0; gpu_id < max_number_gpus; gpu_id++)
+    for (size_t gpu_id = 0; gpu_id < opts().cuda_number_gpus; gpu_id++)
       stream_pool::init<hpx::cuda::experimental::cuda_executor, pool_strategy>(gpu_id,
           opts().cuda_streams_per_gpu, gpu_id, false);
 #endif

--- a/frontend/init_methods.cpp
+++ b/frontend/init_methods.cpp
@@ -291,13 +291,13 @@ void init_executors(void) {
 #if HPX_KOKKOS_CUDA_FUTURE_TYPE == 0  // cuda in the name is correct
     std::cout << "HIP with polling futures enabled!" << std::endl;
     for (size_t gpu_id = 0; gpu_id < opts().cuda_number_gpus; gpu_id++)
-      stream_pool::init<hpx::cuda::experimental::cuda_executor, pool_strategy>(gpu_id,
+      stream_pool::init_executor_pool<hpx::cuda::experimental::cuda_executor, pool_strategy>(gpu_id,
           opts().cuda_streams_per_gpu, gpu_id, true);
     std::cout << "HIP with polling futures created!" << std::endl;
 #else
     std::cout << "HIP with callback futures enabled!" << std::endl;
     for (size_t gpu_id = 0; gpu_id < opts().cuda_number_gpus; gpu_id++)
-      stream_pool::init<hpx::cuda::experimental::cuda_executor, pool_strategy>(gpu_id,
+      stream_pool::init_executor_pool<hpx::cuda::experimental::cuda_executor, pool_strategy>(gpu_id,
           opts().cuda_streams_per_gpu, gpu_id, false);
 #endif
     octotiger::fmm::init_fmm_constants();

--- a/frontend/init_methods.cpp
+++ b/frontend/init_methods.cpp
@@ -246,7 +246,7 @@ void init_executors(void) {
       stream_pool::init_executor_pool<hpx::cuda::experimental::cuda_executor, pool_strategy>(gpu_id,
           opts().cuda_streams_per_gpu, gpu_id, false);
 #endif
-    octotiger::fmm::kernel_scheduler::init_constants();
+    octotiger::fmm::init_fmm_constants();
 
 #endif
 
@@ -264,7 +264,7 @@ void init_executors(void) {
       stream_pool::init<hpx::cuda::experimental::cuda_executor, pool_strategy>(gpu_id,
           opts().cuda_streams_per_gpu, gpu_id, false);
 #endif
-    octotiger::fmm::kernel_scheduler::init_constants();
+    octotiger::fmm::init_fmm_constants();
 #endif
     std::cout << "Stencils initialized!" << std::endl;
 }

--- a/frontend/init_methods.cpp
+++ b/frontend/init_methods.cpp
@@ -190,15 +190,19 @@ void init_executors(void) {
       stream_pool::init_executor_pool<hpx::kokkos::cuda_executor,
           round_robin_pool<hpx::kokkos::cuda_executor>>(
           gpu_id, opts().cuda_streams_per_gpu,
-          gpu_id);
+          hpx::kokkos::execution_space_mode::independent);
     }
     std::cout << "KOKKOS/CUDA is enabled!" << std::endl;
 #elif defined(KOKKOS_ENABLE_HIP)
+    stream_pool::set_device_selector<hpx::kokkos::hip_executor,
+          round_robin_pool<hpx::kokkos::hip_executor>>([](size_t gpu_id) {
+              hipSetDevice(gpu_id);
+              });
     for (size_t gpu_id = 0; gpu_id < max_number_gpus; gpu_id++) {
       stream_pool::init_executor_pool<hpx::kokkos::hip_executor,
           round_robin_pool<hpx::kokkos::hip_executor>>(
           gpu_id, opts().cuda_streams_per_gpu,
-          gpu_id);
+          hpx::kokkos::execution_space_mode::independent);
     }
     std::cout << "KOKKOS/HIP is enabled!" << std::endl;
 #elif defined(KOKKOS_ENABLE_SYCL)
@@ -206,7 +210,7 @@ void init_executors(void) {
       stream_pool::init_executor_pool<hpx::kokkos::sycl_executor,
           round_robin_pool<hpx::kokkos::sycl_executor>>(
           gpu_id, opts().cuda_streams_per_gpu,
-          gpu_id);
+          hpx::kokkos::execution_space_mode::independent);
     }
     std::cout << "KOKKOS/SYCL is enabled!" << std::endl;
 #endif
@@ -252,6 +256,10 @@ void init_executors(void) {
 
 #if defined(OCTOTIGER_HAVE_HIP)
     std::cout << "HIP is enabled!" << std::endl;
+    stream_pool::set_device_selector<hpx::cuda::experimental::cuda_executor,
+          round_robin_pool<hpx::cuda::experimental::cuda_executor>>([](size_t gpu_id) {
+              hipSetDevice(gpu_id);
+              });
 #if HPX_KOKKOS_CUDA_FUTURE_TYPE == 0  // cuda in the name is correct
     std::cout << "HIP with polling futures enabled!" << std::endl;
     for (size_t gpu_id = 0; gpu_id < max_number_gpus; gpu_id++)

--- a/frontend/init_methods.cpp
+++ b/frontend/init_methods.cpp
@@ -166,7 +166,12 @@ void init_executors(void) {
 #else
     std::cout << "Using Kokkos serial executors for monopole FMM kernels..." << std::endl;
 #endif
+#ifdef OCTOTIGER_WITH_HYDRO_HOST_HPX_EXECUTOR
+    std::cout << "Using Kokkos HPX executors for hydro kernels..." << std::endl;
     std::cout << "Number of tasks per KOKKOS hydro kernel: " << OCTOTIGER_KOKKOS_HYDRO_TASKS << std::endl;
+#else
+    std::cout << "Using Kokkos serial executors for hydro kernels..." << std::endl;
+#endif
     // initialize stencils in kokkos host memory
     octotiger::fmm::monopole_interactions::get_host_masks<host_buffer<int>>();
     octotiger::fmm::monopole_interactions::get_host_constants<host_buffer<double>>();

--- a/frontend/init_methods.cpp
+++ b/frontend/init_methods.cpp
@@ -137,7 +137,7 @@ void init_executors(void) {
       }
       if (opts().number_gpus > recycler::max_number_gpus) {
         std::cerr << "ERROR: Requested " << opts().number_gpus
-                  << " GPUs but CPPuddle was built with CPPUDDLE_MAX_NUMBER_GPUS="
+                  << " GPUs but CPPuddle was built with CPPUDDLE_WITH_MAX_NUMBER_GPUS="
                   << recycler::max_number_gpus << std::endl;
         abort();
       }

--- a/frontend/init_methods.cpp
+++ b/frontend/init_methods.cpp
@@ -172,9 +172,9 @@ void init_executors(void) {
 
 #if defined(OCTOTIGER_HAVE_KOKKOS)
     std::cerr << "Initializing Kokkos host executors..." << std::endl;
-    stream_pool::init<hpx::kokkos::serial_executor, round_robin_pool<hpx::kokkos::serial_executor>>(
+    stream_pool::init_all_executor_pools<hpx::kokkos::serial_executor, round_robin_pool<hpx::kokkos::serial_executor>>(
         256, hpx::kokkos::execution_space_mode::independent);
-    stream_pool::init<hpx::kokkos::hpx_executor, round_robin_pool<hpx::kokkos::hpx_executor>>(
+    stream_pool::init_all_executor_pools<hpx::kokkos::hpx_executor, round_robin_pool<hpx::kokkos::hpx_executor>>(
         256, hpx::kokkos::execution_space_mode::independent);
     std::cerr << "Initializing Kokkos device executors..." << std::endl;
     std::cerr << "CPPuddle config: Using " << max_number_gpus << " devices!" << std::endl;
@@ -190,7 +190,7 @@ void init_executors(void) {
       stream_pool::init_executor_pool<hpx::kokkos::cuda_executor,
           round_robin_pool<hpx::kokkos::cuda_executor>>(
           gpu_id, opts().cuda_streams_per_gpu,
-          hpx::kokkos::execution_space_mode::independent);
+          gpu_id);
     }
     std::cout << "KOKKOS/CUDA is enabled!" << std::endl;
 #elif defined(KOKKOS_ENABLE_HIP)
@@ -198,7 +198,7 @@ void init_executors(void) {
       stream_pool::init_executor_pool<hpx::kokkos::hip_executor,
           round_robin_pool<hpx::kokkos::hip_executor>>(
           gpu_id, opts().cuda_streams_per_gpu,
-          hpx::kokkos::execution_space_mode::independent);
+          gpu_id);
     }
     std::cout << "KOKKOS/HIP is enabled!" << std::endl;
 #elif defined(KOKKOS_ENABLE_SYCL)
@@ -206,7 +206,7 @@ void init_executors(void) {
       stream_pool::init_executor_pool<hpx::kokkos::sycl_executor,
           round_robin_pool<hpx::kokkos::sycl_executor>>(
           gpu_id, opts().cuda_streams_per_gpu,
-          hpx::kokkos::execution_space_mode::independent);
+          gpu_id);
     }
     std::cout << "KOKKOS/SYCL is enabled!" << std::endl;
 #endif

--- a/frontend/init_methods.cpp
+++ b/frontend/init_methods.cpp
@@ -75,7 +75,7 @@
 
 void cleanup_puddle_on_this_locality(void) {
     // Shutdown stream manager
-    if (opts().cuda_streams_per_gpu > 0) {
+    if (opts().executors_per_gpu > 0) {
 #if defined(OCTOTIGER_HAVE_CUDA) 
       stream_pool::cleanup<hpx::cuda::experimental::cuda_executor, pool_strategy>();
 #elif defined(OCTOTIGER_HAVE_HIP)  // TODO verify 
@@ -223,7 +223,7 @@ void init_executors(void) {
     for (size_t gpu_id = 0; gpu_id < opts().number_gpus; gpu_id++) {
       stream_pool::init_executor_pool<hpx::kokkos::cuda_executor,
           round_robin_pool<hpx::kokkos::cuda_executor>>(
-          gpu_id, opts().cuda_streams_per_gpu,
+          gpu_id, opts().executors_per_gpu,
           hpx::kokkos::execution_space_mode::independent);
     }
     std::cout << "KOKKOS/CUDA is enabled!" << std::endl;
@@ -236,7 +236,7 @@ void init_executors(void) {
     for (size_t gpu_id = 0; gpu_id < opts().number_gpus; gpu_id++) {
       stream_pool::init_executor_pool<hpx::kokkos::hip_executor,
           round_robin_pool<hpx::kokkos::hip_executor>>(
-          gpu_id, opts().cuda_streams_per_gpu,
+          gpu_id, opts().executors_per_gpu,
           hpx::kokkos::execution_space_mode::independent);
     }
     std::cout << "KOKKOS/HIP is enabled!" << std::endl;
@@ -244,7 +244,7 @@ void init_executors(void) {
     for (size_t gpu_id = 0; gpu_id < opts().number_gpus; gpu_id++) {
       stream_pool::init_executor_pool<hpx::kokkos::sycl_executor,
           round_robin_pool<hpx::kokkos::sycl_executor>>(
-          gpu_id, opts().cuda_streams_per_gpu,
+          gpu_id, opts().executors_per_gpu,
           hpx::kokkos::execution_space_mode::independent);
     }
     std::cout << "KOKKOS/SYCL is enabled!" << std::endl;
@@ -278,13 +278,13 @@ void init_executors(void) {
     std::cout << "CUDA with polling futures enabled!" << std::endl;
     for (size_t gpu_id = 0; gpu_id < opts().number_gpus; gpu_id++) {
       stream_pool::init_executor_pool<hpx::cuda::experimental::cuda_executor, pool_strategy>(gpu_id,
-          opts().cuda_streams_per_gpu, gpu_id, true);
+          opts().executors_per_gpu, gpu_id, true);
     }
 #else
     std::cout << "CUDA with callback futures enabled!" << std::endl;
     for (size_t gpu_id = 0; gpu_id < opts().number_gpus; gpu_id++) {
       stream_pool::init_executor_pool<hpx::cuda::experimental::cuda_executor, pool_strategy>(gpu_id,
-          opts().cuda_streams_per_gpu, gpu_id, false);
+          opts().executors_per_gpu, gpu_id, false);
     }
 #endif
     octotiger::fmm::init_fmm_constants();
@@ -302,7 +302,7 @@ void init_executors(void) {
     std::cout << "HIP with polling futures enabled!" << std::endl;
     for (size_t gpu_id = 0; gpu_id < opts().number_gpus; gpu_id++) {
       stream_pool::init_executor_pool<hpx::cuda::experimental::cuda_executor, pool_strategy>(gpu_id,
-          opts().cuda_streams_per_gpu, gpu_id, true);
+          opts().executors_per_gpu, gpu_id, true);
       hipDeviceSynchronize();
     }
     std::cout << "HIP with polling futures created!" << std::endl;
@@ -310,7 +310,7 @@ void init_executors(void) {
     std::cout << "HIP with callback futures enabled!" << std::endl;
     for (size_t gpu_id = 0; gpu_id < opts().number_gpus; gpu_id++) {
       stream_pool::init_executor_pool<hpx::cuda::experimental::cuda_executor, pool_strategy>(gpu_id,
-          opts().cuda_streams_per_gpu, gpu_id, false);
+          opts().executors_per_gpu, gpu_id, false);
       hipDeviceSynchronize();
     }
     std::cout << "HIP with callback futures created!" << std::endl;

--- a/frontend/main.cpp
+++ b/frontend/main.cpp
@@ -135,6 +135,14 @@ int hpx_main(int argc, char* argv[]) {
 #ifdef OCTOTIGER_HAVE_HIP
     printf("WARNING: Experimental HIP Build! Do not (yet) use for production runs!\n");
 #endif
+#if defined(CPPUDDLE_DEACTIVATE_BUFFER_RECYCLING)
+    printf("WARNING: Using build without buffer recycling enabled. This will cause a major degradation of GPU performance !\n");
+    printf("         Consider recompiling CPPuddle (and Octo-Tiger) with CPPUDDLE_WITH_BUFFER_RECYCLING=ON !\n");
+#endif
+#if defined(CPPUDDLE_DEACTIVATE_AGGRESSIVE_ALLOCATORS)
+    printf("WARNING: Using build without buffer content recycling enabled. This will cause a slight degradation performance !\n");
+    printf("         Consider recompiling CPPuddle (and Octo-Tiger) with CPPUDDLE_WITH_AGGRESSIVE_CONTENT_RECYCLING=ON !\n");
+#endif
     printf("###########################################################\n");
 
 
@@ -226,6 +234,18 @@ int main(int argc, char* argv[]) {
     hpx::init(argc, argv, init_args);
 #ifdef OCTOTIGER_HAVE_HIP
     std::cout << std::endl << "WARNING: Experimental HIP Build! Do not (yet) use for production runs!\n" << std::endl;
+#endif
+#if defined(CPPUDDLE_DEACTIVATE_BUFFER_RECYCLING)
+    std::cout << "WARNING: Using build without buffer recycling enabled. " 
+              << "This will cause a major degradation of GPU performance !\n";
+    std::cout << "         Consider recompiling CPPuddle (and Octo-Tiger) with "
+              << "CPPUDDLE_WITH_BUFFER_RECYCLING=ON !\n";
+#endif
+#if defined(CPPUDDLE_DEACTIVATE_AGGRESSIVE_ALLOCATORS)
+    std::cout << "WARNING: Using build without buffer content recycling enabled. "
+              << "This will cause a slight degradation performance !\n";
+    std::cout << "         Consider recompiling CPPuddle (and Octo-Tiger) with "
+              << "CPPUDDLE_WITH_AGGRESSIVE_CONTENT_RECYCLING=ON !\n";
 #endif
 
 }

--- a/frontend/main.cpp
+++ b/frontend/main.cpp
@@ -168,8 +168,8 @@ void init_resource_partitioner_handler(hpx::resource::partitioner& rp,
         // add N pus to polling pool
         int count = 0;
         for (const hpx::resource::numa_domain& d : rp.numa_domains()) {
-            for (const hpx::resource::core& c : d.cores()) {
-                for (const hpx::resource::pu& p : c.pus()) {
+            for (auto it = d.cores().rbegin(); it != d.cores().rend(); it++) {
+                for (const hpx::resource::pu& p : (*it).pus()) {
                     if (count < polling_threads) {
                         std::cout << "Added pu " << count++ << " to pool \"" <<
                           pool_name << "\"\n";

--- a/frontend/main.cpp
+++ b/frontend/main.cpp
@@ -159,15 +159,14 @@ int main(int argc, char* argv[]) {
     std::setbuf(stdout, nullptr);
     std::cout << "Set to unbuffered stdout on current process... " << std::endl;
 #endif
+    std::cerr << "Starting main..." << std::endl;
     hpx::init_params p;
     p.cfg = {
-        "hpx.commandline.allow_unknown=1",    // HPX should not complain about unknown command line
-                                              // options
-        "hpx.scheduler=local-priority-lifo",          // Use LIFO scheduler by default
-        "hpx.parcel.mpi.zero_copy_optimization!=0"    // Disable the usage of zero copy optimization
-                                                      // for MPI...
+        "hpx.commandline.allow_unknown=1"    // HPX should not complain about unknown command line
     };
+    std::cerr << "Registering functions ..." << std::endl;
     register_hpx_functions();
+    std::cerr << "Starting hpx init ..." << std::endl;
     hpx::init(argc, argv, p);
 #ifdef OCTOTIGER_HAVE_HIP
     std::cout << std::endl << "WARNING: Experimental HIP Build! Do not (yet) use for production runs!\n" << std::endl;

--- a/frontend/main.cpp
+++ b/frontend/main.cpp
@@ -184,8 +184,7 @@ void init_resource_partitioner_handler(hpx::resource::partitioner& rp,
             using namespace hpx::threads::policies;
             auto deft = scheduler_mode::default_;
             auto idle = scheduler_mode::enable_idle_backoff;
-            auto back = scheduler_mode::do_background_work;
-            std::uint32_t mode = deft & ~idle & ~back;
+            std::uint32_t mode = deft & ~idle; 
             //
             rp.create_thread_pool("default",
                                   hpx::resource::scheduling_policy::unspecified,

--- a/frontend/main.cpp
+++ b/frontend/main.cpp
@@ -201,6 +201,7 @@ int main(int argc, char* argv[]) {
       hipSetDevice(gpu_id);
       hipStream_t gpu1;
       hipStreamCreate(&gpu1);
+      hipDeviceSynchronize();
     }
 #endif
 #ifdef OCTOTIGER_HAVE_UNBUFFERED_STDOUT

--- a/frontend/main.cpp
+++ b/frontend/main.cpp
@@ -201,6 +201,7 @@ int main(int argc, char* argv[]) {
     std::cerr << "Starting main..." << std::endl;
     std::cerr << "Registering functions ..." << std::endl;
     register_hpx_functions();
+    register_cppuddle_allocator_counters();
 
     hpx::program_options::options_description desc_cmdline("Options");
     desc_cmdline.add_options()

--- a/octotiger/common_kernel/gravity_performance_counters.hpp
+++ b/octotiger/common_kernel/gravity_performance_counters.hpp
@@ -1,0 +1,37 @@
+
+#pragma once
+
+#include <cstdint>
+#include <atomic>
+
+namespace octotiger {
+namespace fmm {
+
+extern std::atomic<std::uint64_t> p2p_kokkos_cpu_subgrids_launched;
+extern std::atomic<std::uint64_t> p2p_kokkos_gpu_subgrids_launched;
+extern std::atomic<std::uint64_t> p2p_cuda_gpu_subgrids_launched;
+extern std::atomic<std::uint64_t> p2p_vc_cpu_subgrids_launched;
+extern std::atomic<std::uint64_t> p2p_legacy_cpu_subgrids_launched;
+
+extern std::atomic<std::uint64_t> multipole_kokkos_cpu_subgrids_launched;
+extern std::atomic<std::uint64_t> multipole_kokkos_gpu_subgrids_launched;
+extern std::atomic<std::uint64_t> multipole_cuda_gpu_subgrids_launched;
+extern std::atomic<std::uint64_t> multipole_vc_cpu_subgrids_launched;
+extern std::atomic<std::uint64_t> multipole_legacy_cpu_subgrids_launched;
+
+std::uint64_t p2p_kokkos_cpu_subgrid_processed_performance_data(bool reset);
+std::uint64_t p2p_kokkos_gpu_subgrid_processed_performance_data(bool reset);
+std::uint64_t p2p_cuda_gpu_subgrid_processed_performance_data(bool reset);
+std::uint64_t p2p_vc_cpu_subgrid_processed_performance_data(bool reset);
+std::uint64_t p2p_legacy_cpu_subgrid_processed_performance_data(bool reset);
+
+std::uint64_t multipole_kokkos_cpu_subgrid_processed_performance_data(bool reset);
+std::uint64_t multipole_kokkos_gpu_subgrid_processed_performance_data(bool reset);
+std::uint64_t multipole_cuda_gpu_subgrid_processed_performance_data(bool reset);
+std::uint64_t multipole_vc_cpu_subgrid_processed_performance_data(bool reset);
+std::uint64_t multipole_legacy_cpu_subgrid_processed_performance_data(bool reset);
+
+void register_performance_counters(void);
+
+}
+}

--- a/octotiger/common_kernel/interaction_constants.hpp
+++ b/octotiger/common_kernel/interaction_constants.hpp
@@ -45,6 +45,7 @@ namespace fmm {
     constexpr int STENCIL_MIN = -STENCIL_WIDTH;
     constexpr int STENCIL_MAX = STENCIL_WIDTH;
     constexpr int FULL_STENCIL_SIZE = STENCIL_INX * STENCIL_INX * STENCIL_INX;
+    static_assert(STENCIL_WIDTH_HELPER < INX, "Chosen subgrid size too small for chosen OCTOTIGER_THETA_MINIMUM");
 
     constexpr uint64_t INNER_CELLS_PADDING_DEPTH = INX;
     constexpr uint64_t PADDING_OFFSET = INNER_CELLS_PADDING_DEPTH - STENCIL_MAX;

--- a/octotiger/cuda_util/cuda_scheduler.hpp
+++ b/octotiger/cuda_util/cuda_scheduler.hpp
@@ -38,25 +38,6 @@ namespace octotiger { namespace fmm {
         4 * P2P_PADDED_STENCIL_SIZE * sizeof(real);
     constexpr std::size_t full_stencil_size = FULL_STENCIL_SIZE * sizeof(real);
 
-    // Scheduler which decides on what device to launch kernel and what memory to use
-    class kernel_scheduler
-    {
-    public:
-        static OCTOTIGER_EXPORT kernel_scheduler& scheduler();
-
-        OCTOTIGER_EXPORT void init();
-        static OCTOTIGER_EXPORT void init_constants();
-
-    public:
-        kernel_scheduler(kernel_scheduler& other) = delete;
-        kernel_scheduler(kernel_scheduler const& other) = delete;
-        kernel_scheduler operator=(kernel_scheduler const& other) = delete;
-        // Deallocates CUDA memory
-        ~kernel_scheduler();
-
-    private:
-        // Constructs number of streams indicated by the options
-        kernel_scheduler();
-    };
+    OCTOTIGER_EXPORT void init_fmm_constants();
 }}
 #endif

--- a/octotiger/monopole_interactions/kernel/kokkos_kernel.hpp
+++ b/octotiger/monopole_interactions/kernel/kokkos_kernel.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2020-2021 Gregor Daiß
+//  Copyright (c) 2020-2023 Gregor Daiß
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -76,8 +76,7 @@ namespace fmm {
                     stream_pool::select_device<executor_t,
                           round_robin_pool<executor_t>>(gpu_id_loop);
                     executor_t exec{hpx::kokkos::execution_space_mode::independent};
-                    const size_t location_id = gpu_id_loop * instances_per_gpu;
-                    stencil_masks.emplace_back(location_id, FULL_STENCIL_SIZE);
+                    stencil_masks.emplace_back(gpu_id_loop, FULL_STENCIL_SIZE);
                     Kokkos::deep_copy(exec.instance(), stencil_masks[gpu_id_loop], tmp);
                     exec.instance().fence();
                 }
@@ -96,8 +95,7 @@ namespace fmm {
                     stream_pool::select_device<executor_t,
                           round_robin_pool<executor_t>>(gpu_id_loop);
                     executor_t exec{hpx::kokkos::execution_space_mode::independent};
-                    const size_t location_id = gpu_id_loop * instances_per_gpu;
-                    stencil_constants.emplace_back(location_id, 4 * FULL_STENCIL_SIZE);
+                    stencil_constants.emplace_back(gpu_id_loop, 4 * FULL_STENCIL_SIZE);
                     Kokkos::deep_copy(exec.instance(), stencil_constants[gpu_id_loop], tmp);
                     exec.instance().fence();
                 }

--- a/octotiger/monopole_interactions/kernel/kokkos_kernel.hpp
+++ b/octotiger/monopole_interactions/kernel/kokkos_kernel.hpp
@@ -73,7 +73,7 @@ namespace fmm {
             static bool initialized = false;
             if (!initialized) {
                 const storage_host& tmp = get_host_masks<storage_host>();
-                for (int gpu_id_loop = 0; gpu_id_loop < max_number_gpus; gpu_id_loop++) {
+                for (int gpu_id_loop = 0; gpu_id_loop < opts().cuda_number_gpus; gpu_id_loop++) {
                     stream_pool::select_device<executor_t,
                           round_robin_pool<executor_t>>(gpu_id_loop);
                     executor_t exec{hpx::kokkos::execution_space_mode::independent};
@@ -92,7 +92,7 @@ namespace fmm {
             static bool initialized = false;
             if (!initialized) {
                 const storage_host& tmp = get_host_constants<storage_host>();
-                for (int gpu_id_loop = 0; gpu_id_loop < max_number_gpus; gpu_id_loop++) {
+                for (int gpu_id_loop = 0; gpu_id_loop < opts().cuda_number_gpus; gpu_id_loop++) {
                     stream_pool::select_device<executor_t,
                           round_robin_pool<executor_t>>(gpu_id_loop);
                     executor_t exec{hpx::kokkos::execution_space_mode::independent};

--- a/octotiger/monopole_interactions/kernel/kokkos_kernel.hpp
+++ b/octotiger/monopole_interactions/kernel/kokkos_kernel.hpp
@@ -73,7 +73,7 @@ namespace fmm {
             static bool initialized = false;
             if (!initialized) {
                 const storage_host& tmp = get_host_masks<storage_host>();
-                for (int gpu_id_loop = 0; gpu_id_loop < opts().cuda_number_gpus; gpu_id_loop++) {
+                for (int gpu_id_loop = 0; gpu_id_loop < opts().number_gpus; gpu_id_loop++) {
                     stream_pool::select_device<executor_t,
                           round_robin_pool<executor_t>>(gpu_id_loop);
                     executor_t exec{hpx::kokkos::execution_space_mode::independent};
@@ -92,7 +92,7 @@ namespace fmm {
             static bool initialized = false;
             if (!initialized) {
                 const storage_host& tmp = get_host_constants<storage_host>();
-                for (int gpu_id_loop = 0; gpu_id_loop < opts().cuda_number_gpus; gpu_id_loop++) {
+                for (int gpu_id_loop = 0; gpu_id_loop < opts().number_gpus; gpu_id_loop++) {
                     stream_pool::select_device<executor_t,
                           round_robin_pool<executor_t>>(gpu_id_loop);
                     executor_t exec{hpx::kokkos::execution_space_mode::independent};

--- a/octotiger/monopole_interactions/kernel/kokkos_kernel.hpp
+++ b/octotiger/monopole_interactions/kernel/kokkos_kernel.hpp
@@ -13,6 +13,7 @@
 #ifdef OCTOTIGER_HAVE_KOKKOS
 #include "octotiger/common_kernel/kokkos_util.hpp"
 #include "octotiger/common_kernel/kokkos_simd.hpp"
+#include "octotiger/options.hpp"
 
 #ifdef HPX_HAVE_APEX
 #include <apex_api.hpp>
@@ -742,7 +743,7 @@ namespace fmm {
             std::enable_if_t<is_kokkos_device_executor<executor_t>::value, int> = 0>
         void launch_interface_p2p(executor_t& exec, host_buffer<double>& monopoles,
             host_buffer<double>& results, double dx, double theta) {
-            auto gpu_id = get_device_id();
+            auto gpu_id = get_device_id(opts().cuda_number_gpus);
             stream_pool::select_device<executor_t,
                   round_robin_pool<executor_t>>(gpu_id);
             // create device buffers
@@ -809,7 +810,7 @@ namespace fmm {
             std::vector<host_buffer<double>>& center_of_masses, double dx, double theta,
             std::vector<neighbor_gravity_type>& neighbors, gsolve_type type,
             const size_t number_p2m_kernels) {
-            auto gpu_id = get_device_id();
+            auto gpu_id = get_device_id(opts().cuda_number_gpus);
             stream_pool::select_device<executor_t,
                   round_robin_pool<executor_t>>(gpu_id);
             // create device buffers

--- a/octotiger/multipole_interactions/kernel/kokkos_kernel.hpp
+++ b/octotiger/multipole_interactions/kernel/kokkos_kernel.hpp
@@ -63,7 +63,7 @@ namespace fmm {
             if (!initialized) {
                 const storage_host& tmp_masks = get_host_masks<storage_host>(false);
                 const storage_host& tmp_indicators = get_host_masks<storage_host>(true);
-                for (int gpu_id_loop = 0; gpu_id_loop < opts().cuda_number_gpus; gpu_id_loop++) {
+                for (int gpu_id_loop = 0; gpu_id_loop < opts().number_gpus; gpu_id_loop++) {
                     stream_pool::select_device<executor_t,
                           round_robin_pool<executor_t>>(gpu_id_loop);
                     executor_t exec{hpx::kokkos::execution_space_mode::independent};

--- a/octotiger/multipole_interactions/kernel/kokkos_kernel.hpp
+++ b/octotiger/multipole_interactions/kernel/kokkos_kernel.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2020-2021 Gregor Daiß
+//  Copyright (c) 2020-2023 Gregor Daiß
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -66,10 +66,9 @@ namespace fmm {
                     stream_pool::select_device<executor_t,
                           round_robin_pool<executor_t>>(gpu_id_loop);
                     executor_t exec{hpx::kokkos::execution_space_mode::independent};
-                    const size_t location_id = gpu_id_loop * instances_per_gpu;
-                    stencil_masks.emplace_back(location_id, FULL_STENCIL_SIZE);
+                    stencil_masks.emplace_back(gpu_id_loop, FULL_STENCIL_SIZE);
                     Kokkos::deep_copy(exec.instance(), stencil_masks[gpu_id_loop], tmp_masks);
-                    stencil_indicators.emplace_back(location_id, FULL_STENCIL_SIZE);
+                    stencil_indicators.emplace_back(gpu_id_loop, FULL_STENCIL_SIZE);
                     Kokkos::deep_copy(exec.instance(), stencil_indicators[gpu_id_loop], tmp_indicators);
                     exec.instance().fence();
                 }

--- a/octotiger/multipole_interactions/kernel/kokkos_kernel.hpp
+++ b/octotiger/multipole_interactions/kernel/kokkos_kernel.hpp
@@ -13,6 +13,7 @@
 #ifdef OCTOTIGER_HAVE_KOKKOS
 #include "octotiger/common_kernel/kokkos_util.hpp"
 #include "octotiger/common_kernel/kokkos_simd.hpp"
+#include "octotiger/options.hpp"
 
 #ifdef HPX_HAVE_APEX
 #include <apex_api.hpp>
@@ -770,7 +771,7 @@ namespace fmm {
             const host_buffer<double>& centers_of_mass, const host_buffer<double>& multipoles,
             host_buffer<double>& potential_expansions, host_buffer<double>& angular_corrections,
             const double theta, const gsolve_type type, const bool use_root_stencil) {
-            auto gpu_id = get_device_id();
+            auto gpu_id = get_device_id(opts().cuda_number_gpus);
             stream_pool::select_device<executor_t,
                   round_robin_pool<executor_t>>(gpu_id);
             const device_buffer<int>& device_masks =

--- a/octotiger/multipole_interactions/kernel/kokkos_kernel.hpp
+++ b/octotiger/multipole_interactions/kernel/kokkos_kernel.hpp
@@ -770,8 +770,8 @@ namespace fmm {
         void launch_interface(executor_t& exec, const host_buffer<double>& monopoles,
             const host_buffer<double>& centers_of_mass, const host_buffer<double>& multipoles,
             host_buffer<double>& potential_expansions, host_buffer<double>& angular_corrections,
-            const double theta, const gsolve_type type, const bool use_root_stencil) {
-            auto gpu_id = get_device_id(opts().cuda_number_gpus);
+            const double theta, const gsolve_type type, const bool use_root_stencil, const size_t device_id) {
+            auto gpu_id = device_id;
             stream_pool::select_device<executor_t,
                   round_robin_pool<executor_t>>(gpu_id);
             const device_buffer<int>& device_masks =
@@ -780,23 +780,23 @@ namespace fmm {
                 get_device_masks<device_buffer<int>, host_buffer<int>, executor_t>(exec, true, gpu_id);
             // input buffers
             // std::cout << "device buffer creation" << std::endl;
-            device_buffer<double> device_monopoles(NUMBER_LOCAL_MONOPOLE_VALUES);
+            device_buffer<double> device_monopoles(gpu_id, NUMBER_LOCAL_MONOPOLE_VALUES);
             if (!use_root_stencil) {
                 // std::cout << "device buffer deep copy" << std::endl;
                 Kokkos::deep_copy(exec.instance(), device_monopoles, monopoles);
             }
             // std::cout << "device buffer creation" << std::endl;
-            device_buffer<double> device_multipoles(NUMBER_LOCAL_EXPANSION_VALUES);
+            device_buffer<double> device_multipoles(gpu_id, NUMBER_LOCAL_EXPANSION_VALUES);
             // std::cout << "device buffer deep copy" << std::endl;
             Kokkos::deep_copy(exec.instance(), device_multipoles, multipoles);
             // std::cout << "device buffer creation" << std::endl;
-            device_buffer<double> device_centers(NUMBER_MASS_VALUES);
+            device_buffer<double> device_centers(gpu_id, NUMBER_MASS_VALUES);
             // std::cout << "device buffer deep copy" << std::endl;
             Kokkos::deep_copy(exec.instance(), device_centers, centers_of_mass);
             // result buffers
             // std::cout << "device buffer creation" << std::endl;
-            device_buffer<double> device_expansions(NUMBER_POT_EXPANSIONS);
-            device_buffer<double> device_corrections(NUMBER_ANG_CORRECTIONS);
+            device_buffer<double> device_expansions(gpu_id, NUMBER_POT_EXPANSIONS);
+            device_buffer<double> device_corrections(gpu_id, NUMBER_ANG_CORRECTIONS);
 
             int number_blocks = NUMBER_MULTIPOLE_BLOCKS * NUMBER_MULTIPOLE_BLOCKS;
             int number_blocks_dim = NUMBER_MULTIPOLE_BLOCKS;
@@ -816,8 +816,8 @@ namespace fmm {
                 assert(number_blocks_dim * number_blocks_dim == number_blocks);
             }
 
-            device_buffer<double> tmp_device_corrections(number_blocks * NUMBER_ANG_CORRECTIONS);
-            device_buffer<double> tmp_device_expansions(
+            device_buffer<double> tmp_device_corrections(gpu_id, number_blocks * NUMBER_ANG_CORRECTIONS);
+            device_buffer<double> tmp_device_expansions(gpu_id, 
                 number_blocks * NUMBER_POT_EXPANSIONS);
             if (type == RHO) {
                 // Launch kernel with angular corrections
@@ -867,7 +867,7 @@ namespace fmm {
         void launch_interface(executor_t& exec, const host_buffer<double>& monopoles,
             const host_buffer<double>& centers_of_mass, const host_buffer<double>& multipoles,
             host_buffer<double>& potential_expansions, host_buffer<double>& angular_corrections,
-            const double theta, const gsolve_type type, const bool use_root_stencil) {
+            const double theta, const gsolve_type type, const bool use_root_stencil, const size_t device_id) {
             const host_buffer<int>& host_masks = get_host_masks<host_buffer<int>>(false);
             const host_buffer<int>& host_indicators = get_host_masks<host_buffer<int>>(true);
             // check compile time invariants
@@ -947,7 +947,8 @@ namespace fmm {
             std::vector<std::shared_ptr<std::vector<space_vector>>>& com_ptr,
             std::vector<neighbor_gravity_type>& neighbors, gsolve_type type, real dx, real theta,
             std::array<bool, geo::direction::count()>& is_direction_empty,
-            std::array<real, NDIM> xbase, std::shared_ptr<grid> grid, const bool use_root_stencil) {
+            std::array<real, NDIM> xbase, std::shared_ptr<grid> grid, const bool use_root_stencil,
+            const size_t device_id) {
             // input buffers
             host_buffer<double> host_monopoles(NUMBER_LOCAL_MONOPOLE_VALUES);
             host_buffer<double> host_multipoles(NUMBER_LOCAL_EXPANSION_VALUES);
@@ -960,7 +961,7 @@ namespace fmm {
                 xbase, host_monopoles, host_multipoles, host_masses, grid, use_root_stencil);
             // launch kernel (and copy data to device if necessary)
             launch_interface(exec, host_monopoles, host_masses, host_multipoles, host_expansions,
-                host_corrections, theta, type, use_root_stencil);
+                host_corrections, theta, type, use_root_stencil, device_id);
             // Add results back into non-SoA array
             std::vector<expansion>& org = grid->get_L();
             for (size_t component = 0; component < 20; component++) {

--- a/octotiger/multipole_interactions/kernel/kokkos_kernel.hpp
+++ b/octotiger/multipole_interactions/kernel/kokkos_kernel.hpp
@@ -63,7 +63,7 @@ namespace fmm {
             if (!initialized) {
                 const storage_host& tmp_masks = get_host_masks<storage_host>(false);
                 const storage_host& tmp_indicators = get_host_masks<storage_host>(true);
-                for (int gpu_id_loop = 0; gpu_id_loop < max_number_gpus; gpu_id_loop++) {
+                for (int gpu_id_loop = 0; gpu_id_loop < opts().cuda_number_gpus; gpu_id_loop++) {
                     stream_pool::select_device<executor_t,
                           round_robin_pool<executor_t>>(gpu_id_loop);
                     executor_t exec{hpx::kokkos::execution_space_mode::independent};

--- a/octotiger/options.hpp
+++ b/octotiger/options.hpp
@@ -130,9 +130,8 @@ public:
 
 	size_t number_gpus;
 	size_t executors_per_gpu;
-	size_t cuda_buffer_capacity;
+	size_t max_gpu_executor_queue_length;
 	size_t max_executor_slices;
-	/* size_t max_gpu_executor_queue_length; */
 	/* size_t max_gpu_kernels_fused; */
   
 	bool root_node_on_device;
@@ -272,7 +271,7 @@ public:
 		arc & data_dir;
 		arc & number_gpus;
 		arc & executors_per_gpu;
-		arc & cuda_buffer_capacity;
+		arc & max_gpu_executor_queue_length;
 		arc & max_executor_slices;
 	  arc & root_node_on_device;
 	  arc & optimize_local_communication;

--- a/octotiger/options.hpp
+++ b/octotiger/options.hpp
@@ -131,8 +131,7 @@ public:
 	size_t number_gpus;
 	size_t executors_per_gpu;
 	size_t max_gpu_executor_queue_length;
-	size_t max_executor_slices;
-	/* size_t max_gpu_kernels_fused; */
+	size_t max_kernels_fused;
   
 	bool root_node_on_device;
 	bool optimize_local_communication;
@@ -272,7 +271,7 @@ public:
 		arc & number_gpus;
 		arc & executors_per_gpu;
 		arc & max_gpu_executor_queue_length;
-		arc & max_executor_slices;
+		arc & max_kernels_fused;
 	  arc & root_node_on_device;
 	  arc & optimize_local_communication;
     arc & detected_intel_compiler;

--- a/octotiger/options.hpp
+++ b/octotiger/options.hpp
@@ -54,6 +54,7 @@ public:
 	bool idle_rates;
 	bool ipr_test;
   bool detected_intel_compiler;
+  bool print_times_per_timestep;
 
 	integer scf_output_frequency;
 	integer silo_num_groups;
@@ -271,6 +272,8 @@ public:
 		arc & max_executor_slices;
 	  arc & root_node_on_device;
 	  arc & optimize_local_communication;
+    arc & detected_intel_compiler;
+    arc & print_times_per_timestep;
 		arc & atomic_mass;
 		arc & atomic_number;
 		arc & X;

--- a/octotiger/options.hpp
+++ b/octotiger/options.hpp
@@ -129,10 +129,9 @@ public:
         real moving_star_zvelocity;
 
 	size_t number_gpus;
-	size_t cuda_streams_per_gpu;
+	size_t executors_per_gpu;
 	size_t cuda_buffer_capacity;
 	size_t max_executor_slices;
-	/* size_t executors_per_gpu; */
 	/* size_t max_gpu_executor_queue_length; */
 	/* size_t max_gpu_kernels_fused; */
   
@@ -272,7 +271,7 @@ public:
 		eos = static_cast<eos_type>(tmp);
 		arc & data_dir;
 		arc & number_gpus;
-		arc & cuda_streams_per_gpu;
+		arc & executors_per_gpu;
 		arc & cuda_buffer_capacity;
 		arc & max_executor_slices;
 	  arc & root_node_on_device;

--- a/octotiger/options.hpp
+++ b/octotiger/options.hpp
@@ -134,6 +134,7 @@ public:
 	size_t max_executor_slices;
 	bool root_node_on_device;
 	bool optimize_local_communication;
+  int polling_threads;
 
 	std::string input_file;
 	std::string config_file;

--- a/octotiger/options.hpp
+++ b/octotiger/options.hpp
@@ -128,10 +128,14 @@ public:
         real moving_star_yvelocity;
         real moving_star_zvelocity;
 
-	size_t cuda_number_gpus;
+	size_t number_gpus;
 	size_t cuda_streams_per_gpu;
 	size_t cuda_buffer_capacity;
 	size_t max_executor_slices;
+	/* size_t executors_per_gpu; */
+	/* size_t max_gpu_executor_queue_length; */
+	/* size_t max_gpu_kernels_fused; */
+  
 	bool root_node_on_device;
 	bool optimize_local_communication;
   int polling_threads;
@@ -267,7 +271,7 @@ public:
 		arc & tmp;
 		eos = static_cast<eos_type>(tmp);
 		arc & data_dir;
-		arc & cuda_number_gpus;
+		arc & number_gpus;
 		arc & cuda_streams_per_gpu;
 		arc & cuda_buffer_capacity;
 		arc & max_executor_slices;

--- a/octotiger/unitiger/hydro_impl/hydro_kernel_interface.hpp
+++ b/octotiger/unitiger/hydro_impl/hydro_kernel_interface.hpp
@@ -15,7 +15,7 @@ timestep_t launch_hydro_kernels(hydro_computer<NDIM, INX, physics<NDIM>>& hydro,
     const std::vector<std::vector<safe_real>>& U, std::vector<std::vector<safe_real>>& X,
     const double omega, std::vector<hydro_state_t<std::vector<safe_real>>>& F,
     const interaction_host_kernel_type host_type, const interaction_device_kernel_type device_type,
-    const size_t cuda_buffer_capacity);
+    const size_t max_gpu_executor_queue_length);
 
 #if defined(OCTOTIGER_HAVE_CUDA) || defined(OCTOTIGER_HAVE_HIP)
 timestep_t launch_hydro_cuda_kernels(const hydro_computer<NDIM, INX, physics<NDIM>>& hydro,

--- a/octotiger/unitiger/hydro_impl/hydro_kokkos_kernel.hpp
+++ b/octotiger/unitiger/hydro_impl/hydro_kokkos_kernel.hpp
@@ -49,12 +49,14 @@ const storage& get_flux_host_masks() {
 }
 
 template <typename storage, typename storage_host, typename executor_t>
-const storage& get_flux_device_masks(executor_t& exec, const size_t gpu_id = 0) {
+const storage& get_flux_device_masks(executor_t& exec2, const size_t gpu_id = 0) {
     static std::vector<storage> masks;
     static bool initialized = false;
+    /* if (agg_exec.parent.gpu_id == 1) */
     if (!initialized) {
         const storage_host& tmp_masks = get_flux_host_masks<storage_host>();
-        for (size_t gpu_id_loop = 0; gpu_id_loop < max_number_gpus; gpu_id_loop++) {
+        for (int gpu_id_loop = 0; gpu_id_loop < max_number_gpus; gpu_id_loop++) {
+          kokkos_device_executor exec{gpu_id_loop};
           const size_t location_id = gpu_id_loop * instances_per_gpu;
           masks.emplace_back(location_id, NDIM * q_inx3);
           Kokkos::deep_copy(exec.instance(), masks[gpu_id_loop], tmp_masks);
@@ -95,7 +97,7 @@ hpx::shared_future<void> aggregrated_deep_copy_async(
     SourceView_t& source) {
     auto launch_copy_lambda = [](TargetView_t& target, SourceView_t& source,
                                   executor_t& exec) -> hpx::shared_future<void> {
-        return hpx::kokkos::deep_copy_async(exec.instance(), target, source);
+        return hpx::kokkos::deep_copy_async(exec.device_id, exec.instance(), target, source);
     };
     return agg_exec.wrap_async(
         launch_copy_lambda, target, source, agg_exec.get_underlying_executor());
@@ -114,7 +116,7 @@ hpx::shared_future<void> aggregrated_deep_copy_async(
         auto source_slices = Kokkos::subview(
             source, std::make_pair<size_t, size_t>(0, number_slices *
               elements_per_slice));
-        return hpx::kokkos::deep_copy_async(exec.instance(), target_slices, source_slices);
+        return hpx::kokkos::deep_copy_async(exec.device_id, exec.instance(), target_slices, source_slices);
     };
     return agg_exec.wrap_async(
         launch_copy_lambda, target, source, agg_exec.get_underlying_executor());
@@ -1092,6 +1094,7 @@ timestep_t device_interface_kokkos_hydro(executor_t& exec,
         alloc_device_double, (H_N3 + padding) * max_slices);
     aggregated_device_buffer<double, executor_t> disc(
         alloc_device_double, (ndir / 2 * H_N3 + padding) * max_slices);
+    cudaSetDevice(agg_exec.parent.gpu_id);
     find_contact_discs_impl(exec, agg_exec, u, P, disc, physics<NDIM>::A_, physics<NDIM>::B_,
         physics<NDIM>::fgamma_, physics<NDIM>::de_switch_1, ndir, nf, {1, 1, 8,
         8}, {1, 1, 8, 8});
@@ -1100,6 +1103,7 @@ timestep_t device_interface_kokkos_hydro(executor_t& exec,
     aggregated_device_buffer<double, executor_t> large_x(
         alloc_device_double, (NDIM * H_N3 + padding) * max_slices);
     aggregated_deep_copy(agg_exec, large_x, combined_large_x, (NDIM * H_N3 + padding));
+    cudaSetDevice(agg_exec.parent.gpu_id);
     hydro_pre_recon_impl(exec, agg_exec, large_x, omega, angmom, u, nf, n_species, {1, 1,
         8, 8});
 
@@ -1121,10 +1125,11 @@ timestep_t device_interface_kokkos_hydro(executor_t& exec,
     aggregated_device_buffer<double, executor_t> dx_device(alloc_device_double, max_slices);
     aggregated_deep_copy(agg_exec, dx_device, dx);
 
+    cudaSetDevice(agg_exec.parent.gpu_id);
     if (angmom_index > -1) {
-        reconstruct_impl<device_simd_t, device_simd_mask_t>(exec, agg_exec, omega, nf, angmom_index,
-            device_smooth_field, device_disc_detect, q, x, u, AM, dx_device, disc, n_species, ndir,
-            nangmom, 64, 64);
+        reconstruct_impl<device_simd_t, device_simd_mask_t>(exec, agg_exec, omega, nf,
+            angmom_index, device_smooth_field, device_disc_detect, q, x, u, AM, dx_device,
+            disc, n_species, ndir, nangmom, 64, 64);
     } else {
         reconstruct_no_amc_impl<device_simd_t, device_simd_mask_t>(exec, agg_exec, omega, nf,
             angmom_index, device_smooth_field, device_disc_detect, q, x, u, AM, dx_device, disc,
@@ -1147,6 +1152,7 @@ timestep_t device_interface_kokkos_hydro(executor_t& exec,
 
     aggregated_device_buffer<double, executor_t> f(
         alloc_device_double, (NDIM * nf * q_inx3 + padding) * max_slices);
+    cudaSetDevice(agg_exec.parent.gpu_id);
     flux_impl(exec, agg_exec, q, x, f, amax, amax_indices, amax_d, masks, omega, dx_device, A_, B_,
         nf, fgamma, de_switch_1, NDIM * number_blocks_small, 128);
     aggregated_host_buffer<double, executor_t> host_amax(
@@ -1160,7 +1166,8 @@ timestep_t device_interface_kokkos_hydro(executor_t& exec,
     aggregated_deep_copy(agg_exec, host_amax_indices, amax_indices);
     aggregated_deep_copy(agg_exec, host_amax_d, amax_d);
 
-    auto fut = aggregrated_deep_copy_async<executor_t>(agg_exec, host_f, f, (NDIM * nf * q_inx3 + padding));
+    auto fut = aggregrated_deep_copy_async<executor_t>(
+        agg_exec, host_f, f, (NDIM * nf * q_inx3 + padding));
     fut.get();
 
     const int amax_slice_offset = NDIM * (1 + 2 * nf) * number_blocks_small * slice_id;
@@ -1188,7 +1195,6 @@ timestep_t device_interface_kokkos_hydro(executor_t& exec,
     ts.a = host_amax[current_max_slot + amax_slice_offset];
     ts.x = combined_x[current_max_index + x_slice_offset * slice_id];
     ts.y = combined_x[current_max_index + q_inx3 + x_slice_offset * slice_id];
-    ts.z = combined_x[current_max_index + 2 * q_inx3+ x_slice_offset * slice_id];
     ts.z = combined_x[current_max_index + 2 * q_inx3 + x_slice_offset * slice_id];
     const size_t current_i = current_max_slot;
     const size_t current_dim = current_max_slot / number_blocks_small;
@@ -1196,7 +1202,8 @@ timestep_t device_interface_kokkos_hydro(executor_t& exec,
     constexpr int compressedH_DN[3] = {q_inx2, q_inx, 1};
     for (int f = 0; f < nf; f++) {
         URs[f] = host_amax[NDIM * number_blocks_small + current_i * 2 * nf + f + amax_slice_offset];
-        ULs[f] = host_amax[NDIM * number_blocks_small + current_i * 2 * nf + nf + f + amax_slice_offset];
+        ULs[f] =
+            host_amax[NDIM * number_blocks_small + current_i * 2 * nf + nf + f + amax_slice_offset];
     }
     ts.ul = std::move(URs);
     ts.ur = std::move(ULs);
@@ -1238,8 +1245,8 @@ timestep_t device_interface_kokkos_hydro(executor_t& exec,
     aggregated_host_buffer<double, executor_t> P(alloc_host_double, (H_N3 + padding) * max_slices);
     aggregated_host_buffer<double, executor_t> disc(
         alloc_host_double, (ndir / 2 * H_N3 + padding) * max_slices);
-    find_contact_discs_impl(exec, agg_exec, combined_u, P, disc, physics<NDIM>::A_, physics<NDIM>::B_,
-        physics<NDIM>::fgamma_, physics<NDIM>::de_switch_1, ndir, nf,
+    find_contact_discs_impl(exec, agg_exec, combined_u, P, disc, physics<NDIM>::A_,
+        physics<NDIM>::B_, physics<NDIM>::fgamma_, physics<NDIM>::de_switch_1, ndir, nf,
         {1, 32, 8, 8}, {1, 32, 8, 8});
 
     // Pre recon

--- a/octotiger/unitiger/hydro_impl/hydro_kokkos_kernel.hpp
+++ b/octotiger/unitiger/hydro_impl/hydro_kokkos_kernel.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2021-2022 Gregor Daiß
+//  Copyright (c) 2021-2023 Gregor Daiß
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -61,8 +61,7 @@ const storage& get_flux_device_masks(executor_t& exec2, const size_t gpu_id = 0)
             stream_pool::select_device<executor_t,
                   round_robin_pool<executor_t>>(gpu_id_loop);
           executor_t exec{hpx::kokkos::execution_space_mode::independent};
-          const size_t location_id = gpu_id_loop * instances_per_gpu;
-          masks.emplace_back(location_id, NDIM * q_inx3);
+          masks.emplace_back(gpu_id_loop, NDIM * q_inx3);
           Kokkos::deep_copy(exec.instance(), masks[gpu_id_loop], tmp_masks);
           exec.instance().fence();
         }

--- a/octotiger/unitiger/hydro_impl/hydro_kokkos_kernel.hpp
+++ b/octotiger/unitiger/hydro_impl/hydro_kokkos_kernel.hpp
@@ -1138,7 +1138,7 @@ timestep_t device_interface_kokkos_hydro(
     // How many executor slices are working together and what's our ID?
     const size_t slice_id = agg_exec.id;
     const size_t number_slices = agg_exec.number_slices;
-    const size_t max_slices = opts().max_executor_slices;
+    const size_t max_slices = opts().max_kernels_fused;
 
     // Slice offsets
     const int u_slice_offset = nf * H_N3 + padding;
@@ -1300,7 +1300,7 @@ timestep_t device_interface_kokkos_hydro(
     // How many executor slices are working together and what's our ID?
     const size_t slice_id = agg_exec.id;
     const size_t number_slices = agg_exec.number_slices;
-    const size_t max_slices = opts().max_executor_slices;
+    const size_t max_slices = opts().max_kernels_fused;
 
     // Slice offsets
     const int u_slice_offset = nf * H_N3 + padding;
@@ -1445,7 +1445,7 @@ timestep_t launch_hydro_kokkos_kernels(const hydro_computer<NDIM, INX, physics<N
       // How many executor slices are working together and what's our ID?
       const size_t slice_id = agg_exec.id;
       const size_t number_slices = agg_exec.number_slices;
-      const size_t max_slices = opts().max_executor_slices;
+      const size_t max_slices = opts().max_kernels_fused;
 
       // Slice offsets
       const int u_slice_offset = hydro.get_nf() * H_N3 + padding;

--- a/octotiger/unitiger/hydro_impl/hydro_kokkos_kernel.hpp
+++ b/octotiger/unitiger/hydro_impl/hydro_kokkos_kernel.hpp
@@ -57,7 +57,7 @@ const storage& get_flux_device_masks(executor_t& exec2, const size_t gpu_id = 0)
     /* if (agg_exec.parent.gpu_id == 1) */
     if (!initialized) {
         const storage_host& tmp_masks = get_flux_host_masks<storage_host>();
-        for (int gpu_id_loop = 0; gpu_id_loop < opts().cuda_number_gpus; gpu_id_loop++) {
+        for (int gpu_id_loop = 0; gpu_id_loop < opts().number_gpus; gpu_id_loop++) {
             stream_pool::select_device<executor_t,
                   round_robin_pool<executor_t>>(gpu_id_loop);
           executor_t exec{hpx::kokkos::execution_space_mode::independent};

--- a/octotiger/unitiger/hydro_impl/hydro_kokkos_kernel.hpp
+++ b/octotiger/unitiger/hydro_impl/hydro_kokkos_kernel.hpp
@@ -57,7 +57,7 @@ const storage& get_flux_device_masks(executor_t& exec2, const size_t gpu_id = 0)
     /* if (agg_exec.parent.gpu_id == 1) */
     if (!initialized) {
         const storage_host& tmp_masks = get_flux_host_masks<storage_host>();
-        for (int gpu_id_loop = 0; gpu_id_loop < max_number_gpus; gpu_id_loop++) {
+        for (int gpu_id_loop = 0; gpu_id_loop < opts().cuda_number_gpus; gpu_id_loop++) {
             stream_pool::select_device<executor_t,
                   round_robin_pool<executor_t>>(gpu_id_loop);
           executor_t exec{hpx::kokkos::execution_space_mode::independent};

--- a/octotiger/unitiger/hydro_impl/hydro_kokkos_kernel.hpp
+++ b/octotiger/unitiger/hydro_impl/hydro_kokkos_kernel.hpp
@@ -22,6 +22,8 @@
 #include "octotiger/unitiger/hydro_impl/hydro_kernel_interface.hpp"
 #include "octotiger/unitiger/hydro_impl/reconstruct_kernel_templates.hpp"
 
+#include "octotiger/unitiger/hydro_impl/hydro_performance_counters.hpp"
+
 #ifdef HPX_HAVE_APEX
 #include <apex_api.hpp>
 #endif
@@ -1198,6 +1200,10 @@ timestep_t device_interface_kokkos_hydro(executor_t& exec,
         agg_exec, host_f, f, (NDIM * nf * q_inx3 + padding));
     fut.get();
 
+    octotiger::hydro::hydro_kokkos_gpu_subgrids_processed++;
+    if (slice_id == 0)
+        octotiger::hydro::hydro_kokkos_gpu_aggregated_subgrids_launches++;
+
     const int amax_slice_offset = NDIM * (1 + 2 * nf) * number_blocks_small * slice_id;
     const int max_indices_slice_offset = NDIM * number_blocks_small * slice_id;
 
@@ -1343,6 +1349,10 @@ timestep_t device_interface_kokkos_hydro(executor_t& exec,
     apex::stop(flux_timer);
 #endif
     sync_kokkos_host_kernel(agg_exec.get_underlying_executor());
+
+    octotiger::hydro::hydro_kokkos_cpu_subgrids_processed++;
+    if (slice_id == 0)
+        octotiger::hydro::hydro_kokkos_cpu_aggregated_subgrids_launches++;
 
 
     const int amax_slice_offset = (1 + 2 * nf) * blocks * slice_id;

--- a/octotiger/unitiger/hydro_impl/hydro_performance_counters.hpp
+++ b/octotiger/unitiger/hydro_impl/hydro_performance_counters.hpp
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <cstdint>
+#include <atomic>
+
+namespace octotiger {
+namespace hydro {
+
+extern std::atomic<std::uint64_t> hydro_cuda_gpu_subgrids_processed;
+extern std::atomic<std::uint64_t> hydro_cuda_gpu_aggregated_subgrids_launches;
+extern std::atomic<std::uint64_t> hydro_kokkos_cpu_subgrids_processed;
+extern std::atomic<std::uint64_t> hydro_kokkos_cpu_aggregated_subgrids_launches;
+extern std::atomic<std::uint64_t> hydro_kokkos_gpu_subgrids_processed;
+extern std::atomic<std::uint64_t> hydro_kokkos_gpu_aggregated_subgrids_launches;
+extern std::atomic<std::uint64_t> hydro_legacy_subgrids_processed;
+
+std::uint64_t hydro_cuda_gpu_subgrid_processed_performance_data(bool reset);
+std::uint64_t hydro_cuda_gpu_aggregated_subgrids_launches_performance_data(bool reset);
+std::uint64_t hydro_cuda_avg_aggregation_rate(bool reset);
+std::uint64_t hydro_kokkos_cpu_subgrids_processed_performance_data(bool reset);
+std::uint64_t hydro_kokkos_cpu_aggregated_subgrids_launches_performance_data(bool reset);
+std::uint64_t hydro_kokkos_cpu_avg_aggregation_rate(bool reset);
+std::uint64_t hydro_kokkos_gpu_subgrids_processed_performance_data(bool reset);
+std::uint64_t hydro_kokkos_gpu_aggregated_subgrids_launches_performance_data(bool reset);
+std::uint64_t hydro_kokkos_gpu_avg_aggregation_rate(bool reset);
+std::uint64_t hydro_legacy_subgrids_processed_performance_data(bool reset);
+
+void register_performance_counters(void);
+
+}
+}

--- a/octotiger/util/timestep_util.hpp
+++ b/octotiger/util/timestep_util.hpp
@@ -1,0 +1,57 @@
+#include <algorithm>
+#include <iostream>
+#include <numeric>
+#include <vector>
+
+/// Singleton util class to easily store the times per timestep and print them during shutdown
+class timestep_util {
+  private: 
+    std::vector<double> times_per_timestep;
+    /// Init with some space already reserved
+    timestep_util(void) {times_per_timestep.reserve(200);}
+
+    /// print the entire list of timesteps together with min,max,median and average
+    /// Called automatically in destructor
+    void print(void) {
+      if (!times_per_timestep.empty()) {
+        auto times = times_per_timestep;
+        std::size_t n = times.size() / 2;
+        std::nth_element(times.begin(), times.begin() + n, times.end());
+        double median = times[n];
+        if (times.size() % 2 == 0)
+            std::nth_element(times.begin(), times.begin() + n - 1, times.end());
+        median = 0.5 * (median + times[n - 1]);
+        std::cout << std::endl;
+        std::cout << "Time per timestep report (in seconds)" << std::endl;
+        std::cout << "-------------------------------------" << std::endl;
+        std::cout << "Min time-per-timestep: "
+                  << *(std::min_element(std::begin(times), std::end(times))) << std::endl;
+        std::cout << "Median time-per-timestep: " << median << std::endl;
+        std::cout << "Average time-per-timestep: "
+                  << std::reduce(std::begin(times), std::end(times)) /
+                  times.size() << std::endl;
+        std::cout << "Max time-per-timestep: "
+                  << *(std::max_element(std::begin(times), std::end(times))) << std::endl;
+        std::cout << "List of times-per-timestep:";
+        for (const auto time : times_per_timestep)
+            std::cout << " " << time;
+        std::cout << std::endl;
+      }
+    }
+
+    /// Singleton access
+    static timestep_util& instance(void) {
+      static timestep_util inst{};
+      return inst;
+    }
+  public:
+    
+    /// Add a timestep
+    static void add_time_per_timestep(const double runtime) {
+      instance().times_per_timestep.push_back(runtime);
+    }
+
+    /// Print when destroyed (and not empty)
+    ~timestep_util(void) {print();}
+
+};

--- a/octotiger/util/timestep_util.hpp
+++ b/octotiger/util/timestep_util.hpp
@@ -27,9 +27,11 @@ class timestep_util {
         std::cout << "Min time-per-timestep: "
                   << *(std::min_element(std::begin(times), std::end(times))) << std::endl;
         std::cout << "Median time-per-timestep: " << median << std::endl;
-        std::cout << "Average time-per-timestep: "
-                  << std::reduce(std::begin(times), std::end(times)) /
-                  times.size() << std::endl;
+        if (times.size() > 0) {
+          std::cout << "Average time-per-timestep: "
+                    << std::accumulate(std::begin(times), std::end(times), 0.0) /
+                    static_cast<float>(times.size()) << std::endl;
+        }
         std::cout << "Max time-per-timestep: "
                   << *(std::max_element(std::begin(times), std::end(times))) << std::endl;
         std::cout << "List of times-per-timestep:";

--- a/src/common_kernel/gravity_performance_counters.cpp
+++ b/src/common_kernel/gravity_performance_counters.cpp
@@ -1,0 +1,116 @@
+#include "octotiger/common_kernel/gravity_performance_counters.hpp"
+#include <hpx/include/performance_counters.hpp>
+
+namespace octotiger {
+namespace fmm {
+
+std::atomic<std::uint64_t> p2p_kokkos_cpu_subgrids_launched(0);
+std::atomic<std::uint64_t> p2p_kokkos_gpu_subgrids_launched(0);
+std::atomic<std::uint64_t> p2p_cuda_gpu_subgrids_launched(0);
+std::atomic<std::uint64_t> p2p_vc_cpu_subgrids_launched(0);
+std::atomic<std::uint64_t> p2p_legacy_cpu_subgrids_launched(0);
+
+std::atomic<std::uint64_t> multipole_kokkos_cpu_subgrids_launched(0);
+std::atomic<std::uint64_t> multipole_kokkos_gpu_subgrids_launched(0);
+std::atomic<std::uint64_t> multipole_cuda_gpu_subgrids_launched(0);
+std::atomic<std::uint64_t> multipole_vc_cpu_subgrids_launched(0);
+std::atomic<std::uint64_t> multipole_legacy_cpu_subgrids_launched(0);
+
+std::uint64_t p2p_kokkos_cpu_subgrid_processed_performance_data(bool reset) {
+    if (reset)
+        p2p_kokkos_cpu_subgrids_launched = 0;
+    return p2p_kokkos_cpu_subgrids_launched;
+}
+std::uint64_t p2p_kokkos_gpu_subgrid_processed_performance_data(bool reset) {
+    if (reset)
+        p2p_kokkos_gpu_subgrids_launched = 0;
+    return p2p_kokkos_gpu_subgrids_launched;
+}
+std::uint64_t p2p_cuda_gpu_subgrid_processed_performance_data(bool reset) {
+    if (reset)
+        p2p_cuda_gpu_subgrids_launched = 0;
+    return p2p_cuda_gpu_subgrids_launched;
+}
+std::uint64_t p2p_vc_cpu_subgrid_processed_performance_data(bool reset) {
+    if (reset)
+        p2p_vc_cpu_subgrids_launched = 0;
+    return p2p_vc_cpu_subgrids_launched;
+}
+std::uint64_t p2p_legacy_cpu_subgrid_processed_performance_data(bool reset) {
+    if (reset)
+        p2p_legacy_cpu_subgrids_launched = 0;
+    return p2p_legacy_cpu_subgrids_launched;
+}
+
+std::uint64_t multipole_kokkos_cpu_subgrid_processed_performance_data(bool reset) {
+    if (reset)
+        multipole_kokkos_cpu_subgrids_launched = 0;
+    return multipole_kokkos_cpu_subgrids_launched;
+}
+std::uint64_t multipole_kokkos_gpu_subgrid_processed_performance_data(bool reset) {
+    if (reset)
+        multipole_kokkos_gpu_subgrids_launched = 0;
+    return multipole_kokkos_gpu_subgrids_launched;
+}
+std::uint64_t multipole_cuda_gpu_subgrid_processed_performance_data(bool reset) {
+    if (reset)
+        multipole_cuda_gpu_subgrids_launched = 0;
+    return multipole_cuda_gpu_subgrids_launched;
+}
+std::uint64_t multipole_vc_cpu_subgrid_processed_performance_data(bool reset) {
+    if (reset)
+        multipole_vc_cpu_subgrids_launched = 0;
+    return multipole_vc_cpu_subgrids_launched;
+}
+std::uint64_t multipole_legacy_cpu_subgrid_processed_performance_data(bool reset) {
+    if (reset)
+        multipole_legacy_cpu_subgrids_launched = 0;
+    return multipole_legacy_cpu_subgrids_launched;
+}
+
+void register_performance_counters(void) {
+    hpx::performance_counters::install_counter_type("/octotiger/compute/gpu/p2p_cuda",
+        &p2p_cuda_gpu_subgrid_processed_performance_data,
+        "Number of calls to the fmm solver (p2p) with CUDA. Each call handles one sub-grid for one "
+        "sub-timestep");
+    hpx::performance_counters::install_counter_type("/octotiger/compute/gpu/p2p_kokkos",
+        &p2p_kokkos_gpu_subgrid_processed_performance_data,
+        "Number of calls to the fmm solver (p2p) with KOKKOS_GPU. Each call handles one sub-grid for one "
+        "sub-timestep");
+    hpx::performance_counters::install_counter_type("/octotiger/compute/cpu/p2p_kokkos",
+        &p2p_kokkos_cpu_subgrid_processed_performance_data,
+        "Number of calls to the fmm solver (p2p) with KOKKOS_CPU. Each call handles one sub-grid for one "
+        "sub-timestep");
+    hpx::performance_counters::install_counter_type("/octotiger/compute/cpu/p2p_vc",
+        &p2p_vc_cpu_subgrid_processed_performance_data,
+        "Number of calls to the fmm solver (p2p) with VC. Each call handles one sub-grid for one "
+        "sub-timestep");
+    hpx::performance_counters::install_counter_type("/octotiger/compute/cpu/p2p_legacy",
+        &p2p_legacy_cpu_subgrid_processed_performance_data,
+        "Number of calls to the fmm solver (p2p) with LEGACY. Each call handles one sub-grid for one "
+        "sub-timestep");
+
+    hpx::performance_counters::install_counter_type("/octotiger/compute/gpu/multipole_cuda",
+        &multipole_cuda_gpu_subgrid_processed_performance_data,
+        "Number of calls to the fmm solver (multipole) with CUDA. Each call handles one sub-grid for one "
+        "sub-timestep");
+    hpx::performance_counters::install_counter_type("/octotiger/compute/gpu/multipole_kokkos",
+        &multipole_kokkos_gpu_subgrid_processed_performance_data,
+        "Number of calls to the fmm solver (multipole) with KOKKOS_GPU. Each call handles one sub-grid for one "
+        "sub-timestep");
+    hpx::performance_counters::install_counter_type("/octotiger/compute/cpu/multipole_kokkos",
+        &multipole_kokkos_cpu_subgrid_processed_performance_data,
+        "Number of calls to the fmm solver (multipole) with KOKKOS_CPU. Each call handles one sub-grid for one "
+        "sub-timestep");
+    hpx::performance_counters::install_counter_type("/octotiger/compute/cpu/multipole_vc",
+        &multipole_vc_cpu_subgrid_processed_performance_data,
+        "Number of calls to the fmm solver (multipole) with VC. Each call handles one sub-grid for one "
+        "sub-timestep");
+    hpx::performance_counters::install_counter_type("/octotiger/compute/cpu/multipole_legacy",
+        &multipole_legacy_cpu_subgrid_processed_performance_data,
+        "Number of calls to the fmm solver (multipole) with LEGACY. Each call handles one sub-grid for one "
+        "sub-timestep");
+}
+
+}
+}

--- a/src/cuda_util/cuda_scheduler.cpp
+++ b/src/cuda_util/cuda_scheduler.cpp
@@ -29,7 +29,7 @@ namespace fmm {
     }
 #endif
     void init_fmm_constants() {
-        std::size_t gpu_count = max_number_gpus;
+        std::size_t gpu_count = opts().cuda_number_gpus;
         // Create necessary data and add padding
         two_phase_stencil const stencil = multipole_interactions::calculate_stencil();
         auto p2p_stencil_pair = monopole_interactions::calculate_stencil();

--- a/src/cuda_util/cuda_scheduler.cpp
+++ b/src/cuda_util/cuda_scheduler.cpp
@@ -29,7 +29,7 @@ namespace fmm {
     }
 #endif
     void init_fmm_constants() {
-        std::size_t gpu_count = opts().cuda_number_gpus;
+        std::size_t gpu_count = opts().number_gpus;
         // Create necessary data and add padding
         two_phase_stencil const stencil = multipole_interactions::calculate_stencil();
         auto p2p_stencil_pair = monopole_interactions::calculate_stencil();

--- a/src/grid.cpp
+++ b/src/grid.cpp
@@ -1917,7 +1917,7 @@ timestep_t grid::compute_fluxes() {
     
   const interaction_host_kernel_type host_type = opts().hydro_host_kernel_type;
   const interaction_device_kernel_type device_type = opts().hydro_device_kernel_type;
-  const size_t device_queue_length = opts().cuda_buffer_capacity;
+  const size_t device_queue_length = opts().max_gpu_executor_queue_length;
   return launch_hydro_kernels(hydro, U, X, omega, F, host_type, device_type, device_queue_length);
 
 }

--- a/src/monopole_interactions/legacy/cuda_monopole_interaction_interface.cpp
+++ b/src/monopole_interactions/legacy/cuda_monopole_interaction_interface.cpp
@@ -146,7 +146,7 @@ namespace fmm {
 
                 launch_p2p_cuda_kernel_post(executor, grid_spec, threads_per_block, args);
                 void* args_sum[] = {&(tmp_ergs.device_side_buffer),
-                    &(erg.device_side_buffer), &theta, &dx};
+                    &(erg.device_side_buffer)};
                 launch_sum_p2p_results_post(executor, grid_spec_sum, threads_per_block, args_sum);
 #elif defined(OCTOTIGER_HAVE_HIP)
                 hip_p2p_interactions_kernel_post(executor, grid_spec,

--- a/src/monopole_interactions/legacy/cuda_monopole_interaction_interface.cpp
+++ b/src/monopole_interactions/legacy/cuda_monopole_interaction_interface.cpp
@@ -100,7 +100,7 @@ namespace fmm {
             if (p2p_type != interaction_host_kernel_type::DEVICE_ONLY) {
                 // Check where we want to run this:
                 avail = stream_pool::interface_available<hpx::cuda::experimental::cuda_executor,
-                    pool_strategy>(opts().cuda_buffer_capacity, device_id);
+                    pool_strategy>(opts().max_gpu_executor_queue_length, device_id);
             }
 #if defined(OCTOTIGER_HAVE_HIP)
             if (contains_multipole_neighbor) // TODO Add DEVICE_ONLY error/warning

--- a/src/monopole_interactions/legacy/cuda_monopole_interaction_interface.cpp
+++ b/src/monopole_interactions/legacy/cuda_monopole_interaction_interface.cpp
@@ -3,6 +3,7 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+#include <stdexcept>
 #if defined(OCTOTIGER_HAVE_CUDA) || defined(OCTOTIGER_HAVE_HIP)
 
 #include "octotiger/monopole_interactions/legacy/cuda_monopole_interaction_interface.hpp"
@@ -108,6 +109,11 @@ namespace fmm {
                 monopole_interaction_interface::compute_interactions(monopoles, com_ptr, neighbors,
                     type, dx, is_direction_empty, grid_ptr, contains_multipole_neighbor);
             } else {
+                constexpr size_t constant_stencil_size = (FULL_STENCIL_SIZE > 1331) ? 1 : FULL_STENCIL_SIZE;
+                if constexpr (constant_stencil_size == 1) {
+                    throw std::runtime_error("Stencil is too large (theta too small)"
+                                       "Use KOKKOS_CUDA instead or recompile with larger minimal theta!");
+                }
                 // run on CUDA device
                 cuda_launch_counter()++;
 

--- a/src/monopole_interactions/legacy/cuda_monopole_interaction_interface.cpp
+++ b/src/monopole_interactions/legacy/cuda_monopole_interaction_interface.cpp
@@ -106,7 +106,6 @@ namespace fmm {
             if (contains_multipole_neighbor) // TODO Add DEVICE_ONLY error/warning
               avail = false;
 #endif
-
             if (!avail) {
                 // Run CPU implementation
                 monopole_interaction_interface::compute_interactions(monopoles, com_ptr, neighbors,
@@ -144,11 +143,6 @@ namespace fmm {
 #if defined(OCTOTIGER_HAVE_CUDA)
                 void* args[] = {&(device_local_monopoles.device_side_buffer),
                     &(tmp_ergs.device_side_buffer), &theta, &dx};
-                // hpx::apply(static_cast<hpx::cuda::experimental::cuda_executor>(executor),
-                //     cudalaunchkernel<decltype(cuda_p2p_interactions_kernel)>,
-                //     cuda_p2p_interactions_kernel, grid_spec, threads_per_block, args, 0);
-                // executor.post(cudaLaunchKernel<decltype(cuda_p2p_interactions_kernel)>,
-                //  cuda_p2p_interactions_kernel, grid_spec, threads_per_block, args, 0);
 
                 launch_p2p_cuda_kernel_post(executor, grid_spec, threads_per_block, args);
                 void* args_sum[] = {&(tmp_ergs.device_side_buffer),
@@ -184,7 +178,7 @@ namespace fmm {
                     
                     // Get and reset (as it is recycled) buffer for the angular correction results
                     // Same for all p2m kernel types
-                    device_buffer_t<double> device_erg_corrs(NUMBER_ANG_CORRECTIONS);
+                    device_buffer_t<double> device_erg_corrs(NUMBER_ANG_CORRECTIONS, device_id);
                     if (type == RHO)
                       hpx::apply(static_cast<hpx::cuda::experimental::cuda_executor>(executor),
                           cudaMemsetAsync, device_erg_corrs.device_side_buffer, 0,

--- a/src/monopole_interactions/legacy/cuda_monopole_interaction_interface.cpp
+++ b/src/monopole_interactions/legacy/cuda_monopole_interaction_interface.cpp
@@ -94,10 +94,13 @@ namespace fmm {
             std::shared_ptr<grid>& grid_ptr, const bool contains_multipole_neighbor) {
             // Check where we want to run this:
             bool avail = true;
+            size_t device_id =
+                stream_pool::get_next_device_id<hpx::cuda::experimental::cuda_executor,
+                    pool_strategy>(opts().cuda_number_gpus);
             if (p2p_type != interaction_host_kernel_type::DEVICE_ONLY) {
                 // Check where we want to run this:
                 avail = stream_pool::interface_available<hpx::cuda::experimental::cuda_executor,
-                    pool_strategy>(opts().cuda_buffer_capacity);
+                    pool_strategy>(opts().cuda_buffer_capacity, device_id);
             }
 #if defined(OCTOTIGER_HAVE_HIP)
             if (contains_multipole_neighbor) // TODO Add DEVICE_ONLY error/warning
@@ -118,10 +121,7 @@ namespace fmm {
                 cuda_launch_counter()++;
 
                 // Pick device and stream
-                size_t device_id =
-                    stream_pool::get_next_device_id<hpx::cuda::experimental::cuda_executor,
-                        pool_strategy>();
-                stream_interface<hpx::cuda::experimental::cuda_executor, pool_strategy> executor;
+                stream_interface<hpx::cuda::experimental::cuda_executor, pool_strategy> executor{device_id};
 
                 cuda_expansion_result_buffer_t potential_expansions_SoA;
                 cuda_monopole_buffer_t local_monopoles(ENTRIES);

--- a/src/monopole_interactions/legacy/cuda_monopole_interaction_interface.cpp
+++ b/src/monopole_interactions/legacy/cuda_monopole_interaction_interface.cpp
@@ -96,7 +96,7 @@ namespace fmm {
             bool avail = true;
             size_t device_id =
                 stream_pool::get_next_device_id<hpx::cuda::experimental::cuda_executor,
-                    pool_strategy>(opts().cuda_number_gpus);
+                    pool_strategy>(opts().number_gpus);
             if (p2p_type != interaction_host_kernel_type::DEVICE_ONLY) {
                 // Check where we want to run this:
                 avail = stream_pool::interface_available<hpx::cuda::experimental::cuda_executor,

--- a/src/monopole_interactions/legacy/monopole_cuda_kernel.cpp
+++ b/src/monopole_interactions/legacy/monopole_cuda_kernel.cpp
@@ -12,9 +12,13 @@
 namespace octotiger {
 namespace fmm {
     namespace monopole_interactions {
+        // This disables the constant memory optimization when the stencil gets too large
+        // Note: This renders the CUDA versions non-functional -- however there is a mechanism
+        // in place which throws an error if a user tries to use the CUDA kernel in this configuration
+        constexpr size_t constant_stencil_size = (FULL_STENCIL_SIZE > 1331) ? 1 : FULL_STENCIL_SIZE;
         // __constant__ octotiger::fmm::multiindex<> device_stencil_const[P2P_PADDED_STENCIL_SIZE];
-        __device__ __constant__ bool device_stencil_masks[FULL_STENCIL_SIZE];
-        __device__ __constant__ double device_four_constants[FULL_STENCIL_SIZE * 4];
+        __device__ __constant__ bool device_stencil_masks[constant_stencil_size];
+        __device__ __constant__ double device_four_constants[constant_stencil_size];
 
         __host__ void init_stencil(size_t gpu_id, std::unique_ptr<bool[]> stencil_masks,
             std::unique_ptr<double[]> four_constants_tmp) {

--- a/src/monopole_interactions/legacy/monopole_cuda_kernel.cpp
+++ b/src/monopole_interactions/legacy/monopole_cuda_kernel.cpp
@@ -18,7 +18,7 @@ namespace fmm {
         constexpr size_t constant_stencil_size = (FULL_STENCIL_SIZE > 1331) ? 1 : FULL_STENCIL_SIZE;
         // __constant__ octotiger::fmm::multiindex<> device_stencil_const[P2P_PADDED_STENCIL_SIZE];
         __device__ __constant__ bool device_stencil_masks[constant_stencil_size];
-        __device__ __constant__ double device_four_constants[constant_stencil_size];
+        __device__ __constant__ double device_four_constants[constant_stencil_size * 4];
 
         __host__ void init_stencil(size_t gpu_id, std::unique_ptr<bool[]> stencil_masks,
             std::unique_ptr<double[]> four_constants_tmp) {

--- a/src/monopole_interactions/legacy/monopole_interaction_interface.cpp
+++ b/src/monopole_interactions/legacy/monopole_interaction_interface.cpp
@@ -7,6 +7,7 @@
 #include "octotiger/monopole_interactions/legacy/p2m_interaction_interface.hpp"
 #include "octotiger/monopole_interactions/legacy/p2p_cpu_kernel.hpp"    //VC ?
 #include "octotiger/monopole_interactions/util/calculate_stencil.hpp"
+#include "octotiger/common_kernel/gravity_performance_counters.hpp"
 #include "octotiger/options.hpp"
 
 #include <algorithm>
@@ -110,6 +111,7 @@ namespace fmm {
 #endif
                 kernel_monopoles.apply_stencil(local_monopoles_staging_area,
                     potential_expansions_SoA, stencil_masks(), stencil_four_constants(), dx);
+                octotiger::fmm::p2p_vc_cpu_subgrids_launched++;
 #ifdef HPX_HAVE_APEX
                 apex::stop(p2p_timer);
 #endif
@@ -133,6 +135,7 @@ namespace fmm {
                         }
                     }
                 }
+                octotiger::fmm::p2p_legacy_cpu_subgrids_launched++;
 #ifdef HPX_HAVE_APEX
                 apex::stop(p2p_timer);
 #endif

--- a/src/monopole_interactions/monopole_kernel_interface.cpp
+++ b/src/monopole_interactions/monopole_kernel_interface.cpp
@@ -83,8 +83,8 @@ namespace fmm {
                     if (contains_multipole_neighbor) // TODO Add device_only warning
                         avail = false;
 #elif (defined(KOKKOS_ENABLE_CUDA) && defined(__clang__) )
-                    if (contains_multipole_neighbor && opts().detected_intel_compiler) // TODO Add device_only warning
-                        avail = false;
+                    /* if (contains_multipole_neighbor && opts().detected_intel_compiler) // TODO Add device_only warning */
+                    /*     avail = false; */
 #endif
                     if (avail) {
                         executor_interface_t executor;

--- a/src/monopole_interactions/monopole_kernel_interface.cpp
+++ b/src/monopole_interactions/monopole_kernel_interface.cpp
@@ -12,6 +12,7 @@
 #include "octotiger/common_kernel/interactions_iterators.hpp"
 #include "octotiger/monopole_interactions/legacy/monopole_interaction_interface.hpp"
 #include "octotiger/monopole_interactions/util/calculate_stencil.hpp"
+#include "octotiger/common_kernel/gravity_performance_counters.hpp"
 #include "octotiger/options.hpp"
 
 #include <algorithm>
@@ -91,6 +92,7 @@ namespace fmm {
                         monopole_kernel<device_executor>(executor, monopoles, com_ptr, neighbors,
                             type, dx, opts().theta, is_direction_empty, grid_ptr,
                             contains_multipole_neighbor);
+                        p2p_kokkos_gpu_subgrids_launched++;
                         return;
                     }
                 }
@@ -106,6 +108,7 @@ namespace fmm {
                     cuda_monopole_interaction_interface monopole_interactor{};
                     monopole_interactor.compute_interactions(monopoles, com_ptr, neighbors, type,
                         dx, is_direction_empty, grid_ptr, contains_multipole_neighbor);
+                    p2p_cuda_gpu_subgrids_launched++;
                     return;
                 }
 #else
@@ -119,6 +122,7 @@ namespace fmm {
                     cuda_monopole_interaction_interface monopole_interactor{};
                     monopole_interactor.compute_interactions(monopoles, com_ptr, neighbors, type,
                         dx, is_direction_empty, grid_ptr, contains_multipole_neighbor);
+                    p2p_cuda_gpu_subgrids_launched++;
                     return;
                 }
 #else
@@ -135,6 +139,7 @@ namespace fmm {
                 host_executor executor{hpx::kokkos::execution_space_mode::independent};
                 monopole_kernel<host_executor>(executor, monopoles, com_ptr, neighbors, type, dx,
                     opts().theta, is_direction_empty, grid_ptr, contains_multipole_neighbor);
+                p2p_kokkos_cpu_subgrids_launched++;
                 return;
 #else
                 std::cerr << "Trying to call P2P Kokkos kernel in a non-kokkos build! Aborting..."

--- a/src/monopole_interactions/monopole_kernel_interface.cpp
+++ b/src/monopole_interactions/monopole_kernel_interface.cpp
@@ -78,7 +78,7 @@ namespace fmm {
                         // Check where we want to run this:
                         avail =
                             stream_pool::interface_available<device_executor, device_pool_strategy>(
-                                opts().cuda_buffer_capacity, device_id);
+                                opts().max_gpu_executor_queue_length, device_id);
                     }
                     // TODO p2m kokkos bug - probably not enough threads for a wavefront
                     // TODO how to identify the intel sycl compile here?

--- a/src/monopole_interactions/monopole_kernel_interface.cpp
+++ b/src/monopole_interactions/monopole_kernel_interface.cpp
@@ -73,7 +73,7 @@ namespace fmm {
     defined(KOKKOS_ENABLE_HIP)|| defined(KOKKOS_ENABLE_SYCL))
                     bool avail = true;
                     size_t device_id =
-                        stream_pool::get_next_device_id<device_executor, device_pool_strategy>(opts().cuda_number_gpus);
+                        stream_pool::get_next_device_id<device_executor, device_pool_strategy>(opts().number_gpus);
                     if (host_type != interaction_host_kernel_type::DEVICE_ONLY) {
                         // Check where we want to run this:
                         avail =

--- a/src/multipole_interactions/legacy/cuda_multipole_interaction_interface.cpp
+++ b/src/multipole_interactions/legacy/cuda_multipole_interaction_interface.cpp
@@ -60,9 +60,12 @@ namespace fmm {
             std::array<bool, geo::direction::count()>& is_direction_empty,
             std::array<real, NDIM> xbase, const bool use_root_stencil) {
             bool avail = true;
+            size_t device_id =
+                stream_pool::get_next_device_id<hpx::cuda::experimental::cuda_executor,
+                    pool_strategy>(opts().cuda_number_gpus);
             if (m2m_type != interaction_host_kernel_type::DEVICE_ONLY) {
                 avail = stream_pool::interface_available<hpx::cuda::experimental::cuda_executor,
-                    pool_strategy>(opts().cuda_buffer_capacity);
+                    pool_strategy>(opts().cuda_buffer_capacity, device_id);
             }
             // if (!avail || m2m_type == interaction_host_kernel_type::LEGACY ||
             //     (use_root_stencil && !opts().root_node_on_device)) {
@@ -76,10 +79,7 @@ namespace fmm {
                 else
                     cuda_launch_counter_non_rho()++;
 
-                size_t device_id =
-                    stream_pool::get_next_device_id<hpx::cuda::experimental::cuda_executor,
-                        pool_strategy>();
-                stream_interface<hpx::cuda::experimental::cuda_executor, pool_strategy> executor;
+                stream_interface<hpx::cuda::experimental::cuda_executor, pool_strategy> executor{device_id};
 
                 cuda_monopole_buffer_t local_monopoles(ENTRIES);
                 cuda_expansion_buffer_t local_expansions_SoA;
@@ -94,7 +94,7 @@ namespace fmm {
 
 
                 device_buffer_t<double> device_erg_exp(NUMBER_POT_EXPANSIONS, device_id);
-                device_buffer_t<double> device_erg_corrs(NUMBER_ANG_CORRECTIONS);
+                device_buffer_t<double> device_erg_corrs(NUMBER_ANG_CORRECTIONS, device_id);
 
                 // Move data into SoA arrays
                 this->dX = dx;
@@ -119,7 +119,7 @@ namespace fmm {
                     block_numbers = INX;
                 }
                 device_buffer_t<double> device_tmp_erg_exp(block_numbers * NUMBER_POT_EXPANSIONS, device_id);
-                device_buffer_t<double> device_tmp_erg_corrs(block_numbers * NUMBER_ANG_CORRECTIONS);
+                device_buffer_t<double> device_tmp_erg_corrs(block_numbers * NUMBER_ANG_CORRECTIONS, device_id);
 
                 if (use_root_stencil) {
                     dim3 const grid_spec(INX, INX, 1);

--- a/src/multipole_interactions/legacy/cuda_multipole_interaction_interface.cpp
+++ b/src/multipole_interactions/legacy/cuda_multipole_interaction_interface.cpp
@@ -65,7 +65,7 @@ namespace fmm {
                     pool_strategy>(opts().number_gpus);
             if (m2m_type != interaction_host_kernel_type::DEVICE_ONLY) {
                 avail = stream_pool::interface_available<hpx::cuda::experimental::cuda_executor,
-                    pool_strategy>(opts().cuda_buffer_capacity, device_id);
+                    pool_strategy>(opts().max_gpu_executor_queue_length, device_id);
             }
             // if (!avail || m2m_type == interaction_host_kernel_type::LEGACY ||
             //     (use_root_stencil && !opts().root_node_on_device)) {

--- a/src/multipole_interactions/legacy/cuda_multipole_interaction_interface.cpp
+++ b/src/multipole_interactions/legacy/cuda_multipole_interaction_interface.cpp
@@ -62,7 +62,7 @@ namespace fmm {
             bool avail = true;
             size_t device_id =
                 stream_pool::get_next_device_id<hpx::cuda::experimental::cuda_executor,
-                    pool_strategy>(opts().cuda_number_gpus);
+                    pool_strategy>(opts().number_gpus);
             if (m2m_type != interaction_host_kernel_type::DEVICE_ONLY) {
                 avail = stream_pool::interface_available<hpx::cuda::experimental::cuda_executor,
                     pool_strategy>(opts().cuda_buffer_capacity, device_id);

--- a/src/multipole_interactions/legacy/multipole_interaction_interface.cpp
+++ b/src/multipole_interactions/legacy/multipole_interaction_interface.cpp
@@ -8,6 +8,7 @@
 #include "octotiger/multipole_interactions/util/calculate_stencil.hpp"
 
 #include "octotiger/common_kernel/interactions_iterators.hpp"
+#include "octotiger/common_kernel/gravity_performance_counters.hpp"
 
 #include "octotiger/options.hpp"
 
@@ -146,6 +147,7 @@ namespace fmm {
                 if (type == RHO) {
                     angular_corrections_SoA.to_non_SoA(grid_ptr->get_L_c());
                 }
+                octotiger::fmm::multipole_vc_cpu_subgrids_launched++;
                 potential_expansions_SoA.add_to_non_SoA(grid_ptr->get_L());
 #else    // should not happen - option gets already checked at application startup
                 std::cerr << "Tried to call Vc kernel in non-Vc build!" << std::endl;
@@ -169,6 +171,7 @@ namespace fmm {
                             neighbor_data.is_monopole, neighbor_data.data);
                     }
                 }
+                octotiger::fmm::multipole_legacy_cpu_subgrids_launched++;
 #ifdef HPX_HAVE_APEX
                 apex::stop(multipole_timer);
 #endif

--- a/src/multipole_interactions/multipole_kernel_interface.cpp
+++ b/src/multipole_interactions/multipole_kernel_interface.cpp
@@ -72,7 +72,7 @@ namespace fmm {
 #if defined(OCTOTIGER_HAVE_KOKKOS) && (defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP) || defined(KOKKOS_ENABLE_SYCL))
                     bool avail = true;
                     size_t device_id =
-                        stream_pool::get_next_device_id<device_executor, device_pool_strategy>(opts().cuda_number_gpus);
+                        stream_pool::get_next_device_id<device_executor, device_pool_strategy>(opts().number_gpus);
                     if (host_type != interaction_host_kernel_type::DEVICE_ONLY) {
                         // Check where we want to run this:
                         avail =

--- a/src/multipole_interactions/multipole_kernel_interface.cpp
+++ b/src/multipole_interactions/multipole_kernel_interface.cpp
@@ -77,7 +77,7 @@ namespace fmm {
                         // Check where we want to run this:
                         avail =
                             stream_pool::interface_available<device_executor, device_pool_strategy>(
-                                opts().cuda_buffer_capacity, device_id);
+                                opts().max_gpu_executor_queue_length, device_id);
                     }
                     if (avail) {
 

--- a/src/multipole_interactions/multipole_kernel_interface.cpp
+++ b/src/multipole_interactions/multipole_kernel_interface.cpp
@@ -11,6 +11,7 @@
 #include "octotiger/common_kernel/interactions_iterators.hpp"
 #include "octotiger/multipole_interactions/legacy/multipole_interaction_interface.hpp"
 #include "octotiger/multipole_interactions/util/calculate_stencil.hpp"
+#include "octotiger/common_kernel/gravity_performance_counters.hpp"
 #include "octotiger/options.hpp"
 
 #include <algorithm>
@@ -77,10 +78,13 @@ namespace fmm {
                                 opts().cuda_buffer_capacity);
                     }
                     if (avail) {
+
                         executor_interface_t executor;
                         multipole_kernel<device_executor>(executor, monopoles, M_ptr, com_ptr,
                             neighbors, type, dx, opts().theta, is_direction_empty, xbase, grid,
                             use_root_stencil);
+
+                        octotiger::fmm::multipole_kokkos_gpu_subgrids_launched++;
                         return;
                     }
                 }
@@ -97,6 +101,7 @@ namespace fmm {
                     multipole_interactor.set_grid_ptr(grid);
                     multipole_interactor.compute_multipole_interactions(monopoles, M_ptr, com_ptr,
                         neighbors, type, dx, is_direction_empty, xbase, use_root_stencil);
+                    octotiger::fmm::multipole_cuda_gpu_subgrids_launched++;
                     return;
                 }
 #else
@@ -111,6 +116,7 @@ namespace fmm {
                     multipole_interactor.set_grid_ptr(grid);
                     multipole_interactor.compute_multipole_interactions(monopoles, M_ptr, com_ptr,
                         neighbors, type, dx, is_direction_empty, xbase, use_root_stencil);
+                    octotiger::fmm::multipole_cuda_gpu_subgrids_launched++;
                     return;
                 }
 #else
@@ -127,6 +133,7 @@ namespace fmm {
                 host_executor executor{hpx::kokkos::execution_space_mode::independent};
                 multipole_kernel<host_executor>(executor, monopoles, M_ptr, com_ptr, neighbors,
                     type, dx, opts().theta, is_direction_empty, xbase, grid, use_root_stencil);
+                octotiger::fmm::multipole_kokkos_cpu_subgrids_launched++;
                 return;
 #else
                 std::cerr

--- a/src/multipole_interactions/multipole_kernel_interface.cpp
+++ b/src/multipole_interactions/multipole_kernel_interface.cpp
@@ -71,18 +71,20 @@ namespace fmm {
                     device_type == interaction_device_kernel_type::KOKKOS_SYCL) {
 #if defined(OCTOTIGER_HAVE_KOKKOS) && (defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP) || defined(KOKKOS_ENABLE_SYCL))
                     bool avail = true;
+                    size_t device_id =
+                        stream_pool::get_next_device_id<device_executor, device_pool_strategy>(opts().cuda_number_gpus);
                     if (host_type != interaction_host_kernel_type::DEVICE_ONLY) {
                         // Check where we want to run this:
                         avail =
                             stream_pool::interface_available<device_executor, device_pool_strategy>(
-                                opts().cuda_buffer_capacity);
+                                opts().cuda_buffer_capacity, device_id);
                     }
                     if (avail) {
 
-                        executor_interface_t executor;
+                        executor_interface_t executor{device_id};
                         multipole_kernel<device_executor>(executor, monopoles, M_ptr, com_ptr,
                             neighbors, type, dx, opts().theta, is_direction_empty, xbase, grid,
-                            use_root_stencil);
+                            use_root_stencil, device_id);
 
                         octotiger::fmm::multipole_kokkos_gpu_subgrids_launched++;
                         return;
@@ -132,7 +134,7 @@ namespace fmm {
 #ifdef OCTOTIGER_HAVE_KOKKOS
                 host_executor executor{hpx::kokkos::execution_space_mode::independent};
                 multipole_kernel<host_executor>(executor, monopoles, M_ptr, com_ptr, neighbors,
-                    type, dx, opts().theta, is_direction_empty, xbase, grid, use_root_stencil);
+                    type, dx, opts().theta, is_direction_empty, xbase, grid, use_root_stencil, 0);
                 octotiger::fmm::multipole_kokkos_cpu_subgrids_launched++;
                 return;
 #else

--- a/src/node_server.cpp
+++ b/src/node_server.cpp
@@ -393,7 +393,7 @@ void node_server::collect_hydro_boundaries(bool energy_only) {
 		if (kernel_type == AMR_CUDA)
       avail = true;
 			/* avail = stream_pool::interface_available<hpx::cuda::experimental::cuda_executor, */
-			/* 		pool_strategy>(opts().cuda_buffer_capacity); */
+			/* 		pool_strategy>(opts().max_gpu_executor_queue_length); */
 		if (!avail) { // no stream is available or flag is turned off, proceed with CPU implementations
 	#if defined __x86_64__ && defined OCTOTIGER_HAVE_VC
 			complete_hydro_amr_boundary_vc(dx, energy_only, grid_ptr->Ushad, grid_ptr->is_coarse, xmin, grid_ptr->U);

--- a/src/options_processing.cpp
+++ b/src/options_processing.cpp
@@ -172,6 +172,7 @@ bool options::process_options(int argc, char *argv[]) {
 	("max_executor_slices", po::value<size_t>(&(opts().max_executor_slices))->default_value(size_t(1)), "Can be aggregated?") //
 	("root_node_on_device", po::value<bool>(&(opts().root_node_on_device))->default_value(true), "Offload root node gravity kernels to the GPU? May degrade performance given weak GPUs") //
 	("optimize_local_communication", po::value<bool>(&(opts().optimize_local_communication))->default_value(true), "Use pointers of neighbors in local subgrids directly") //
+	("print_times_per_timestep", po::value<bool>(&(opts().print_times_per_timestep))->default_value(false), "Print times per timestep during cleanup") //
 	("input_file", po::value<std::string>(&(opts().input_file))->default_value(""), "input file for test problems") //
 	("config_file", po::value<std::string>(&(opts().config_file))->default_value(""), "configuration file") //
 	("n_species", po::value<integer>(&(opts().n_species))->default_value(5), "number of mass species") //
@@ -233,7 +234,7 @@ bool options::process_options(int argc, char *argv[]) {
 		std::cerr << "Either increase theta or recompile with a new theta minimum using the cmake parameter OCTOTIGER_THETA_MINIMUM";
 		abort();
 	}
-  opts().detected_intel_compiler=true;
+  opts().detected_intel_compiler = false;
 
 #ifdef __VERSION__
   std::string compiler_version = std::string(__VERSION__);

--- a/src/options_processing.cpp
+++ b/src/options_processing.cpp
@@ -506,7 +506,7 @@ bool options::process_options(int argc, char *argv[]) {
    if (opts().monopole_host_kernel_type == DEVICE_ONLY) {
      std::cerr << "\nWARNING: Monopole DEVICE_ONLY is currently not fully supported in HIP builds!!" << std::endl;
      std::cerr << "p2m kernel always executed on the cpu in this build..." << std::endl << std::endl;
-     sleep(10);
+     sleep(1);
    }
 
 #endif

--- a/src/options_processing.cpp
+++ b/src/options_processing.cpp
@@ -484,6 +484,19 @@ bool options::process_options(int argc, char *argv[]) {
             abort();
         }
     }
+    if (opts().executors_per_gpu < 1 && (opts().monopole_device_kernel_type != OFF ||
+          opts().multipole_device_kernel_type != OFF || opts().hydro_device_kernel_type != OFF)) {
+        std::cerr << std::endl << "ERROR: "; 
+        std::cerr << "You have chosen an GPU kernel, however, you did not specify --executor_per_gpu > 0" << std::endl
+        << " Choose a different kernel or add at least one or more executors via --executor_per_gpu=X" << std::endl;
+        abort();
+    }
+    if (opts().max_kernels_fused < 1 && (opts().monopole_device_kernel_type != OFF ||
+          opts().multipole_device_kernel_type != OFF || opts().hydro_device_kernel_type != OFF)) {
+        std::cerr << std::endl << "ERROR: "; 
+        std::cerr << "minimum value for --max_kernels_fused is 1 when a GPU kernel is active!" << std::endl;
+        abort();
+    }
     if (opts().monopole_device_kernel_type == OFF && opts().monopole_host_kernel_type == DEVICE_ONLY ||
         opts().multipole_device_kernel_type == OFF && opts().multipole_host_kernel_type == DEVICE_ONLY ||
 	opts().hydro_device_kernel_type == OFF && opts().hydro_host_kernel_type == DEVICE_ONLY) {

--- a/src/options_processing.cpp
+++ b/src/options_processing.cpp
@@ -365,13 +365,6 @@ bool options::process_options(int argc, char *argv[]) {
 	}
     // Check parameters if we hit any implementation limitation as in
     // unsupported kernel configurations
-    if (opts().cuda_number_gpus > 1) {
-        std::cerr << std::endl << "ERROR: "; 
-        std::cerr << "Currently there is no multi-GPU support. " << std::endl;
-        std::cerr << "To use multiple GPUs per node, use one HPX locality per GPU " 
-                  << "and use slurm or CUDA_VISIBLE_DEVICES to have each locality access a different GPU" << std::endl;
-        abort();
-    }
     if (opts().gravity) {
 #ifdef OCTOTIGER_DISABLE_ILIST
         std::cerr << "ERROR! Gravity is turned on but Octo-Tiger was compiled without interaction list" << std::endl

--- a/src/options_processing.cpp
+++ b/src/options_processing.cpp
@@ -170,7 +170,7 @@ bool options::process_options(int argc, char *argv[]) {
 	("executors_per_gpu", po::value<size_t>(&(opts().executors_per_gpu))->default_value(size_t(0)), "cuda streams per GPU (per locality)") //
 	("max_gpu_executor_queue_length", po::value<size_t>(&(opts().max_gpu_executor_queue_length))->default_value(size_t(5)), "How many launches should be buffered before using the CPU") //
 ("polling-threads", po::value<int>(&(opts().polling_threads))->default_value(0), "Enable dedicated HPX thread pool for cuda/network polling using N threads!") //
-	("max_executor_slices", po::value<size_t>(&(opts().max_executor_slices))->default_value(size_t(1)), "Can be aggregated?") //
+	("max_kernels_fused", po::value<size_t>(&(opts().max_kernels_fused))->default_value(size_t(1)), "Maximum numbers of kernels combined into one by the dynamic work aggegation") //
 	("root_node_on_device", po::value<bool>(&(opts().root_node_on_device))->default_value(true), "Offload root node gravity kernels to the GPU? May degrade performance given weak GPUs") //
 	("optimize_local_communication", po::value<bool>(&(opts().optimize_local_communication))->default_value(true), "Use pointers of neighbors in local subgrids directly") //
 	("print_times_per_timestep", po::value<bool>(&(opts().print_times_per_timestep))->default_value(false), "Print times per timestep during cleanup") //
@@ -331,7 +331,7 @@ bool options::process_options(int argc, char *argv[]) {
 		SHOW(number_gpus);
 		SHOW(executors_per_gpu);
 		SHOW(max_gpu_executor_queue_length);
-		SHOW(max_executor_slices);
+		SHOW(max_kernels_fused);
 		SHOW(amr_boundary_kernel_type);
 		SHOW(root_node_on_device);
 		SHOW(optimize_local_communication);
@@ -512,7 +512,7 @@ bool options::process_options(int argc, char *argv[]) {
 #endif
 #endif
 
-   if (opts().hydro_host_kernel_type == KOKKOS && opts().max_executor_slices > 1) {
+   if (opts().hydro_host_kernel_type == KOKKOS && opts().max_kernels_fused > 1) {
      std::cerr << "\nERROR: work aggregation not yet supported for Kokkos host kernel!" << std::endl;
      abort();
    }

--- a/src/options_processing.cpp
+++ b/src/options_processing.cpp
@@ -167,7 +167,7 @@ bool options::process_options(int argc, char *argv[]) {
 	("hydro_device_kernel_type", po::value<interaction_device_kernel_type>(&(opts().hydro_device_kernel_type))->default_value(OFF), "Device kernel type for the hydro solver ") //
 #endif
 	("number_gpus", po::value<size_t>(&(opts().number_gpus))->default_value(size_t(0)), "cuda streams per HPX locality") //
-	("cuda_streams_per_gpu", po::value<size_t>(&(opts().cuda_streams_per_gpu))->default_value(size_t(0)), "cuda streams per GPU (per locality)") //
+	("executors_per_gpu", po::value<size_t>(&(opts().executors_per_gpu))->default_value(size_t(0)), "cuda streams per GPU (per locality)") //
 	("cuda_buffer_capacity", po::value<size_t>(&(opts().cuda_buffer_capacity))->default_value(size_t(5)), "How many launches should be buffered before using the CPU") //
 ("polling-threads", po::value<int>(&(opts().polling_threads))->default_value(0), "Enable dedicated HPX thread pool for cuda/network polling using N threads!") //
 	("max_executor_slices", po::value<size_t>(&(opts().max_executor_slices))->default_value(size_t(1)), "Can be aggregated?") //
@@ -228,7 +228,7 @@ bool options::process_options(int argc, char *argv[]) {
 		}
 		load_options_from_silo(opts().restart_filename);
 	}
-    if (opts().cuda_streams_per_gpu > 0 && opts().number_gpus == 0) {
+    if (opts().executors_per_gpu > 0 && opts().number_gpus == 0) {
         opts().number_gpus = 1;
 	}
 	if (opts().theta < octotiger::fmm::THETA_FLOOR) {
@@ -329,7 +329,7 @@ bool options::process_options(int argc, char *argv[]) {
 		SHOW(idle_rates);
 		SHOW(xscale);
 		SHOW(number_gpus);
-		SHOW(cuda_streams_per_gpu);
+		SHOW(executors_per_gpu);
 		SHOW(cuda_buffer_capacity);
 		SHOW(max_executor_slices);
 		SHOW(amr_boundary_kernel_type);

--- a/src/options_processing.cpp
+++ b/src/options_processing.cpp
@@ -168,7 +168,7 @@ bool options::process_options(int argc, char *argv[]) {
 #endif
 	("number_gpus", po::value<size_t>(&(opts().number_gpus))->default_value(size_t(0)), "cuda streams per HPX locality") //
 	("executors_per_gpu", po::value<size_t>(&(opts().executors_per_gpu))->default_value(size_t(0)), "cuda streams per GPU (per locality)") //
-	("cuda_buffer_capacity", po::value<size_t>(&(opts().cuda_buffer_capacity))->default_value(size_t(5)), "How many launches should be buffered before using the CPU") //
+	("max_gpu_executor_queue_length", po::value<size_t>(&(opts().max_gpu_executor_queue_length))->default_value(size_t(5)), "How many launches should be buffered before using the CPU") //
 ("polling-threads", po::value<int>(&(opts().polling_threads))->default_value(0), "Enable dedicated HPX thread pool for cuda/network polling using N threads!") //
 	("max_executor_slices", po::value<size_t>(&(opts().max_executor_slices))->default_value(size_t(1)), "Can be aggregated?") //
 	("root_node_on_device", po::value<bool>(&(opts().root_node_on_device))->default_value(true), "Offload root node gravity kernels to the GPU? May degrade performance given weak GPUs") //
@@ -330,7 +330,7 @@ bool options::process_options(int argc, char *argv[]) {
 		SHOW(xscale);
 		SHOW(number_gpus);
 		SHOW(executors_per_gpu);
-		SHOW(cuda_buffer_capacity);
+		SHOW(max_gpu_executor_queue_length);
 		SHOW(max_executor_slices);
 		SHOW(amr_boundary_kernel_type);
 		SHOW(root_node_on_device);

--- a/src/options_processing.cpp
+++ b/src/options_processing.cpp
@@ -166,7 +166,7 @@ bool options::process_options(int argc, char *argv[]) {
 	("hydro_host_kernel_type", po::value<interaction_host_kernel_type>(&(opts().hydro_host_kernel_type))->default_value(LEGACY), "Host kernel type for the hydro solver ") //
 	("hydro_device_kernel_type", po::value<interaction_device_kernel_type>(&(opts().hydro_device_kernel_type))->default_value(OFF), "Device kernel type for the hydro solver ") //
 #endif
-	("cuda_number_gpus", po::value<size_t>(&(opts().cuda_number_gpus))->default_value(size_t(0)), "cuda streams per HPX locality") //
+	("number_gpus", po::value<size_t>(&(opts().number_gpus))->default_value(size_t(0)), "cuda streams per HPX locality") //
 	("cuda_streams_per_gpu", po::value<size_t>(&(opts().cuda_streams_per_gpu))->default_value(size_t(0)), "cuda streams per GPU (per locality)") //
 	("cuda_buffer_capacity", po::value<size_t>(&(opts().cuda_buffer_capacity))->default_value(size_t(5)), "How many launches should be buffered before using the CPU") //
 ("polling-threads", po::value<int>(&(opts().polling_threads))->default_value(0), "Enable dedicated HPX thread pool for cuda/network polling using N threads!") //
@@ -228,8 +228,8 @@ bool options::process_options(int argc, char *argv[]) {
 		}
 		load_options_from_silo(opts().restart_filename);
 	}
-    if (opts().cuda_streams_per_gpu > 0 && opts().cuda_number_gpus == 0) {
-        opts().cuda_number_gpus = 1;
+    if (opts().cuda_streams_per_gpu > 0 && opts().number_gpus == 0) {
+        opts().number_gpus = 1;
 	}
 	if (opts().theta < octotiger::fmm::THETA_FLOOR) {
 		std::cerr << "theta " << theta << " is too small since Octo-Tiger was compiled for a minimum of " << octotiger::fmm::THETA_FLOOR << std::endl;
@@ -328,7 +328,7 @@ bool options::process_options(int argc, char *argv[]) {
 		SHOW(v1309);
 		SHOW(idle_rates);
 		SHOW(xscale);
-		SHOW(cuda_number_gpus);
+		SHOW(number_gpus);
 		SHOW(cuda_streams_per_gpu);
 		SHOW(cuda_buffer_capacity);
 		SHOW(max_executor_slices);

--- a/src/options_processing.cpp
+++ b/src/options_processing.cpp
@@ -169,6 +169,7 @@ bool options::process_options(int argc, char *argv[]) {
 	("cuda_number_gpus", po::value<size_t>(&(opts().cuda_number_gpus))->default_value(size_t(0)), "cuda streams per HPX locality") //
 	("cuda_streams_per_gpu", po::value<size_t>(&(opts().cuda_streams_per_gpu))->default_value(size_t(0)), "cuda streams per GPU (per locality)") //
 	("cuda_buffer_capacity", po::value<size_t>(&(opts().cuda_buffer_capacity))->default_value(size_t(5)), "How many launches should be buffered before using the CPU") //
+("polling-threads", po::value<int>(&(opts().polling_threads))->default_value(0), "Enable dedicated HPX thread pool for cuda/network polling using N threads!") \\
 	("max_executor_slices", po::value<size_t>(&(opts().max_executor_slices))->default_value(size_t(1)), "Can be aggregated?") //
 	("root_node_on_device", po::value<bool>(&(opts().root_node_on_device))->default_value(true), "Offload root node gravity kernels to the GPU? May degrade performance given weak GPUs") //
 	("optimize_local_communication", po::value<bool>(&(opts().optimize_local_communication))->default_value(true), "Use pointers of neighbors in local subgrids directly") //
@@ -188,7 +189,8 @@ bool options::process_options(int argc, char *argv[]) {
 			;
 
 	boost::program_options::variables_map vm;
-	po::store(po::parse_command_line(argc, argv, command_opts), vm);
+	//po::store(po::parse_command_line(argc, argv, command_opts), vm);
+  po::store(po::command_line_parser(argc, argv).options(command_opts).allow_unregistered().run(), vm);
 	po::notify(vm);
 	if (vm.count("help")) {
 		std::cout << command_opts << "\n";

--- a/src/unitiger/hydro_impl/hydro_boundary_exchange.cpp
+++ b/src/unitiger/hydro_impl/hydro_boundary_exchange.cpp
@@ -24,7 +24,7 @@ using amr_cuda_agg_executor_pool = aggregation_pool<amr_cuda_kernel_identifier, 
 hpx::once_flag init_pool_flag;
 
 void init_aggregation_pool(void) {
-    const size_t max_slices = opts().max_executor_slices;
+    const size_t max_slices = opts().max_kernels_fused;
     constexpr size_t number_aggregation_executors = 16;
     constexpr Aggregated_Executor_Modes executor_mode = Aggregated_Executor_Modes::EAGER;
     amr_cuda_agg_executor_pool::init(number_aggregation_executors, max_slices, executor_mode);
@@ -69,7 +69,7 @@ __host__ void launch_complete_hydro_amr_boundary_cuda(double dx, bool
             exec_slice.template make_allocator<int, recycler::detail::cuda_device_allocator<int>>();
         int nfields = opts().n_fields;
 
-        const size_t max_slices = opts().max_executor_slices;
+        const size_t max_slices = opts().max_kernels_fused;
         // Create host buffers
         std::vector<double, decltype(alloc_host_double)> unified_uf(
             max_slices * opts().n_fields * HS_N3 * 8, double{},

--- a/src/unitiger/hydro_impl/hydro_boundary_exchange.cpp
+++ b/src/unitiger/hydro_impl/hydro_boundary_exchange.cpp
@@ -88,18 +88,18 @@ __host__ void launch_complete_hydro_amr_boundary_cuda(double dx, bool
 
         // Create device buffers
         recycler::cuda_aggregated_device_buffer<double, decltype(alloc_device_double)> device_uf(
-            max_slices * opts().n_fields * HS_N3 * 8, 0, alloc_device_double);
+            max_slices * opts().n_fields * HS_N3 * 8, alloc_device_double);
         recycler::cuda_aggregated_device_buffer<double, decltype(alloc_device_double)> device_ushad(
-            max_slices * opts().n_fields * HS_N3, 0, alloc_device_double);
+            max_slices * opts().n_fields * HS_N3, alloc_device_double);
         recycler::cuda_aggregated_device_buffer<int, decltype(alloc_device_int)> device_coarse(
-            max_slices * HS_N3, 0, alloc_device_int);
+            max_slices * HS_N3, alloc_device_int);
         recycler::cuda_aggregated_device_buffer<double, decltype(alloc_device_double)> device_xmin(
-            max_slices * NDIM, 0, alloc_device_double);
+            max_slices * NDIM, alloc_device_double);
 
         recycler::cuda_aggregated_device_buffer<int, decltype(alloc_device_int)> energy_only_device(
-            max_slices * 1, 0, alloc_device_int);
+            max_slices * 1, alloc_device_int);
         recycler::cuda_aggregated_device_buffer<double, decltype(alloc_device_double)> dx_device(
-            max_slices * 1, 0, alloc_device_double);
+            max_slices * 1, alloc_device_double);
 
         for (int d = 0; d < NDIM; d++) {
             x_min[d + slice_id * NDIM] = xmin[d];
@@ -188,7 +188,7 @@ __host__ void launch_complete_hydro_amr_boundary_cuda(double dx, bool
         /* } */ 
 
         recycler::cuda_aggregated_device_buffer<double, decltype(alloc_device_double)> device_u(
-            max_slices * nfields * H_N3, 0, alloc_device_double);
+            max_slices * nfields * H_N3, alloc_device_double);
         std::vector<double, decltype(alloc_host_double)> unified_u(
             max_slices * nfields * H_N3, double{},
             alloc_host_double);

--- a/src/unitiger/hydro_impl/hydro_cuda_interface.cpp
+++ b/src/unitiger/hydro_impl/hydro_cuda_interface.cpp
@@ -82,7 +82,7 @@ void init_hydro_aggregation_pool(void) {
 __host__ void init_gpu_masks(std::array<bool*, max_number_gpus>& masks) {
     boost::container::vector<bool> masks_boost(NDIM * q_inx * q_inx * q_inx);
     fill_masks(masks_boost);
-    for (size_t gpu_id = 0; gpu_id < max_number_gpus; gpu_id++) {
+    for (size_t gpu_id = 0; gpu_id < opts().cuda_number_gpus; gpu_id++) {
       const size_t location_id = 0;
 #if defined(OCTOTIGER_HAVE_CUDA)
       masks[gpu_id] = recycler::detail::buffer_recycler::get<bool,

--- a/src/unitiger/hydro_impl/hydro_cuda_interface.cpp
+++ b/src/unitiger/hydro_impl/hydro_cuda_interface.cpp
@@ -76,13 +76,13 @@ void init_hydro_aggregation_pool(void) {
     constexpr size_t number_aggregation_executors = 16;
     constexpr Aggregated_Executor_Modes executor_mode = Aggregated_Executor_Modes::EAGER;
     hydro_cuda_agg_executor_pool::init(number_aggregation_executors, max_slices,
-        executor_mode, opts().cuda_number_gpus);
+        executor_mode, opts().number_gpus);
 }
 
 __host__ void init_gpu_masks(std::array<bool*, recycler::max_number_gpus>& masks) {
     boost::container::vector<bool> masks_boost(NDIM * q_inx * q_inx * q_inx);
     fill_masks(masks_boost);
-    for (size_t gpu_id = 0; gpu_id < opts().cuda_number_gpus; gpu_id++) {
+    for (size_t gpu_id = 0; gpu_id < opts().number_gpus; gpu_id++) {
       const size_t location_id = 0;
 #if defined(OCTOTIGER_HAVE_CUDA)
       masks[gpu_id] = recycler::detail::buffer_recycler::get<bool,

--- a/src/unitiger/hydro_impl/hydro_cuda_interface.cpp
+++ b/src/unitiger/hydro_impl/hydro_cuda_interface.cpp
@@ -23,6 +23,8 @@
 #include "octotiger/unitiger/hydro_impl/reconstruct_kernel_interface.hpp"
 #include "octotiger/unitiger/hydro_impl/reconstruct_kernel_templates.hpp"    // required for constants
 
+#include "octotiger/unitiger/hydro_impl/hydro_performance_counters.hpp"
+
 static const char hydro_cuda_kernel_identifier[] = "hydro_kernel_aggregator_cuda";
 using hydro_cuda_agg_executor_pool = aggregation_pool<hydro_cuda_kernel_identifier,
     hpx::cuda::experimental::cuda_executor, pool_strategy>;
@@ -317,6 +319,11 @@ timestep_t launch_hydro_cuda_kernels(const hydro_computer<NDIM, INX, physics<NDI
               number_slices * (NDIM * nf_local * q_inx3 + 128) *
               sizeof(double),
               cudaMemcpyDeviceToHost);
+
+      octotiger::hydro::hydro_cuda_gpu_subgrids_processed++;
+      if(slice_id == 0)
+        octotiger::hydro::hydro_cuda_gpu_aggregated_subgrids_launches++;
+
       flux_kernel_fut.get();
 
       // Find Maximum

--- a/src/unitiger/hydro_impl/hydro_cuda_interface.cpp
+++ b/src/unitiger/hydro_impl/hydro_cuda_interface.cpp
@@ -79,7 +79,7 @@ void init_hydro_aggregation_pool(void) {
         executor_mode, opts().cuda_number_gpus);
 }
 
-__host__ void init_gpu_masks(std::array<bool*, max_number_gpus>& masks) {
+__host__ void init_gpu_masks(std::array<bool*, recycler::max_number_gpus>& masks) {
     boost::container::vector<bool> masks_boost(NDIM * q_inx * q_inx * q_inx);
     fill_masks(masks_boost);
     for (size_t gpu_id = 0; gpu_id < opts().cuda_number_gpus; gpu_id++) {
@@ -98,7 +98,7 @@ __host__ void init_gpu_masks(std::array<bool*, max_number_gpus>& masks) {
 }
 
 __host__ bool* get_gpu_masks(const size_t gpu_id = 0) {
-    static std::array<bool*, max_number_gpus> masks;
+    static std::array<bool*, recycler::max_number_gpus> masks;
     hpx::call_once(flag1, init_gpu_masks, masks);
     return masks[gpu_id];
 }

--- a/src/unitiger/hydro_impl/hydro_cuda_interface.cpp
+++ b/src/unitiger/hydro_impl/hydro_cuda_interface.cpp
@@ -72,7 +72,7 @@ using aggregated_host_buffer_t = std::vector<T, Alloc>;
 #endif
 
 void init_hydro_aggregation_pool(void) {
-    const size_t max_slices = opts().max_executor_slices;
+    const size_t max_slices = opts().max_kernels_fused;
     constexpr size_t number_aggregation_executors = 16;
     constexpr Aggregated_Executor_Modes executor_mode = Aggregated_Executor_Modes::EAGER;
     hydro_cuda_agg_executor_pool::init(number_aggregation_executors, max_slices,
@@ -139,7 +139,7 @@ timestep_t launch_hydro_cuda_kernels(const hydro_computer<NDIM, INX, physics<NDI
 
       static const cell_geometry<NDIM, INX> geo;
 
-      const size_t max_slices = opts().max_executor_slices;
+      const size_t max_slices = opts().max_kernels_fused;
 
       // Move input to device
       aggregated_host_buffer_t<double, decltype(alloc_host_double)> combined_u(

--- a/src/unitiger/hydro_impl/hydro_cuda_interface.cpp
+++ b/src/unitiger/hydro_impl/hydro_cuda_interface.cpp
@@ -75,7 +75,8 @@ void init_hydro_aggregation_pool(void) {
     const size_t max_slices = opts().max_executor_slices;
     constexpr size_t number_aggregation_executors = 16;
     constexpr Aggregated_Executor_Modes executor_mode = Aggregated_Executor_Modes::EAGER;
-    hydro_cuda_agg_executor_pool::init(number_aggregation_executors, max_slices, executor_mode);
+    hydro_cuda_agg_executor_pool::init(number_aggregation_executors, max_slices,
+        executor_mode, opts().cuda_number_gpus);
 }
 
 __host__ void init_gpu_masks(std::array<bool*, max_number_gpus>& masks) {

--- a/src/unitiger/hydro_impl/hydro_kernel_interface.cpp
+++ b/src/unitiger/hydro_impl/hydro_kernel_interface.cpp
@@ -35,7 +35,7 @@ using host_executor = hpx::kokkos::hpx_executor;
 using host_executor = hpx::kokkos::serial_executor;
 #endif
 void init_hydro_kokkos_aggregation_pool(void) {
-    const size_t max_slices = opts().max_executor_slices;
+    const size_t max_slices = opts().max_kernels_fused;
     constexpr size_t number_aggregation_executors = 128;
     Aggregated_Executor_Modes executor_mode = Aggregated_Executor_Modes::EAGER;
     if (max_slices == 1) {

--- a/src/unitiger/hydro_impl/hydro_kernel_interface.cpp
+++ b/src/unitiger/hydro_impl/hydro_kernel_interface.cpp
@@ -43,11 +43,11 @@ void init_hydro_kokkos_aggregation_pool(void) {
     }
     if (opts().cuda_streams_per_gpu > 0) {
 #if defined(KOKKOS_ENABLE_CUDA)
-    hydro_kokkos_agg_executor_pool<hpx::kokkos::cuda_executor>::init(number_aggregation_executors, max_slices, executor_mode);
+    hydro_kokkos_agg_executor_pool<hpx::kokkos::cuda_executor>::init(number_aggregation_executors, max_slices, executor_mode, opts().cuda_number_gpus);
 #elif defined(KOKKOS_ENABLE_HIP)
-    hydro_kokkos_agg_executor_pool<hpx::kokkos::hip_executor>::init(number_aggregation_executors, max_slices, executor_mode);
+    hydro_kokkos_agg_executor_pool<hpx::kokkos::hip_executor>::init(number_aggregation_executors, max_slices, executor_mode, opts().cuda_number_gpus);
 #elif defined(KOKKOS_ENABLE_SYCL)
-    hydro_kokkos_agg_executor_pool<hpx::kokkos::sycl_executor>::init(number_aggregation_executors, max_slices, executor_mode);
+    hydro_kokkos_agg_executor_pool<hpx::kokkos::sycl_executor>::init(number_aggregation_executors, max_slices, executor_mode, opts().cuda_number_gpus);
 #endif
     }
     hydro_kokkos_agg_executor_pool<host_executor>::init(number_aggregation_executors, max_slices, executor_mode);

--- a/src/unitiger/hydro_impl/hydro_kernel_interface.cpp
+++ b/src/unitiger/hydro_impl/hydro_kernel_interface.cpp
@@ -7,6 +7,7 @@
 //#undef NDEBUG
 #include "octotiger/unitiger/hydro_impl/hydro_kernel_interface.hpp"
 #include "octotiger/unitiger/hydro_impl/flux_kernel_interface.hpp"
+#include "octotiger/unitiger/hydro_impl/hydro_performance_counters.hpp"
 #ifdef OCTOTIGER_HAVE_KOKKOS
 #include <hpx/kokkos/executors.hpp>
 #include <hpx/kokkos.hpp>
@@ -165,6 +166,7 @@ timestep_t launch_hydro_kernels(hydro_computer<NDIM, INX, physics<NDIM>>& hydro,
         auto flux_timer = apex::start("kernel hydro_flux legacy");
 #endif
         max_lambda = hydro.flux(U, q, f, X, omega);
+        octotiger::hydro::hydro_legacy_subgrids_processed++;
 #ifdef HPX_HAVE_APEX
         apex::stop(flux_timer);
 #endif

--- a/src/unitiger/hydro_impl/hydro_kernel_interface.cpp
+++ b/src/unitiger/hydro_impl/hydro_kernel_interface.cpp
@@ -43,11 +43,11 @@ void init_hydro_kokkos_aggregation_pool(void) {
     }
     if (opts().cuda_streams_per_gpu > 0) {
 #if defined(KOKKOS_ENABLE_CUDA)
-    hydro_kokkos_agg_executor_pool<hpx::kokkos::cuda_executor>::init(number_aggregation_executors, max_slices, executor_mode, opts().cuda_number_gpus);
+    hydro_kokkos_agg_executor_pool<hpx::kokkos::cuda_executor>::init(number_aggregation_executors, max_slices, executor_mode, opts().number_gpus);
 #elif defined(KOKKOS_ENABLE_HIP)
-    hydro_kokkos_agg_executor_pool<hpx::kokkos::hip_executor>::init(number_aggregation_executors, max_slices, executor_mode, opts().cuda_number_gpus);
+    hydro_kokkos_agg_executor_pool<hpx::kokkos::hip_executor>::init(number_aggregation_executors, max_slices, executor_mode, opts().number_gpus);
 #elif defined(KOKKOS_ENABLE_SYCL)
-    hydro_kokkos_agg_executor_pool<hpx::kokkos::sycl_executor>::init(number_aggregation_executors, max_slices, executor_mode, opts().cuda_number_gpus);
+    hydro_kokkos_agg_executor_pool<hpx::kokkos::sycl_executor>::init(number_aggregation_executors, max_slices, executor_mode, opts().number_gpus);
 #endif
     }
     hydro_kokkos_agg_executor_pool<host_executor>::init(number_aggregation_executors, max_slices, executor_mode, 1);

--- a/src/unitiger/hydro_impl/hydro_kernel_interface.cpp
+++ b/src/unitiger/hydro_impl/hydro_kernel_interface.cpp
@@ -133,8 +133,13 @@ timestep_t launch_hydro_kernels(hydro_computer<NDIM, INX, physics<NDIM>>& hydro,
 #ifdef OCTOTIGER_HAVE_HIP
             bool avail = true;
             if (host_type != interaction_host_kernel_type::DEVICE_ONLY) {
-              avail = stream_pool::interface_available<hpx::cuda::experimental::cuda_executor,
-                  pool_strategy>(cuda_buffer_capacity);
+              // TODO CPU/GPU currently not working with work aggregation 
+              /* avail = stream_pool::interface_available<hpx::cuda::experimental::cuda_executor, */
+              /*     pool_strategy>(cuda_buffer_capacity); */
+              std::cerr << "hydro_host_kernel_type should be DEVICE_ONLY when hydro_device_kernel_type != OFF "
+                           "Aborting..."
+                        << std::endl;
+              abort();
             }
             if (avail) {
                 size_t device_id = 0;

--- a/src/unitiger/hydro_impl/hydro_kernel_interface.cpp
+++ b/src/unitiger/hydro_impl/hydro_kernel_interface.cpp
@@ -41,7 +41,7 @@ void init_hydro_kokkos_aggregation_pool(void) {
     if (max_slices == 1) {
       executor_mode = Aggregated_Executor_Modes::STRICT;
     }
-    if (opts().cuda_streams_per_gpu > 0) {
+    if (opts().executors_per_gpu > 0) {
 #if defined(KOKKOS_ENABLE_CUDA)
     hydro_kokkos_agg_executor_pool<hpx::kokkos::cuda_executor>::init(number_aggregation_executors, max_slices, executor_mode, opts().number_gpus);
 #elif defined(KOKKOS_ENABLE_HIP)

--- a/src/unitiger/hydro_impl/hydro_kernel_interface.cpp
+++ b/src/unitiger/hydro_impl/hydro_kernel_interface.cpp
@@ -60,7 +60,7 @@ timestep_t launch_hydro_kernels(hydro_computer<NDIM, INX, physics<NDIM>>& hydro,
     const std::vector<std::vector<safe_real>>& U, std::vector<std::vector<safe_real>>& X,
     const double omega, std::vector<hydro_state_t<std::vector<safe_real>>>& F,
     const interaction_host_kernel_type host_type, const interaction_device_kernel_type device_type,
-    const size_t cuda_buffer_capacity) {
+    const size_t max_gpu_executor_queue_length) {
     static const cell_geometry<NDIM, INX> geo;
 
     // interaction_host_kernel_type host_type = opts().hydro_host_kernel_type;
@@ -83,7 +83,7 @@ timestep_t launch_hydro_kernels(hydro_computer<NDIM, INX, physics<NDIM>>& hydro,
             if (host_type != interaction_host_kernel_type::DEVICE_ONLY) {
                 // TODO CPU/GPU currently not working with work aggregation 
                 /* avail = stream_pool::interface_available<device_executor, device_pool_strategy>( */
-                /*     cuda_buffer_capacity); */
+                /*     max_gpu_executor_queue_length); */
                 std::cerr << "hydro_host_kernel_type should be DEVICE_ONLY when hydro_device_kernel_type != OFF "
                              "Aborting..."
                           << std::endl;
@@ -111,7 +111,7 @@ timestep_t launch_hydro_kernels(hydro_computer<NDIM, INX, physics<NDIM>>& hydro,
             if (host_type != interaction_host_kernel_type::DEVICE_ONLY) {
                 // TODO CPU/GPU currently not working with work aggregation 
                 /* avail = stream_pool::interface_available<hpx::cuda::experimental::cuda_executor, */
-                /*     pool_strategy>(cuda_buffer_capacity); */
+                /*     pool_strategy>(max_gpu_executor_queue_length); */
                 std::cerr << "hydro_host_kernel_type should be DEVICE_ONLY when hydro_device_kernel_type != OFF "
                              "Aborting..."
                           << std::endl;
@@ -135,7 +135,7 @@ timestep_t launch_hydro_kernels(hydro_computer<NDIM, INX, physics<NDIM>>& hydro,
             if (host_type != interaction_host_kernel_type::DEVICE_ONLY) {
               // TODO CPU/GPU currently not working with work aggregation 
               /* avail = stream_pool::interface_available<hpx::cuda::experimental::cuda_executor, */
-              /*     pool_strategy>(cuda_buffer_capacity); */
+              /*     pool_strategy>(max_gpu_executor_queue_length); */
               std::cerr << "hydro_host_kernel_type should be DEVICE_ONLY when hydro_device_kernel_type != OFF "
                            "Aborting..."
                         << std::endl;

--- a/src/unitiger/hydro_impl/hydro_kernel_interface.cpp
+++ b/src/unitiger/hydro_impl/hydro_kernel_interface.cpp
@@ -50,7 +50,7 @@ void init_hydro_kokkos_aggregation_pool(void) {
     hydro_kokkos_agg_executor_pool<hpx::kokkos::sycl_executor>::init(number_aggregation_executors, max_slices, executor_mode, opts().cuda_number_gpus);
 #endif
     }
-    hydro_kokkos_agg_executor_pool<host_executor>::init(number_aggregation_executors, max_slices, executor_mode);
+    hydro_kokkos_agg_executor_pool<host_executor>::init(number_aggregation_executors, max_slices, executor_mode, 1);
 }
 #endif
 
@@ -81,13 +81,18 @@ timestep_t launch_hydro_kernels(hydro_computer<NDIM, INX, physics<NDIM>>& hydro,
             // Host execution is possible: Check if there is a launch slot for device - if not 
             // we will execute the kernel on the CPU instead
             if (host_type != interaction_host_kernel_type::DEVICE_ONLY) {
-                avail = stream_pool::interface_available<device_executor, device_pool_strategy>(
-                    cuda_buffer_capacity);
+                // TODO CPU/GPU currently not working with work aggregation 
+                /* avail = stream_pool::interface_available<device_executor, device_pool_strategy>( */
+                /*     cuda_buffer_capacity); */
+                std::cerr << "hydro_host_kernel_type should be DEVICE_ONLY when hydro_device_kernel_type != OFF "
+                             "Aborting..."
+                          << std::endl;
+                abort();
             }
             if (avail) {
-                executor_interface_t executor;
+                // executor_interface_t executor;
                 max_lambda = launch_hydro_kokkos_kernels<device_executor>(
-                    hydro, U, X, omega, opts().n_species, executor, F);
+                    hydro, U, X, omega, opts().n_species, F);
                 return max_lambda;
             }
         }
@@ -104,8 +109,13 @@ timestep_t launch_hydro_kernels(hydro_computer<NDIM, INX, physics<NDIM>>& hydro,
             // Host execution is possible: Check if there is a launch slot for device - if not 
             // we will execute the kernel on the CPU instead
             if (host_type != interaction_host_kernel_type::DEVICE_ONLY) {
-                avail = stream_pool::interface_available<hpx::cuda::experimental::cuda_executor,
-                    pool_strategy>(cuda_buffer_capacity);
+                // TODO CPU/GPU currently not working with work aggregation 
+                /* avail = stream_pool::interface_available<hpx::cuda::experimental::cuda_executor, */
+                /*     pool_strategy>(cuda_buffer_capacity); */
+                std::cerr << "hydro_host_kernel_type should be DEVICE_ONLY when hydro_device_kernel_type != OFF "
+                             "Aborting..."
+                          << std::endl;
+                abort();
             }
             if (avail) {
                 size_t device_id = 0;
@@ -144,9 +154,8 @@ timestep_t launch_hydro_kernels(hydro_computer<NDIM, INX, physics<NDIM>>& hydro,
     if (host_type == interaction_host_kernel_type::KOKKOS) {
 #ifdef OCTOTIGER_HAVE_KOKKOS
         hpx::call_once(init_hydro_kokkos_pool_flag, init_hydro_kokkos_aggregation_pool);
-        host_executor executor{hpx::kokkos::execution_space_mode::independent};
         max_lambda = launch_hydro_kokkos_kernels<host_executor>(
-            hydro, U, X, omega, opts().n_species, executor, F);
+            hydro, U, X, omega, opts().n_species, F);
         return max_lambda;
 #else
         std::cerr << "Trying to call Hydro Kokkos kernels in a non-kokkos build! Aborting..."

--- a/src/unitiger/hydro_impl/hydro_performance_counters.cpp
+++ b/src/unitiger/hydro_impl/hydro_performance_counters.cpp
@@ -1,0 +1,114 @@
+#include "octotiger/unitiger/hydro_impl/hydro_performance_counters.hpp"
+#include <hpx/include/performance_counters.hpp>
+
+namespace octotiger {
+namespace hydro {
+
+std::atomic<std::uint64_t> hydro_cuda_gpu_subgrids_processed(0);
+std::atomic<std::uint64_t> hydro_cuda_gpu_aggregated_subgrids_launches(0);
+std::atomic<std::uint64_t> hydro_kokkos_gpu_subgrids_processed(0);
+std::atomic<std::uint64_t> hydro_kokkos_gpu_aggregated_subgrids_launches(0);
+std::atomic<std::uint64_t> hydro_kokkos_cpu_subgrids_processed(0);
+std::atomic<std::uint64_t> hydro_kokkos_cpu_aggregated_subgrids_launches(0);
+std::atomic<std::uint64_t> hydro_legacy_subgrids_processed(0);
+
+std::uint64_t hydro_cuda_gpu_subgrid_processed_performance_data(bool reset) {
+    if (reset)
+        hydro_cuda_gpu_subgrids_processed = 0;
+    return hydro_cuda_gpu_subgrids_processed;
+}
+std::uint64_t hydro_cuda_gpu_aggregated_subgrids_launches_performance_data(bool reset) {
+    if (reset)
+        hydro_cuda_gpu_aggregated_subgrids_launches = 0;
+    return hydro_cuda_gpu_aggregated_subgrids_launches;
+}
+std::uint64_t hydro_cuda_avg_aggregation_rate(bool reset) {
+    if (hydro_cuda_gpu_aggregated_subgrids_launches > 0)
+        return hydro_cuda_gpu_subgrids_processed / hydro_cuda_gpu_aggregated_subgrids_launches;
+    else
+        return 1;
+}
+std::uint64_t hydro_kokkos_cpu_subgrids_processed_performance_data(bool reset) {
+    if (reset)
+        hydro_kokkos_cpu_subgrids_processed = 0;
+    return hydro_kokkos_cpu_subgrids_processed;
+}
+std::uint64_t hydro_kokkos_cpu_aggregated_subgrids_launches_performance_data(bool reset) {
+    if (reset)
+        hydro_kokkos_cpu_aggregated_subgrids_launches = 0;
+    return hydro_kokkos_cpu_aggregated_subgrids_launches;
+}
+std::uint64_t hydro_kokkos_cpu_avg_aggregation_rate(bool reset) {
+    if (hydro_kokkos_cpu_aggregated_subgrids_launches > 0)
+        return hydro_kokkos_cpu_subgrids_processed / hydro_kokkos_cpu_aggregated_subgrids_launches;
+    else
+        return 1;
+}
+std::uint64_t hydro_kokkos_gpu_subgrids_processed_performance_data(bool reset) {
+    if (reset)
+        hydro_kokkos_gpu_subgrids_processed = 0;
+    return hydro_kokkos_gpu_subgrids_processed;
+}
+std::uint64_t hydro_kokkos_gpu_aggregated_subgrids_launches_performance_data(bool reset) {
+    if (reset)
+        hydro_kokkos_gpu_aggregated_subgrids_launches = 0;
+    return hydro_kokkos_gpu_aggregated_subgrids_launches;
+}
+std::uint64_t hydro_kokkos_gpu_avg_aggregation_rate(bool reset) {
+    if (hydro_kokkos_gpu_aggregated_subgrids_launches > 0)
+        return hydro_kokkos_gpu_subgrids_processed / hydro_kokkos_gpu_aggregated_subgrids_launches;
+    else
+        return 1;
+}
+std::uint64_t hydro_legacy_subgrids_processed_performance_data(bool reset) {
+    if (reset)
+        hydro_legacy_subgrids_processed = 0;
+    return hydro_legacy_subgrids_processed;
+}
+
+void register_performance_counters(void) {
+    hpx::performance_counters::install_counter_type("/octotiger/compute/gpu/hydro_cuda",
+        &hydro_cuda_gpu_subgrid_processed_performance_data,
+        "Number of calls to the hydro_solver with CUDA. Each call handles one sub-grid for one "
+        "sub-timestep");
+    hpx::performance_counters::install_counter_type("/octotiger/compute/gpu/hydro_cuda_aggregated",
+        &hydro_cuda_gpu_aggregated_subgrids_launches_performance_data,
+        "Number of aggregated calls to the hydro_solver with CUDA. Each call handles one ore more "
+        "sub-grids for one sub-timestep");
+    hpx::performance_counters::install_counter_type(
+        "/octotiger/compute/gpu/hydro_cuda_aggregation_rate", &hydro_cuda_avg_aggregation_rate,
+        "Average number of hydro CUDA kernels per aggregated kernel call");
+    hpx::performance_counters::install_counter_type("/octotiger/compute/cpu/hydro_kokkos",
+        &hydro_kokkos_cpu_subgrids_processed_performance_data,
+        "Number of calls to the hydro_solver with KOKKOS_CPU. Each call handles one sub-grid for "
+        "one sub-timestep");
+    hpx::performance_counters::install_counter_type(
+        "/octotiger/compute/cpu/hydro_kokkos_aggregated",
+        &hydro_kokkos_cpu_aggregated_subgrids_launches_performance_data,
+        "Number of aggregated calls to the hydro_solver with KOKKOS_CPU. Each call handles one ore "
+        "more sub-grids for one sub-timestep");
+    hpx::performance_counters::install_counter_type(
+        "/octotiger/compute/cpu/hydro_kokkos_aggregation_rate",
+        &hydro_kokkos_cpu_avg_aggregation_rate,
+        "Average number of hydro KOKKOS_CPU kernels per aggregated kernel call");
+    hpx::performance_counters::install_counter_type("/octotiger/compute/gpu/hydro_kokkos",
+        &hydro_kokkos_gpu_subgrids_processed_performance_data,
+        "Number of calls to the hydro_solver with KOKKOS_GPU. Each call handles one sub-grid for "
+        "one sub-timestep");
+    hpx::performance_counters::install_counter_type(
+        "/octotiger/compute/gpu/hydro_kokkos_aggregated",
+        &hydro_kokkos_gpu_aggregated_subgrids_launches_performance_data,
+        "Number of aggregated calls to the hydro_solver with KOKKOS_GPU. Each call handles one ore "
+        "more sub-grids for one sub-timestep");
+    hpx::performance_counters::install_counter_type(
+        "/octotiger/compute/gpu/hydro_kokkos_aggregation_rate",
+        &hydro_kokkos_gpu_avg_aggregation_rate,
+        "Average number of hydro KOKKOS_GPU kernels per aggregated kernel call");
+    hpx::performance_counters::install_counter_type("/octotiger/compute/cpu/hydro_legacy",
+        &hydro_legacy_subgrids_processed_performance_data,
+        "Number of calls to the hydro_solver with LEGACY. Each call handles one sub-grid for "
+        "one sub-timestep");
+}
+
+}
+}

--- a/test_problems/blast/CMakeLists.txt
+++ b/test_problems/blast/CMakeLists.txt
@@ -140,15 +140,15 @@ test_blast_scenario(test_problems.cpu.am_hydro_on.blast_legacy blast_with_am_hyd
 "  --correct_am_hydro=1 --hydro_device_kernel_type=OFF --hydro_host_kernel_type=LEGACY")
 if(OCTOTIGER_WITH_CUDA)
   test_blast_scenario(test_problems.gpu.am_hydro_on.blast_cuda blast_with_am_hydro_cuda_log.txt ${silo_scenario_filename}
-  "  --correct_am_hydro=1 --number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1024 --hydro_device_kernel_type=CUDA --hydro_host_kernel_type=LEGACY")
+  "  --correct_am_hydro=1 --number_gpus=1 --executors_per_gpu=32 --cuda_buffer_capacity=1024 --hydro_device_kernel_type=CUDA --hydro_host_kernel_type=LEGACY")
 #if(NOT OCTOTIGER_WITH_FAST_FP_CONTRACT)
 #   test_blast_scenario(test_problems.cpu_gpu.am_hydro_on.blast_cuda blast_without_am_hydro_cuda_log.txt ${silo_scenario_filename}
-#     " --correct_am_hydro=1 --number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1 --hydro_device_kernel_type=CUDA --hydro_host_kernel_type=LEGACY")
+#     " --correct_am_hydro=1 --number_gpus=1 --executors_per_gpu=32 --cuda_buffer_capacity=1 --hydro_device_kernel_type=CUDA --hydro_host_kernel_type=LEGACY")
 # endif()
 endif()
 if(OCTOTIGER_WITH_HIP)
   test_blast_scenario(test_problems.gpu.am_hydro_off.blast_hip blast_without_am_hydro_hip_log.txt ${silo_scenario_filename}
-  " --correct_am_hydro=1 --number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1024 --hydro_device_kernel_type=HIP --hydro_host_kernel_type=LEGACY")
+  " --correct_am_hydro=1 --number_gpus=1 --executors_per_gpu=32 --cuda_buffer_capacity=1024 --hydro_device_kernel_type=HIP --hydro_host_kernel_type=LEGACY")
 endif()
 
 if(OCTOTIGER_WITH_KOKKOS)
@@ -156,15 +156,15 @@ if(OCTOTIGER_WITH_KOKKOS)
   "  --correct_am_hydro=1 --hydro_device_kernel_type=OFF --hydro_host_kernel_type=KOKKOS")
   if(OCTOTIGER_WITH_CUDA)
     test_blast_scenario(test_problems.gpu.am_hydro_on.blast_kokkos blast_without_am_hydro_kokkos_cuda_log.txt ${silo_scenario_filename}
-    " --correct_am_hydro=1 --number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1024 --hydro_device_kernel_type=KOKKOS_CUDA --hydro_host_kernel_type=DEVICE_ONLY")
+    " --correct_am_hydro=1 --number_gpus=1 --executors_per_gpu=32 --cuda_buffer_capacity=1024 --hydro_device_kernel_type=KOKKOS_CUDA --hydro_host_kernel_type=DEVICE_ONLY")
   #   if(NOT OCTOTIGER_WITH_FAST_FP_CONTRACT)
   #   test_blast_scenario(test_problems.cpu_gpu.am_hydro_on.blast_kokkos blast_with_am_hydro_kokkos_cuda_log.txt ${silo_scenario_filename}
-  #   "  --correct_am_hydro=1 --number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1 --hydro_device_kernel_type=KOKKOS_CUDA --hydro_host_kernel_type=KOKKOS")
+  #   "  --correct_am_hydro=1 --number_gpus=1 --executors_per_gpu=32 --cuda_buffer_capacity=1 --hydro_device_kernel_type=KOKKOS_CUDA --hydro_host_kernel_type=KOKKOS")
   # endif()
   endif()
   if(OCTOTIGER_WITH_HIP)
     test_blast_scenario(test_problems.gpu.am_hydro_on.blast_kokkos blast_with_am_hydro_kokkos_hip_log.txt ${silo_scenario_filename}
-    "  --correct_am_hydro=1 --number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1024 --hydro_device_kernel_type=KOKKOS_HIP --hydro_host_kernel_type=KOKKOS")
+    "  --correct_am_hydro=1 --number_gpus=1 --executors_per_gpu=32 --cuda_buffer_capacity=1024 --hydro_device_kernel_type=KOKKOS_HIP --hydro_host_kernel_type=KOKKOS")
   endif()
 endif()
 
@@ -218,15 +218,15 @@ test_blast_scenario(test_problems.cpu.am_hydro_off.blast_legacy blast_without_am
 " --correct_am_hydro=0 --hydro_device_kernel_type=OFF --hydro_host_kernel_type=LEGACY")
 if(OCTOTIGER_WITH_CUDA)
   test_blast_scenario(test_problems.gpu.am_hydro_off.blast_cuda blast_without_am_hydro_cuda_log.txt ${silo_scenario_filename}
-  " --correct_am_hydro=0 --number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1024 --hydro_device_kernel_type=CUDA --hydro_host_kernel_type=DEVICE_ONLY")
+  " --correct_am_hydro=0 --number_gpus=1 --executors_per_gpu=32 --cuda_buffer_capacity=1024 --hydro_device_kernel_type=CUDA --hydro_host_kernel_type=DEVICE_ONLY")
 #if(NOT OCTOTIGER_WITH_FAST_FP_CONTRACT)
 #   test_blast_scenario(test_problems.cpu_gpu.am_hydro_off.blast_cuda blast_without_am_hydro_cuda_log.txt ${silo_scenario_filename}
-#   " --correct_am_hydro=0 --number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1 --hydro_device_kernel_type=CUDA --hydro_host_kernel_type=LEGACY")
+#   " --correct_am_hydro=0 --number_gpus=1 --executors_per_gpu=32 --cuda_buffer_capacity=1 --hydro_device_kernel_type=CUDA --hydro_host_kernel_type=LEGACY")
 # endif()
 endif()
 if(OCTOTIGER_WITH_HIP)
   test_blast_scenario(test_problems.gpu.am_hydro_off.blast_hip blast_without_am_hydro_hip_log.txt ${silo_scenario_filename}
-  " --correct_am_hydro=0 --number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1024 --hydro_device_kernel_type=HIP --hydro_host_kernel_type=DEVICE_ONLY")
+  " --correct_am_hydro=0 --number_gpus=1 --executors_per_gpu=32 --cuda_buffer_capacity=1024 --hydro_device_kernel_type=HIP --hydro_host_kernel_type=DEVICE_ONLY")
 endif()
 
 if(OCTOTIGER_WITH_KOKKOS)
@@ -235,13 +235,13 @@ if(OCTOTIGER_WITH_KOKKOS)
   if(OCTOTIGER_WITH_CUDA)
     #   if(NOT OCTOTIGER_WITH_FAST_FP_CONTRACT)
     # test_blast_scenario(test_problems.cpu_gpu.am_hydro_off.blast_kokkos blast_without_am_hydro_kokkos_cuda_log.txt ${silo_scenario_filename}
-    # " --correct_am_hydro=0 --number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1 --hydro_device_kernel_type=KOKKOS_CUDA --hydro_host_kernel_type=KOKKOS")
+    # " --correct_am_hydro=0 --number_gpus=1 --executors_per_gpu=32 --cuda_buffer_capacity=1 --hydro_device_kernel_type=KOKKOS_CUDA --hydro_host_kernel_type=KOKKOS")
     #endif()
     test_blast_scenario(test_problems.gpu.am_hydro_off.blast_kokkos blast_without_am_hydro_kokkos_cuda_log.txt ${silo_scenario_filename}
-    " --correct_am_hydro=0 --number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1024 --hydro_device_kernel_type=KOKKOS_CUDA --hydro_host_kernel_type=DEVICE_ONLY")
+    " --correct_am_hydro=0 --number_gpus=1 --executors_per_gpu=32 --cuda_buffer_capacity=1024 --hydro_device_kernel_type=KOKKOS_CUDA --hydro_host_kernel_type=DEVICE_ONLY")
   endif()
   if(OCTOTIGER_WITH_HIP)
     test_blast_scenario(test_problems.gpu.am_hydro_off.blast_kokkos blast_without_am_hydro_kokkos_hip_log.txt ${silo_scenario_filename}
-   " --correct_am_hydro=0 --number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1024 --hydro_device_kernel_type=KOKKOS_HIP --hydro_host_kernel_type=DEVICE_ONLY")
+   " --correct_am_hydro=0 --number_gpus=1 --executors_per_gpu=32 --cuda_buffer_capacity=1024 --hydro_device_kernel_type=KOKKOS_HIP --hydro_host_kernel_type=DEVICE_ONLY")
   endif()
 endif()

--- a/test_problems/blast/CMakeLists.txt
+++ b/test_problems/blast/CMakeLists.txt
@@ -140,15 +140,15 @@ test_blast_scenario(test_problems.cpu.am_hydro_on.blast_legacy blast_with_am_hyd
 "  --correct_am_hydro=1 --hydro_device_kernel_type=OFF --hydro_host_kernel_type=LEGACY")
 if(OCTOTIGER_WITH_CUDA)
   test_blast_scenario(test_problems.gpu.am_hydro_on.blast_cuda blast_with_am_hydro_cuda_log.txt ${silo_scenario_filename}
-  "  --correct_am_hydro=1 --number_gpus=1 --executors_per_gpu=32 --cuda_buffer_capacity=1024 --hydro_device_kernel_type=CUDA --hydro_host_kernel_type=LEGACY")
+  "  --correct_am_hydro=1 --number_gpus=1 --executors_per_gpu=32 --max_gpu_executor_queue_length=1024 --hydro_device_kernel_type=CUDA --hydro_host_kernel_type=LEGACY")
 #if(NOT OCTOTIGER_WITH_FAST_FP_CONTRACT)
 #   test_blast_scenario(test_problems.cpu_gpu.am_hydro_on.blast_cuda blast_without_am_hydro_cuda_log.txt ${silo_scenario_filename}
-#     " --correct_am_hydro=1 --number_gpus=1 --executors_per_gpu=32 --cuda_buffer_capacity=1 --hydro_device_kernel_type=CUDA --hydro_host_kernel_type=LEGACY")
+#     " --correct_am_hydro=1 --number_gpus=1 --executors_per_gpu=32 --max_gpu_executor_queue_length=1 --hydro_device_kernel_type=CUDA --hydro_host_kernel_type=LEGACY")
 # endif()
 endif()
 if(OCTOTIGER_WITH_HIP)
   test_blast_scenario(test_problems.gpu.am_hydro_off.blast_hip blast_without_am_hydro_hip_log.txt ${silo_scenario_filename}
-  " --correct_am_hydro=1 --number_gpus=1 --executors_per_gpu=32 --cuda_buffer_capacity=1024 --hydro_device_kernel_type=HIP --hydro_host_kernel_type=LEGACY")
+  " --correct_am_hydro=1 --number_gpus=1 --executors_per_gpu=32 --max_gpu_executor_queue_length=1024 --hydro_device_kernel_type=HIP --hydro_host_kernel_type=LEGACY")
 endif()
 
 if(OCTOTIGER_WITH_KOKKOS)
@@ -156,15 +156,15 @@ if(OCTOTIGER_WITH_KOKKOS)
   "  --correct_am_hydro=1 --hydro_device_kernel_type=OFF --hydro_host_kernel_type=KOKKOS")
   if(OCTOTIGER_WITH_CUDA)
     test_blast_scenario(test_problems.gpu.am_hydro_on.blast_kokkos blast_without_am_hydro_kokkos_cuda_log.txt ${silo_scenario_filename}
-    " --correct_am_hydro=1 --number_gpus=1 --executors_per_gpu=32 --cuda_buffer_capacity=1024 --hydro_device_kernel_type=KOKKOS_CUDA --hydro_host_kernel_type=DEVICE_ONLY")
+    " --correct_am_hydro=1 --number_gpus=1 --executors_per_gpu=32 --max_gpu_executor_queue_length=1024 --hydro_device_kernel_type=KOKKOS_CUDA --hydro_host_kernel_type=DEVICE_ONLY")
   #   if(NOT OCTOTIGER_WITH_FAST_FP_CONTRACT)
   #   test_blast_scenario(test_problems.cpu_gpu.am_hydro_on.blast_kokkos blast_with_am_hydro_kokkos_cuda_log.txt ${silo_scenario_filename}
-  #   "  --correct_am_hydro=1 --number_gpus=1 --executors_per_gpu=32 --cuda_buffer_capacity=1 --hydro_device_kernel_type=KOKKOS_CUDA --hydro_host_kernel_type=KOKKOS")
+  #   "  --correct_am_hydro=1 --number_gpus=1 --executors_per_gpu=32 --max_gpu_executor_queue_length=1 --hydro_device_kernel_type=KOKKOS_CUDA --hydro_host_kernel_type=KOKKOS")
   # endif()
   endif()
   if(OCTOTIGER_WITH_HIP)
     test_blast_scenario(test_problems.gpu.am_hydro_on.blast_kokkos blast_with_am_hydro_kokkos_hip_log.txt ${silo_scenario_filename}
-    "  --correct_am_hydro=1 --number_gpus=1 --executors_per_gpu=32 --cuda_buffer_capacity=1024 --hydro_device_kernel_type=KOKKOS_HIP --hydro_host_kernel_type=KOKKOS")
+    "  --correct_am_hydro=1 --number_gpus=1 --executors_per_gpu=32 --max_gpu_executor_queue_length=1024 --hydro_device_kernel_type=KOKKOS_HIP --hydro_host_kernel_type=KOKKOS")
   endif()
 endif()
 
@@ -218,15 +218,15 @@ test_blast_scenario(test_problems.cpu.am_hydro_off.blast_legacy blast_without_am
 " --correct_am_hydro=0 --hydro_device_kernel_type=OFF --hydro_host_kernel_type=LEGACY")
 if(OCTOTIGER_WITH_CUDA)
   test_blast_scenario(test_problems.gpu.am_hydro_off.blast_cuda blast_without_am_hydro_cuda_log.txt ${silo_scenario_filename}
-  " --correct_am_hydro=0 --number_gpus=1 --executors_per_gpu=32 --cuda_buffer_capacity=1024 --hydro_device_kernel_type=CUDA --hydro_host_kernel_type=DEVICE_ONLY")
+  " --correct_am_hydro=0 --number_gpus=1 --executors_per_gpu=32 --max_gpu_executor_queue_length=1024 --hydro_device_kernel_type=CUDA --hydro_host_kernel_type=DEVICE_ONLY")
 #if(NOT OCTOTIGER_WITH_FAST_FP_CONTRACT)
 #   test_blast_scenario(test_problems.cpu_gpu.am_hydro_off.blast_cuda blast_without_am_hydro_cuda_log.txt ${silo_scenario_filename}
-#   " --correct_am_hydro=0 --number_gpus=1 --executors_per_gpu=32 --cuda_buffer_capacity=1 --hydro_device_kernel_type=CUDA --hydro_host_kernel_type=LEGACY")
+#   " --correct_am_hydro=0 --number_gpus=1 --executors_per_gpu=32 --max_gpu_executor_queue_length=1 --hydro_device_kernel_type=CUDA --hydro_host_kernel_type=LEGACY")
 # endif()
 endif()
 if(OCTOTIGER_WITH_HIP)
   test_blast_scenario(test_problems.gpu.am_hydro_off.blast_hip blast_without_am_hydro_hip_log.txt ${silo_scenario_filename}
-  " --correct_am_hydro=0 --number_gpus=1 --executors_per_gpu=32 --cuda_buffer_capacity=1024 --hydro_device_kernel_type=HIP --hydro_host_kernel_type=DEVICE_ONLY")
+  " --correct_am_hydro=0 --number_gpus=1 --executors_per_gpu=32 --max_gpu_executor_queue_length=1024 --hydro_device_kernel_type=HIP --hydro_host_kernel_type=DEVICE_ONLY")
 endif()
 
 if(OCTOTIGER_WITH_KOKKOS)
@@ -235,13 +235,13 @@ if(OCTOTIGER_WITH_KOKKOS)
   if(OCTOTIGER_WITH_CUDA)
     #   if(NOT OCTOTIGER_WITH_FAST_FP_CONTRACT)
     # test_blast_scenario(test_problems.cpu_gpu.am_hydro_off.blast_kokkos blast_without_am_hydro_kokkos_cuda_log.txt ${silo_scenario_filename}
-    # " --correct_am_hydro=0 --number_gpus=1 --executors_per_gpu=32 --cuda_buffer_capacity=1 --hydro_device_kernel_type=KOKKOS_CUDA --hydro_host_kernel_type=KOKKOS")
+    # " --correct_am_hydro=0 --number_gpus=1 --executors_per_gpu=32 --max_gpu_executor_queue_length=1 --hydro_device_kernel_type=KOKKOS_CUDA --hydro_host_kernel_type=KOKKOS")
     #endif()
     test_blast_scenario(test_problems.gpu.am_hydro_off.blast_kokkos blast_without_am_hydro_kokkos_cuda_log.txt ${silo_scenario_filename}
-    " --correct_am_hydro=0 --number_gpus=1 --executors_per_gpu=32 --cuda_buffer_capacity=1024 --hydro_device_kernel_type=KOKKOS_CUDA --hydro_host_kernel_type=DEVICE_ONLY")
+    " --correct_am_hydro=0 --number_gpus=1 --executors_per_gpu=32 --max_gpu_executor_queue_length=1024 --hydro_device_kernel_type=KOKKOS_CUDA --hydro_host_kernel_type=DEVICE_ONLY")
   endif()
   if(OCTOTIGER_WITH_HIP)
     test_blast_scenario(test_problems.gpu.am_hydro_off.blast_kokkos blast_without_am_hydro_kokkos_hip_log.txt ${silo_scenario_filename}
-   " --correct_am_hydro=0 --number_gpus=1 --executors_per_gpu=32 --cuda_buffer_capacity=1024 --hydro_device_kernel_type=KOKKOS_HIP --hydro_host_kernel_type=DEVICE_ONLY")
+   " --correct_am_hydro=0 --number_gpus=1 --executors_per_gpu=32 --max_gpu_executor_queue_length=1024 --hydro_device_kernel_type=KOKKOS_HIP --hydro_host_kernel_type=DEVICE_ONLY")
   endif()
 endif()

--- a/test_problems/blast/CMakeLists.txt
+++ b/test_problems/blast/CMakeLists.txt
@@ -140,7 +140,7 @@ test_blast_scenario(test_problems.cpu.am_hydro_on.blast_legacy blast_with_am_hyd
 "  --correct_am_hydro=1 --hydro_device_kernel_type=OFF --hydro_host_kernel_type=LEGACY")
 if(OCTOTIGER_WITH_CUDA)
   test_blast_scenario(test_problems.gpu.am_hydro_on.blast_cuda blast_with_am_hydro_cuda_log.txt ${silo_scenario_filename}
-  "  --correct_am_hydro=1 --number_gpus=1 --executors_per_gpu=32 --max_gpu_executor_queue_length=1024 --hydro_device_kernel_type=CUDA --hydro_host_kernel_type=LEGACY")
+    "  --correct_am_hydro=1 --number_gpus=1 --executors_per_gpu=32 --max_gpu_executor_queue_length=1024 --hydro_device_kernel_type=CUDA --hydro_host_kernel_type=DEVICE_ONLY")
 #if(NOT OCTOTIGER_WITH_FAST_FP_CONTRACT)
 #   test_blast_scenario(test_problems.cpu_gpu.am_hydro_on.blast_cuda blast_without_am_hydro_cuda_log.txt ${silo_scenario_filename}
 #     " --correct_am_hydro=1 --number_gpus=1 --executors_per_gpu=32 --max_gpu_executor_queue_length=1 --hydro_device_kernel_type=CUDA --hydro_host_kernel_type=LEGACY")

--- a/test_problems/blast/CMakeLists.txt
+++ b/test_problems/blast/CMakeLists.txt
@@ -140,15 +140,15 @@ test_blast_scenario(test_problems.cpu.am_hydro_on.blast_legacy blast_with_am_hyd
 "  --correct_am_hydro=1 --hydro_device_kernel_type=OFF --hydro_host_kernel_type=LEGACY")
 if(OCTOTIGER_WITH_CUDA)
   test_blast_scenario(test_problems.gpu.am_hydro_on.blast_cuda blast_with_am_hydro_cuda_log.txt ${silo_scenario_filename}
-  "  --correct_am_hydro=1 --cuda_number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1024 --hydro_device_kernel_type=CUDA --hydro_host_kernel_type=LEGACY")
+  "  --correct_am_hydro=1 --number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1024 --hydro_device_kernel_type=CUDA --hydro_host_kernel_type=LEGACY")
 #if(NOT OCTOTIGER_WITH_FAST_FP_CONTRACT)
 #   test_blast_scenario(test_problems.cpu_gpu.am_hydro_on.blast_cuda blast_without_am_hydro_cuda_log.txt ${silo_scenario_filename}
-#     " --correct_am_hydro=1 --cuda_number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1 --hydro_device_kernel_type=CUDA --hydro_host_kernel_type=LEGACY")
+#     " --correct_am_hydro=1 --number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1 --hydro_device_kernel_type=CUDA --hydro_host_kernel_type=LEGACY")
 # endif()
 endif()
 if(OCTOTIGER_WITH_HIP)
   test_blast_scenario(test_problems.gpu.am_hydro_off.blast_hip blast_without_am_hydro_hip_log.txt ${silo_scenario_filename}
-  " --correct_am_hydro=1 --cuda_number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1024 --hydro_device_kernel_type=HIP --hydro_host_kernel_type=LEGACY")
+  " --correct_am_hydro=1 --number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1024 --hydro_device_kernel_type=HIP --hydro_host_kernel_type=LEGACY")
 endif()
 
 if(OCTOTIGER_WITH_KOKKOS)
@@ -156,15 +156,15 @@ if(OCTOTIGER_WITH_KOKKOS)
   "  --correct_am_hydro=1 --hydro_device_kernel_type=OFF --hydro_host_kernel_type=KOKKOS")
   if(OCTOTIGER_WITH_CUDA)
     test_blast_scenario(test_problems.gpu.am_hydro_on.blast_kokkos blast_without_am_hydro_kokkos_cuda_log.txt ${silo_scenario_filename}
-    " --correct_am_hydro=1 --cuda_number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1024 --hydro_device_kernel_type=KOKKOS_CUDA --hydro_host_kernel_type=DEVICE_ONLY")
+    " --correct_am_hydro=1 --number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1024 --hydro_device_kernel_type=KOKKOS_CUDA --hydro_host_kernel_type=DEVICE_ONLY")
   #   if(NOT OCTOTIGER_WITH_FAST_FP_CONTRACT)
   #   test_blast_scenario(test_problems.cpu_gpu.am_hydro_on.blast_kokkos blast_with_am_hydro_kokkos_cuda_log.txt ${silo_scenario_filename}
-  #   "  --correct_am_hydro=1 --cuda_number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1 --hydro_device_kernel_type=KOKKOS_CUDA --hydro_host_kernel_type=KOKKOS")
+  #   "  --correct_am_hydro=1 --number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1 --hydro_device_kernel_type=KOKKOS_CUDA --hydro_host_kernel_type=KOKKOS")
   # endif()
   endif()
   if(OCTOTIGER_WITH_HIP)
     test_blast_scenario(test_problems.gpu.am_hydro_on.blast_kokkos blast_with_am_hydro_kokkos_hip_log.txt ${silo_scenario_filename}
-    "  --correct_am_hydro=1 --cuda_number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1024 --hydro_device_kernel_type=KOKKOS_HIP --hydro_host_kernel_type=KOKKOS")
+    "  --correct_am_hydro=1 --number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1024 --hydro_device_kernel_type=KOKKOS_HIP --hydro_host_kernel_type=KOKKOS")
   endif()
 endif()
 
@@ -218,15 +218,15 @@ test_blast_scenario(test_problems.cpu.am_hydro_off.blast_legacy blast_without_am
 " --correct_am_hydro=0 --hydro_device_kernel_type=OFF --hydro_host_kernel_type=LEGACY")
 if(OCTOTIGER_WITH_CUDA)
   test_blast_scenario(test_problems.gpu.am_hydro_off.blast_cuda blast_without_am_hydro_cuda_log.txt ${silo_scenario_filename}
-  " --correct_am_hydro=0 --cuda_number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1024 --hydro_device_kernel_type=CUDA --hydro_host_kernel_type=DEVICE_ONLY")
+  " --correct_am_hydro=0 --number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1024 --hydro_device_kernel_type=CUDA --hydro_host_kernel_type=DEVICE_ONLY")
 #if(NOT OCTOTIGER_WITH_FAST_FP_CONTRACT)
 #   test_blast_scenario(test_problems.cpu_gpu.am_hydro_off.blast_cuda blast_without_am_hydro_cuda_log.txt ${silo_scenario_filename}
-#   " --correct_am_hydro=0 --cuda_number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1 --hydro_device_kernel_type=CUDA --hydro_host_kernel_type=LEGACY")
+#   " --correct_am_hydro=0 --number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1 --hydro_device_kernel_type=CUDA --hydro_host_kernel_type=LEGACY")
 # endif()
 endif()
 if(OCTOTIGER_WITH_HIP)
   test_blast_scenario(test_problems.gpu.am_hydro_off.blast_hip blast_without_am_hydro_hip_log.txt ${silo_scenario_filename}
-  " --correct_am_hydro=0 --cuda_number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1024 --hydro_device_kernel_type=HIP --hydro_host_kernel_type=DEVICE_ONLY")
+  " --correct_am_hydro=0 --number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1024 --hydro_device_kernel_type=HIP --hydro_host_kernel_type=DEVICE_ONLY")
 endif()
 
 if(OCTOTIGER_WITH_KOKKOS)
@@ -235,13 +235,13 @@ if(OCTOTIGER_WITH_KOKKOS)
   if(OCTOTIGER_WITH_CUDA)
     #   if(NOT OCTOTIGER_WITH_FAST_FP_CONTRACT)
     # test_blast_scenario(test_problems.cpu_gpu.am_hydro_off.blast_kokkos blast_without_am_hydro_kokkos_cuda_log.txt ${silo_scenario_filename}
-    # " --correct_am_hydro=0 --cuda_number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1 --hydro_device_kernel_type=KOKKOS_CUDA --hydro_host_kernel_type=KOKKOS")
+    # " --correct_am_hydro=0 --number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1 --hydro_device_kernel_type=KOKKOS_CUDA --hydro_host_kernel_type=KOKKOS")
     #endif()
     test_blast_scenario(test_problems.gpu.am_hydro_off.blast_kokkos blast_without_am_hydro_kokkos_cuda_log.txt ${silo_scenario_filename}
-    " --correct_am_hydro=0 --cuda_number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1024 --hydro_device_kernel_type=KOKKOS_CUDA --hydro_host_kernel_type=DEVICE_ONLY")
+    " --correct_am_hydro=0 --number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1024 --hydro_device_kernel_type=KOKKOS_CUDA --hydro_host_kernel_type=DEVICE_ONLY")
   endif()
   if(OCTOTIGER_WITH_HIP)
     test_blast_scenario(test_problems.gpu.am_hydro_off.blast_kokkos blast_without_am_hydro_kokkos_hip_log.txt ${silo_scenario_filename}
-   " --correct_am_hydro=0 --cuda_number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1024 --hydro_device_kernel_type=KOKKOS_HIP --hydro_host_kernel_type=DEVICE_ONLY")
+   " --correct_am_hydro=0 --number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1024 --hydro_device_kernel_type=KOKKOS_HIP --hydro_host_kernel_type=DEVICE_ONLY")
   endif()
 endif()

--- a/test_problems/blast/CMakeLists.txt
+++ b/test_problems/blast/CMakeLists.txt
@@ -141,10 +141,10 @@ test_blast_scenario(test_problems.cpu.am_hydro_on.blast_legacy blast_with_am_hyd
 if(OCTOTIGER_WITH_CUDA)
   test_blast_scenario(test_problems.gpu.am_hydro_on.blast_cuda blast_with_am_hydro_cuda_log.txt ${silo_scenario_filename}
   "  --correct_am_hydro=1 --cuda_number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1024 --hydro_device_kernel_type=CUDA --hydro_host_kernel_type=LEGACY")
-  if(NOT OCTOTIGER_WITH_FAST_FP_CONTRACT)
-    test_blast_scenario(test_problems.cpu_gpu.am_hydro_on.blast_cuda blast_without_am_hydro_cuda_log.txt ${silo_scenario_filename}
-      " --correct_am_hydro=1 --cuda_number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1 --hydro_device_kernel_type=CUDA --hydro_host_kernel_type=LEGACY")
-  endif()
+#if(NOT OCTOTIGER_WITH_FAST_FP_CONTRACT)
+#   test_blast_scenario(test_problems.cpu_gpu.am_hydro_on.blast_cuda blast_without_am_hydro_cuda_log.txt ${silo_scenario_filename}
+#     " --correct_am_hydro=1 --cuda_number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1 --hydro_device_kernel_type=CUDA --hydro_host_kernel_type=LEGACY")
+# endif()
 endif()
 if(OCTOTIGER_WITH_HIP)
   test_blast_scenario(test_problems.gpu.am_hydro_off.blast_hip blast_without_am_hydro_hip_log.txt ${silo_scenario_filename}
@@ -157,10 +157,10 @@ if(OCTOTIGER_WITH_KOKKOS)
   if(OCTOTIGER_WITH_CUDA)
     test_blast_scenario(test_problems.gpu.am_hydro_on.blast_kokkos blast_without_am_hydro_kokkos_cuda_log.txt ${silo_scenario_filename}
     " --correct_am_hydro=1 --cuda_number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1024 --hydro_device_kernel_type=KOKKOS_CUDA --hydro_host_kernel_type=DEVICE_ONLY")
-    if(NOT OCTOTIGER_WITH_FAST_FP_CONTRACT)
-      test_blast_scenario(test_problems.cpu_gpu.am_hydro_on.blast_kokkos blast_with_am_hydro_kokkos_cuda_log.txt ${silo_scenario_filename}
-      "  --correct_am_hydro=1 --cuda_number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1 --hydro_device_kernel_type=KOKKOS_CUDA --hydro_host_kernel_type=KOKKOS")
-    endif()
+  #   if(NOT OCTOTIGER_WITH_FAST_FP_CONTRACT)
+  #   test_blast_scenario(test_problems.cpu_gpu.am_hydro_on.blast_kokkos blast_with_am_hydro_kokkos_cuda_log.txt ${silo_scenario_filename}
+  #   "  --correct_am_hydro=1 --cuda_number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1 --hydro_device_kernel_type=KOKKOS_CUDA --hydro_host_kernel_type=KOKKOS")
+  # endif()
   endif()
   if(OCTOTIGER_WITH_HIP)
     test_blast_scenario(test_problems.gpu.am_hydro_on.blast_kokkos blast_with_am_hydro_kokkos_hip_log.txt ${silo_scenario_filename}
@@ -219,10 +219,10 @@ test_blast_scenario(test_problems.cpu.am_hydro_off.blast_legacy blast_without_am
 if(OCTOTIGER_WITH_CUDA)
   test_blast_scenario(test_problems.gpu.am_hydro_off.blast_cuda blast_without_am_hydro_cuda_log.txt ${silo_scenario_filename}
   " --correct_am_hydro=0 --cuda_number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1024 --hydro_device_kernel_type=CUDA --hydro_host_kernel_type=DEVICE_ONLY")
-  if(NOT OCTOTIGER_WITH_FAST_FP_CONTRACT)
-    test_blast_scenario(test_problems.cpu_gpu.am_hydro_off.blast_cuda blast_without_am_hydro_cuda_log.txt ${silo_scenario_filename}
-    " --correct_am_hydro=0 --cuda_number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1 --hydro_device_kernel_type=CUDA --hydro_host_kernel_type=LEGACY")
-  endif()
+#if(NOT OCTOTIGER_WITH_FAST_FP_CONTRACT)
+#   test_blast_scenario(test_problems.cpu_gpu.am_hydro_off.blast_cuda blast_without_am_hydro_cuda_log.txt ${silo_scenario_filename}
+#   " --correct_am_hydro=0 --cuda_number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1 --hydro_device_kernel_type=CUDA --hydro_host_kernel_type=LEGACY")
+# endif()
 endif()
 if(OCTOTIGER_WITH_HIP)
   test_blast_scenario(test_problems.gpu.am_hydro_off.blast_hip blast_without_am_hydro_hip_log.txt ${silo_scenario_filename}
@@ -233,10 +233,10 @@ if(OCTOTIGER_WITH_KOKKOS)
   test_blast_scenario(test_problems.cpu.am_hydro_off.blast_kokkos blast_without_am_hydro_kokkos_log.txt ${silo_scenario_filename}
   " --correct_am_hydro=0 --hydro_device_kernel_type=OFF --hydro_host_kernel_type=KOKKOS")
   if(OCTOTIGER_WITH_CUDA)
-    if(NOT OCTOTIGER_WITH_FAST_FP_CONTRACT)
-      test_blast_scenario(test_problems.cpu_gpu.am_hydro_off.blast_kokkos blast_without_am_hydro_kokkos_cuda_log.txt ${silo_scenario_filename}
-      " --correct_am_hydro=0 --cuda_number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1 --hydro_device_kernel_type=KOKKOS_CUDA --hydro_host_kernel_type=KOKKOS")
-    endif()
+    #   if(NOT OCTOTIGER_WITH_FAST_FP_CONTRACT)
+    # test_blast_scenario(test_problems.cpu_gpu.am_hydro_off.blast_kokkos blast_without_am_hydro_kokkos_cuda_log.txt ${silo_scenario_filename}
+    # " --correct_am_hydro=0 --cuda_number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1 --hydro_device_kernel_type=KOKKOS_CUDA --hydro_host_kernel_type=KOKKOS")
+    #endif()
     test_blast_scenario(test_problems.gpu.am_hydro_off.blast_kokkos blast_without_am_hydro_kokkos_cuda_log.txt ${silo_scenario_filename}
     " --correct_am_hydro=0 --cuda_number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1024 --hydro_device_kernel_type=KOKKOS_CUDA --hydro_host_kernel_type=DEVICE_ONLY")
   endif()

--- a/test_problems/rotating_star/CMakeLists.txt
+++ b/test_problems/rotating_star/CMakeLists.txt
@@ -239,7 +239,7 @@ if(OCTOTIGER_WITH_CUDA)
   test_rotating_star_scenario(test_problems.gpu.am_hydro_off.rotating_star_cuda rotating_star_am_hydro_off_cuda_log.txt ${silo_scenario_filename}
   " --correct_am_hydro=0 --number_gpus=1 --executors_per_gpu=32 --max_gpu_executor_queue_length=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=CUDA --multipole_device_kernel_type=CUDA --hydro_device_kernel_type=CUDA --hydro_host_kernel_type=DEVICE_ONLY")
   test_rotating_star_scenario(test_problems.gpu.am_hydro_off.rotating_star_cuda_work_aggregation rotating_star_am_hydro_off_cuda_work_aggregation_log.txt ${silo_scenario_filename}
-  " --correct_am_hydro=0 --number_gpus=1 --executors_per_gpu=32 --max_gpu_executor_queue_length=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=CUDA --multipole_device_kernel_type=CUDA --hydro_device_kernel_type=CUDA --hydro_host_kernel_type=DEVICE_ONLY --max_executor_slices=8")
+  " --correct_am_hydro=0 --number_gpus=1 --executors_per_gpu=32 --max_gpu_executor_queue_length=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=CUDA --multipole_device_kernel_type=CUDA --hydro_device_kernel_type=CUDA --hydro_host_kernel_type=DEVICE_ONLY --max_kernels_fused=8")
   if(NOT OCTOTIGER_WITH_FAST_FP_CONTRACT)
   # combined cpu+gpu
     test_rotating_star_scenario(test_problems.cpu_gpu.am_hydro_off.rotating_star_cuda rotating_star_am_hydro_off_cuda_log.txt ${silo_scenario_filename} 
@@ -250,7 +250,7 @@ if(OCTOTIGER_WITH_HIP)
   test_rotating_star_scenario(test_problems.gpu.am_hydro_off.rotating_star_hip rotating_star_am_hydro_off_hip_log.txt ${silo_scenario_filename}
     " --correct_am_hydro=0 --number_gpus=1 --executors_per_gpu=32 --max_gpu_executor_queue_length=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=HIP --multipole_device_kernel_type=HIP --hydro_device_kernel_type=HIP --hydro_host_kernel_type=DEVICE_ONLY")
   test_rotating_star_scenario(test_problems.gpu.am_hydro_off.rotating_star_hip_work_aggregation rotating_star_am_hydro_off_hip_work_aggregation_log.txt ${silo_scenario_filename}
-  " --correct_am_hydro=0 --number_gpus=1 --executors_per_gpu=32 --max_gpu_executor_queue_length=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=HIP --multipole_device_kernel_type=HIP --hydro_device_kernel_type=HIP --hydro_host_kernel_type=DEVICE_ONLY --max_executor_slices=8")
+  " --correct_am_hydro=0 --number_gpus=1 --executors_per_gpu=32 --max_gpu_executor_queue_length=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=HIP --multipole_device_kernel_type=HIP --hydro_device_kernel_type=HIP --hydro_host_kernel_type=DEVICE_ONLY --max_kernels_fused=8")
 endif()
 
 if(OCTOTIGER_WITH_KOKKOS)
@@ -260,7 +260,7 @@ if(OCTOTIGER_WITH_KOKKOS)
     test_rotating_star_scenario(test_problems.gpu.am_hydro_off.rotating_star_kokkos_cuda rotating_star_am_hydro_off_kokkos_cuda_log.txt ${silo_scenario_filename}
     " --correct_am_hydro=0 --number_gpus=1 --executors_per_gpu=32 --max_gpu_executor_queue_length=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=KOKKOS_CUDA --multipole_device_kernel_type=KOKKOS_CUDA --hydro_device_kernel_type=KOKKOS_CUDA --hydro_host_kernel_type=DEVICE_ONLY")
   test_rotating_star_scenario(test_problems.gpu.am_hydro_off.rotating_star_kokkos_cuda_work_aggregation rotating_star_am_hydro_off_kokkos_cuda_work_aggregation_log.txt ${silo_scenario_filename}
-  " --correct_am_hydro=0 --number_gpus=1 --executors_per_gpu=32 --max_gpu_executor_queue_length=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=KOKKOS_CUDA --multipole_device_kernel_type=KOKKOS_CUDA --hydro_device_kernel_type=KOKKOS_CUDA --hydro_host_kernel_type=DEVICE_ONLY --max_executor_slices=8")
+  " --correct_am_hydro=0 --number_gpus=1 --executors_per_gpu=32 --max_gpu_executor_queue_length=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=KOKKOS_CUDA --multipole_device_kernel_type=KOKKOS_CUDA --hydro_device_kernel_type=KOKKOS_CUDA --hydro_host_kernel_type=DEVICE_ONLY --max_kernels_fused=8")
     if(NOT OCTOTIGER_WITH_FAST_FP_CONTRACT)
       # combined cpu+gpu
       test_rotating_star_scenario(test_problems.cpu_gpu.am_hydro_off.rotating_star_kokkos_cuda rotating_star_am_hydro_off_kokkos_cuda_log.txt ${silo_scenario_filename} 
@@ -271,13 +271,13 @@ if(OCTOTIGER_WITH_KOKKOS)
     test_rotating_star_scenario(test_problems.gpu.am_hydro_off.rotating_star_kokkos_hip rotating_star_am_hydro_off_kokkos_hip_log.txt ${silo_scenario_filename}
       " --correct_am_hydro=0 --number_gpus=1 --executors_per_gpu=32 --max_gpu_executor_queue_length=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=KOKKOS_HIP --multipole_device_kernel_type=KOKKOS_HIP --hydro_device_kernel_type=KOKKOS_HIP --hydro_host_kernel_type=DEVICE_ONLY")
   test_rotating_star_scenario(test_problems.gpu.am_hydro_off.rotating_star_kokkos_hip_work_aggregation rotating_star_am_hydro_off_kokkos_hip_work_aggregation_log.txt ${silo_scenario_filename}
-  " --correct_am_hydro=0 --number_gpus=1 --executors_per_gpu=32 --max_gpu_executor_queue_length=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=KOKKOS_HIP --multipole_device_kernel_type=KOKKOS_HIP --hydro_device_kernel_type=KOKKOS_HIP --hydro_host_kernel_type=DEVICE_ONLY --max_executor_slices=8")
+  " --correct_am_hydro=0 --number_gpus=1 --executors_per_gpu=32 --max_gpu_executor_queue_length=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=KOKKOS_HIP --multipole_device_kernel_type=KOKKOS_HIP --hydro_device_kernel_type=KOKKOS_HIP --hydro_host_kernel_type=DEVICE_ONLY --max_kernels_fused=8")
   endif()
   if(Kokkos_ENABLE_SYCL)
     test_rotating_star_scenario(test_problems.gpu.am_hydro_off.rotating_star_kokkos_sycl rotating_star_am_hydro_off_kokkos_sycl_log.txt ${silo_scenario_filename}
       " --correct_am_hydro=0 --number_gpus=1 --executors_per_gpu=32 --max_gpu_executor_queue_length=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=KOKKOS_SYCL --multipole_device_kernel_type=KOKKOS_SYCL --hydro_device_kernel_type=KOKKOS_SYCL --hydro_host_kernel_type=DEVICE_ONLY")
     test_rotating_star_scenario(test_problems.gpu.am_hydro_off.rotating_star_kokkos_sycl_work_aggregation rotating_star_am_hydro_off_kokkos_sycl_work_aggregation_log.txt ${silo_scenario_filename}
-    " --correct_am_hydro=0 --number_gpus=1 --executors_per_gpu=32 --max_gpu_executor_queue_length=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=KOKKOS_SYCL --multipole_device_kernel_type=KOKKOS_SYCL --hydro_device_kernel_type=KOKKOS_SYCL --hydro_host_kernel_type=DEVICE_ONLY --max_executor_slices=8")
+    " --correct_am_hydro=0 --number_gpus=1 --executors_per_gpu=32 --max_gpu_executor_queue_length=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=KOKKOS_SYCL --multipole_device_kernel_type=KOKKOS_SYCL --hydro_device_kernel_type=KOKKOS_SYCL --hydro_host_kernel_type=DEVICE_ONLY --max_kernels_fused=8")
   endif()
 endif()
 

--- a/test_problems/rotating_star/CMakeLists.txt
+++ b/test_problems/rotating_star/CMakeLists.txt
@@ -148,16 +148,16 @@ test_rotating_star_scenario(test_problems.cpu.am_hydro_on.rotating_star_legacy r
 "  --correct_am_hydro=1 --monopole_host_kernel_type=LEGACY --multipole_host_kernel_type=LEGACY --monopole_device_kernel_type=OFF --multipole_device_kernel_type=OFF --hydro_device_kernel_type=OFF --hydro_host_kernel_type=LEGACY")
 if(OCTOTIGER_WITH_CUDA)
   test_rotating_star_scenario(test_problems.gpu.am_hydro_on.rotating_star_cuda rotating_star_am_hydro_on_cuda_log.txt ${silo_scenario_filename} 
-  "  --correct_am_hydro=1 --number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=CUDA --multipole_device_kernel_type=CUDA --hydro_device_kernel_type=CUDA --hydro_host_kernel_type=DEVICE_ONLY")
+  "  --correct_am_hydro=1 --number_gpus=1 --executors_per_gpu=32 --cuda_buffer_capacity=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=CUDA --multipole_device_kernel_type=CUDA --hydro_device_kernel_type=CUDA --hydro_host_kernel_type=DEVICE_ONLY")
   if(NOT OCTOTIGER_WITH_FAST_FP_CONTRACT)
     # combined cpu+gpu
     test_rotating_star_scenario(test_problems.cpu_gpu.am_hydro_on.rotating_star_cuda rotating_star_am_hydro_on_cuda_log.txt ${silo_scenario_filename} 
-      "  --correct_am_hydro=1 --number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1 --monopole_host_kernel_type=VC --multipole_host_kernel_type=VC --monopole_device_kernel_type=CUDA --multipole_device_kernel_type=CUDA --hydro_device_kernel_type=CUDA --hydro_host_kernel_type=DEVICE_ONLY")
+      "  --correct_am_hydro=1 --number_gpus=1 --executors_per_gpu=32 --cuda_buffer_capacity=1 --monopole_host_kernel_type=VC --multipole_host_kernel_type=VC --monopole_device_kernel_type=CUDA --multipole_device_kernel_type=CUDA --hydro_device_kernel_type=CUDA --hydro_host_kernel_type=DEVICE_ONLY")
   endif()
 endif()
 if(OCTOTIGER_WITH_HIP)
   test_rotating_star_scenario(test_problems.gpu.am_hydro_on.rotating_star_hip rotating_star_am_hydro_on_hip_log.txt ${silo_scenario_filename} 
-    "  --correct_am_hydro=1 --number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=HIP --multipole_device_kernel_type=HIP --hydro_device_kernel_type=HIP --hydro_host_kernel_type=DEVICE_ONLY ")
+    "  --correct_am_hydro=1 --number_gpus=1 --executors_per_gpu=32 --cuda_buffer_capacity=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=HIP --multipole_device_kernel_type=HIP --hydro_device_kernel_type=HIP --hydro_host_kernel_type=DEVICE_ONLY ")
 endif()
 
 if(OCTOTIGER_WITH_KOKKOS)
@@ -165,20 +165,20 @@ if(OCTOTIGER_WITH_KOKKOS)
   "  --correct_am_hydro=1 --monopole_host_kernel_type=KOKKOS --multipole_host_kernel_type=KOKKOS --monopole_device_kernel_type=OFF --multipole_device_kernel_type=OFF --hydro_device_kernel_type=OFF --hydro_host_kernel_type=KOKKOS")
   if(OCTOTIGER_WITH_CUDA)
     test_rotating_star_scenario(test_problems.gpu.am_hydro_on.rotating_star_kokkos rotating_star_am_hydro_on_kokkos_cuda_log.txt ${silo_scenario_filename} 
-    "  --correct_am_hydro=1 --number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=KOKKOS_CUDA --multipole_device_kernel_type=KOKKOS_CUDA --hydro_device_kernel_type=KOKKOS_CUDA --hydro_host_kernel_type=DEVICE_ONLY")
+    "  --correct_am_hydro=1 --number_gpus=1 --executors_per_gpu=32 --cuda_buffer_capacity=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=KOKKOS_CUDA --multipole_device_kernel_type=KOKKOS_CUDA --hydro_device_kernel_type=KOKKOS_CUDA --hydro_host_kernel_type=DEVICE_ONLY")
     if(NOT OCTOTIGER_WITH_FAST_FP_CONTRACT)
       # combined cpu+gpu
       test_rotating_star_scenario(test_problems.cpu_gpu.am_hydro_on.rotating_star_kokkos_cuda rotating_star_am_hydro_on_kokkos_cuda_log.txt ${silo_scenario_filename} 
-        "  --correct_am_hydro=1 --number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1 --monopole_host_kernel_type=KOKKOS --multipole_host_kernel_type=KOKKOS --monopole_device_kernel_type=KOKKOS_CUDA --multipole_device_kernel_type=KOKKOS_CUDA --hydro_device_kernel_type=KOKKOS_CUDA --hydro_host_kernel_type=DEVICE_ONLY")
+        "  --correct_am_hydro=1 --number_gpus=1 --executors_per_gpu=32 --cuda_buffer_capacity=1 --monopole_host_kernel_type=KOKKOS --multipole_host_kernel_type=KOKKOS --monopole_device_kernel_type=KOKKOS_CUDA --multipole_device_kernel_type=KOKKOS_CUDA --hydro_device_kernel_type=KOKKOS_CUDA --hydro_host_kernel_type=DEVICE_ONLY")
     endif()
   endif()
   if(OCTOTIGER_WITH_HIP)
     test_rotating_star_scenario(test_problems.gpu.am_hydro_on.rotating_star_kokkos_hip rotating_star_am_hydro_on_kokkos_hip_log.txt ${silo_scenario_filename} 
-      "  --correct_am_hydro=1 --number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=KOKKOS_HIP --multipole_device_kernel_type=KOKKOS_HIP --hydro_device_kernel_type=KOKKOS_HIP --hydro_host_kernel_type=DEVICE_ONLY")
+      "  --correct_am_hydro=1 --number_gpus=1 --executors_per_gpu=32 --cuda_buffer_capacity=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=KOKKOS_HIP --multipole_device_kernel_type=KOKKOS_HIP --hydro_device_kernel_type=KOKKOS_HIP --hydro_host_kernel_type=DEVICE_ONLY")
   endif()
   if(Kokkos_ENABLE_SYCL)
     test_rotating_star_scenario(test_problems.gpu.am_hydro_on.rotating_star_kokkos_sycl rotating_star_am_hydro_on_kokkos_sycl_log.txt ${silo_scenario_filename} 
-      "  --correct_am_hydro=1 --number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=KOKKOS_SYCL --multipole_device_kernel_type=KOKKOS_SYCL --hydro_device_kernel_type=KOKKOS_SYCL --hydro_host_kernel_type=DEVICE_ONLY")
+      "  --correct_am_hydro=1 --number_gpus=1 --executors_per_gpu=32 --cuda_buffer_capacity=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=KOKKOS_SYCL --multipole_device_kernel_type=KOKKOS_SYCL --hydro_device_kernel_type=KOKKOS_SYCL --hydro_host_kernel_type=DEVICE_ONLY")
   endif()
 endif()
 
@@ -237,20 +237,20 @@ test_rotating_star_scenario(test_problems.cpu.am_hydro_off.rotating_star_legacy 
 " --correct_am_hydro=0 --monopole_host_kernel_type=LEGACY --multipole_host_kernel_type=LEGACY --monopole_device_kernel_type=OFF --multipole_device_kernel_type=OFF --hydro_device_kernel_type=OFF --hydro_host_kernel_type=LEGACY")
 if(OCTOTIGER_WITH_CUDA)
   test_rotating_star_scenario(test_problems.gpu.am_hydro_off.rotating_star_cuda rotating_star_am_hydro_off_cuda_log.txt ${silo_scenario_filename}
-  " --correct_am_hydro=0 --number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=CUDA --multipole_device_kernel_type=CUDA --hydro_device_kernel_type=CUDA --hydro_host_kernel_type=DEVICE_ONLY")
+  " --correct_am_hydro=0 --number_gpus=1 --executors_per_gpu=32 --cuda_buffer_capacity=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=CUDA --multipole_device_kernel_type=CUDA --hydro_device_kernel_type=CUDA --hydro_host_kernel_type=DEVICE_ONLY")
   test_rotating_star_scenario(test_problems.gpu.am_hydro_off.rotating_star_cuda_work_aggregation rotating_star_am_hydro_off_cuda_work_aggregation_log.txt ${silo_scenario_filename}
-  " --correct_am_hydro=0 --number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=CUDA --multipole_device_kernel_type=CUDA --hydro_device_kernel_type=CUDA --hydro_host_kernel_type=DEVICE_ONLY --max_executor_slices=8")
+  " --correct_am_hydro=0 --number_gpus=1 --executors_per_gpu=32 --cuda_buffer_capacity=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=CUDA --multipole_device_kernel_type=CUDA --hydro_device_kernel_type=CUDA --hydro_host_kernel_type=DEVICE_ONLY --max_executor_slices=8")
   if(NOT OCTOTIGER_WITH_FAST_FP_CONTRACT)
   # combined cpu+gpu
     test_rotating_star_scenario(test_problems.cpu_gpu.am_hydro_off.rotating_star_cuda rotating_star_am_hydro_off_cuda_log.txt ${silo_scenario_filename} 
-      "  --correct_am_hydro=0 --number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1 --monopole_host_kernel_type=VC --multipole_host_kernel_type=VC --monopole_device_kernel_type=CUDA --multipole_device_kernel_type=CUDA --hydro_device_kernel_type=CUDA --hydro_host_kernel_type=DEVICE_ONLY")
+      "  --correct_am_hydro=0 --number_gpus=1 --executors_per_gpu=32 --cuda_buffer_capacity=1 --monopole_host_kernel_type=VC --multipole_host_kernel_type=VC --monopole_device_kernel_type=CUDA --multipole_device_kernel_type=CUDA --hydro_device_kernel_type=CUDA --hydro_host_kernel_type=DEVICE_ONLY")
   endif()
 endif()
 if(OCTOTIGER_WITH_HIP)
   test_rotating_star_scenario(test_problems.gpu.am_hydro_off.rotating_star_hip rotating_star_am_hydro_off_hip_log.txt ${silo_scenario_filename}
-    " --correct_am_hydro=0 --number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=HIP --multipole_device_kernel_type=HIP --hydro_device_kernel_type=HIP --hydro_host_kernel_type=DEVICE_ONLY")
+    " --correct_am_hydro=0 --number_gpus=1 --executors_per_gpu=32 --cuda_buffer_capacity=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=HIP --multipole_device_kernel_type=HIP --hydro_device_kernel_type=HIP --hydro_host_kernel_type=DEVICE_ONLY")
   test_rotating_star_scenario(test_problems.gpu.am_hydro_off.rotating_star_hip_work_aggregation rotating_star_am_hydro_off_hip_work_aggregation_log.txt ${silo_scenario_filename}
-  " --correct_am_hydro=0 --number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=HIP --multipole_device_kernel_type=HIP --hydro_device_kernel_type=HIP --hydro_host_kernel_type=DEVICE_ONLY --max_executor_slices=8")
+  " --correct_am_hydro=0 --number_gpus=1 --executors_per_gpu=32 --cuda_buffer_capacity=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=HIP --multipole_device_kernel_type=HIP --hydro_device_kernel_type=HIP --hydro_host_kernel_type=DEVICE_ONLY --max_executor_slices=8")
 endif()
 
 if(OCTOTIGER_WITH_KOKKOS)
@@ -258,26 +258,26 @@ if(OCTOTIGER_WITH_KOKKOS)
   " --correct_am_hydro=0 --monopole_host_kernel_type=KOKKOS --multipole_host_kernel_type=KOKKOS --monopole_device_kernel_type=OFF --multipole_device_kernel_type=OFF --hydro_device_kernel_type=OFF --hydro_host_kernel_type=KOKKOS")
   if(OCTOTIGER_WITH_CUDA)
     test_rotating_star_scenario(test_problems.gpu.am_hydro_off.rotating_star_kokkos_cuda rotating_star_am_hydro_off_kokkos_cuda_log.txt ${silo_scenario_filename}
-    " --correct_am_hydro=0 --number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=KOKKOS_CUDA --multipole_device_kernel_type=KOKKOS_CUDA --hydro_device_kernel_type=KOKKOS_CUDA --hydro_host_kernel_type=DEVICE_ONLY")
+    " --correct_am_hydro=0 --number_gpus=1 --executors_per_gpu=32 --cuda_buffer_capacity=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=KOKKOS_CUDA --multipole_device_kernel_type=KOKKOS_CUDA --hydro_device_kernel_type=KOKKOS_CUDA --hydro_host_kernel_type=DEVICE_ONLY")
   test_rotating_star_scenario(test_problems.gpu.am_hydro_off.rotating_star_kokkos_cuda_work_aggregation rotating_star_am_hydro_off_kokkos_cuda_work_aggregation_log.txt ${silo_scenario_filename}
-  " --correct_am_hydro=0 --number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=KOKKOS_CUDA --multipole_device_kernel_type=KOKKOS_CUDA --hydro_device_kernel_type=KOKKOS_CUDA --hydro_host_kernel_type=DEVICE_ONLY --max_executor_slices=8")
+  " --correct_am_hydro=0 --number_gpus=1 --executors_per_gpu=32 --cuda_buffer_capacity=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=KOKKOS_CUDA --multipole_device_kernel_type=KOKKOS_CUDA --hydro_device_kernel_type=KOKKOS_CUDA --hydro_host_kernel_type=DEVICE_ONLY --max_executor_slices=8")
     if(NOT OCTOTIGER_WITH_FAST_FP_CONTRACT)
       # combined cpu+gpu
       test_rotating_star_scenario(test_problems.cpu_gpu.am_hydro_off.rotating_star_kokkos_cuda rotating_star_am_hydro_off_kokkos_cuda_log.txt ${silo_scenario_filename} 
-        "  --correct_am_hydro=0 --number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1 --monopole_host_kernel_type=KOKKOS --multipole_host_kernel_type=KOKKOS --monopole_device_kernel_type=KOKKOS_CUDA --multipole_device_kernel_type=KOKKOS_CUDA --hydro_device_kernel_type=KOKKOS_CUDA --hydro_host_kernel_type=DEVICE_ONLY")
+        "  --correct_am_hydro=0 --number_gpus=1 --executors_per_gpu=32 --cuda_buffer_capacity=1 --monopole_host_kernel_type=KOKKOS --multipole_host_kernel_type=KOKKOS --monopole_device_kernel_type=KOKKOS_CUDA --multipole_device_kernel_type=KOKKOS_CUDA --hydro_device_kernel_type=KOKKOS_CUDA --hydro_host_kernel_type=DEVICE_ONLY")
     endif()
   endif()
   if(OCTOTIGER_WITH_HIP)
     test_rotating_star_scenario(test_problems.gpu.am_hydro_off.rotating_star_kokkos_hip rotating_star_am_hydro_off_kokkos_hip_log.txt ${silo_scenario_filename}
-      " --correct_am_hydro=0 --number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=KOKKOS_HIP --multipole_device_kernel_type=KOKKOS_HIP --hydro_device_kernel_type=KOKKOS_HIP --hydro_host_kernel_type=DEVICE_ONLY")
+      " --correct_am_hydro=0 --number_gpus=1 --executors_per_gpu=32 --cuda_buffer_capacity=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=KOKKOS_HIP --multipole_device_kernel_type=KOKKOS_HIP --hydro_device_kernel_type=KOKKOS_HIP --hydro_host_kernel_type=DEVICE_ONLY")
   test_rotating_star_scenario(test_problems.gpu.am_hydro_off.rotating_star_kokkos_hip_work_aggregation rotating_star_am_hydro_off_kokkos_hip_work_aggregation_log.txt ${silo_scenario_filename}
-  " --correct_am_hydro=0 --number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=KOKKOS_HIP --multipole_device_kernel_type=KOKKOS_HIP --hydro_device_kernel_type=KOKKOS_HIP --hydro_host_kernel_type=DEVICE_ONLY --max_executor_slices=8")
+  " --correct_am_hydro=0 --number_gpus=1 --executors_per_gpu=32 --cuda_buffer_capacity=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=KOKKOS_HIP --multipole_device_kernel_type=KOKKOS_HIP --hydro_device_kernel_type=KOKKOS_HIP --hydro_host_kernel_type=DEVICE_ONLY --max_executor_slices=8")
   endif()
   if(Kokkos_ENABLE_SYCL)
     test_rotating_star_scenario(test_problems.gpu.am_hydro_off.rotating_star_kokkos_sycl rotating_star_am_hydro_off_kokkos_sycl_log.txt ${silo_scenario_filename}
-      " --correct_am_hydro=0 --number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=KOKKOS_SYCL --multipole_device_kernel_type=KOKKOS_SYCL --hydro_device_kernel_type=KOKKOS_SYCL --hydro_host_kernel_type=DEVICE_ONLY")
+      " --correct_am_hydro=0 --number_gpus=1 --executors_per_gpu=32 --cuda_buffer_capacity=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=KOKKOS_SYCL --multipole_device_kernel_type=KOKKOS_SYCL --hydro_device_kernel_type=KOKKOS_SYCL --hydro_host_kernel_type=DEVICE_ONLY")
     test_rotating_star_scenario(test_problems.gpu.am_hydro_off.rotating_star_kokkos_sycl_work_aggregation rotating_star_am_hydro_off_kokkos_sycl_work_aggregation_log.txt ${silo_scenario_filename}
-    " --correct_am_hydro=0 --number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=KOKKOS_SYCL --multipole_device_kernel_type=KOKKOS_SYCL --hydro_device_kernel_type=KOKKOS_SYCL --hydro_host_kernel_type=DEVICE_ONLY --max_executor_slices=8")
+    " --correct_am_hydro=0 --number_gpus=1 --executors_per_gpu=32 --cuda_buffer_capacity=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=KOKKOS_SYCL --multipole_device_kernel_type=KOKKOS_SYCL --hydro_device_kernel_type=KOKKOS_SYCL --hydro_host_kernel_type=DEVICE_ONLY --max_executor_slices=8")
   endif()
 endif()
 
@@ -318,11 +318,11 @@ if (OCTOTIGER_WITH_GRIDDIM EQUAL 8)
     " --correct_am_hydro=0 --eos=WD --monopole_host_kernel_type=LEGACY --multipole_host_kernel_type=LEGACY --monopole_device_kernel_type=OFF --multipole_device_kernel_type=OFF --hydro_device_kernel_type=OFF --hydro_host_kernel_type=LEGACY")
   if(OCTOTIGER_WITH_CUDA)
     test_rotating_star_scenario(test_problems.gpu.eos_wd.rotating_star_cuda rotating_star_eos_wd_cuda_log.txt ${silo_scenario_filename}
-      " --correct_am_hydro=0 --eos=WD --number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=CUDA --multipole_device_kernel_type=CUDA --hydro_device_kernel_type=CUDA --hydro_host_kernel_type=DEVICE_ONLY")
+      " --correct_am_hydro=0 --eos=WD --number_gpus=1 --executors_per_gpu=32 --cuda_buffer_capacity=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=CUDA --multipole_device_kernel_type=CUDA --hydro_device_kernel_type=CUDA --hydro_host_kernel_type=DEVICE_ONLY")
   endif()
   if(OCTOTIGER_WITH_HIP)
     test_rotating_star_scenario(test_problems.gpu.eos_wd.rotating_star_hip rotating_star_eos_wd_hip.txt ${silo_scenario_filename}
-      " --correct_am_hydro=0 --eos=WD --number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=HIP --multipole_device_kernel_type=HIP --hydro_device_kernel_type=HIP --hydro_host_kernel_type=DEVICE_ONLY")
+      " --correct_am_hydro=0 --eos=WD --number_gpus=1 --executors_per_gpu=32 --cuda_buffer_capacity=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=HIP --multipole_device_kernel_type=HIP --hydro_device_kernel_type=HIP --hydro_host_kernel_type=DEVICE_ONLY")
   endif()
   # TODO Add eos=wd CPU+GPU test
 
@@ -331,16 +331,16 @@ if (OCTOTIGER_WITH_GRIDDIM EQUAL 8)
       " --correct_am_hydro=0 --eos=WD --monopole_host_kernel_type=KOKKOS --multipole_host_kernel_type=KOKKOS --monopole_device_kernel_type=OFF --multipole_device_kernel_type=OFF --hydro_device_kernel_type=OFF --hydro_host_kernel_type=KOKKOS")
     if(OCTOTIGER_WITH_CUDA)
       test_rotating_star_scenario(test_problems.gpu.eos_wd.rotating_star_kokkos_cuda rotating_star_eos_wd_kokkos_cuda_log.txt ${silo_scenario_filename}
-        " --correct_am_hydro=0 --eos=WD --number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=KOKKOS_CUDA --multipole_device_kernel_type=KOKKOS_CUDA --hydro_device_kernel_type=KOKKOS_CUDA --hydro_host_kernel_type=DEVICE_ONLY")
+        " --correct_am_hydro=0 --eos=WD --number_gpus=1 --executors_per_gpu=32 --cuda_buffer_capacity=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=KOKKOS_CUDA --multipole_device_kernel_type=KOKKOS_CUDA --hydro_device_kernel_type=KOKKOS_CUDA --hydro_host_kernel_type=DEVICE_ONLY")
     endif()
     if(OCTOTIGER_WITH_HIP)
       test_rotating_star_scenario(test_problems.gpu.eos_wd.rotating_star_kokkos_hip rotating_star_eos_wd_kokkos_hip.txt ${silo_scenario_filename}
-        " --correct_am_hydro=0 --eos=WD --number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=KOKKOS_HIP --multipole_device_kernel_type=KOKKOS_HIP --hydro_device_kernel_type=KOKKOS_HIP --hydro_host_kernel_type=DEVICE_ONLY")
+        " --correct_am_hydro=0 --eos=WD --number_gpus=1 --executors_per_gpu=32 --cuda_buffer_capacity=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=KOKKOS_HIP --multipole_device_kernel_type=KOKKOS_HIP --hydro_device_kernel_type=KOKKOS_HIP --hydro_host_kernel_type=DEVICE_ONLY")
     endif()
   endif()
   if(Kokkos_ENABLE_SYCL)
       test_rotating_star_scenario(test_problems.gpu.eos_wd.rotating_star_kokkos_sycl rotating_star_eos_wd_kokkos_sycl.txt ${silo_scenario_filename}
-        " --correct_am_hydro=0 --eos=WD --number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=KOKKOS_SYCL --multipole_device_kernel_type=KOKKOS_SYCL --hydro_device_kernel_type=KOKKOS_SYCL --hydro_host_kernel_type=DEVICE_ONLY")
+        " --correct_am_hydro=0 --eos=WD --number_gpus=1 --executors_per_gpu=32 --cuda_buffer_capacity=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=KOKKOS_SYCL --multipole_device_kernel_type=KOKKOS_SYCL --hydro_device_kernel_type=KOKKOS_SYCL --hydro_host_kernel_type=DEVICE_ONLY")
   endif()
   # TODO Add eos=wd CPU+GPU kokkos test
 

--- a/test_problems/rotating_star/CMakeLists.txt
+++ b/test_problems/rotating_star/CMakeLists.txt
@@ -152,7 +152,7 @@ if(OCTOTIGER_WITH_CUDA)
   if(NOT OCTOTIGER_WITH_FAST_FP_CONTRACT)
     # combined cpu+gpu
     test_rotating_star_scenario(test_problems.cpu_gpu.am_hydro_on.rotating_star_cuda rotating_star_am_hydro_on_cuda_log.txt ${silo_scenario_filename} 
-    "  --correct_am_hydro=1 --cuda_number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1 --monopole_host_kernel_type=VC --multipole_host_kernel_type=VC --monopole_device_kernel_type=CUDA --multipole_device_kernel_type=CUDA --hydro_device_kernel_type=CUDA --hydro_host_kernel_type=LEGACY")
+      "  --correct_am_hydro=1 --cuda_number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1 --monopole_host_kernel_type=VC --multipole_host_kernel_type=VC --monopole_device_kernel_type=CUDA --multipole_device_kernel_type=CUDA --hydro_device_kernel_type=CUDA --hydro_host_kernel_type=DEVICE_ONLY")
   endif()
 endif()
 if(OCTOTIGER_WITH_HIP)

--- a/test_problems/rotating_star/CMakeLists.txt
+++ b/test_problems/rotating_star/CMakeLists.txt
@@ -249,8 +249,10 @@ endif()
 if(OCTOTIGER_WITH_HIP)
   test_rotating_star_scenario(test_problems.gpu.am_hydro_off.rotating_star_hip rotating_star_am_hydro_off_hip_log.txt ${silo_scenario_filename}
     " --correct_am_hydro=0 --number_gpus=1 --executors_per_gpu=32 --max_gpu_executor_queue_length=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=HIP --multipole_device_kernel_type=HIP --hydro_device_kernel_type=HIP --hydro_host_kernel_type=DEVICE_ONLY")
-  test_rotating_star_scenario(test_problems.gpu.am_hydro_off.rotating_star_hip_work_aggregation rotating_star_am_hydro_off_hip_work_aggregation_log.txt ${silo_scenario_filename}
-  " --correct_am_hydro=0 --number_gpus=1 --executors_per_gpu=32 --max_gpu_executor_queue_length=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=HIP --multipole_device_kernel_type=HIP --hydro_device_kernel_type=HIP --hydro_host_kernel_type=DEVICE_ONLY --max_kernels_fused=8")
+  if (OCTOTIGER_WITH_GRIDDIM EQUAL 8)
+    test_rotating_star_scenario(test_problems.gpu.am_hydro_off.rotating_star_hip_work_aggregation rotating_star_am_hydro_off_hip_work_aggregation_log.txt ${silo_scenario_filename}
+    " --correct_am_hydro=0 --number_gpus=1 --executors_per_gpu=32 --max_gpu_executor_queue_length=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=HIP --multipole_device_kernel_type=HIP --hydro_device_kernel_type=HIP --hydro_host_kernel_type=DEVICE_ONLY --max_kernels_fused=8")
+  endif()
 endif()
 
 if(OCTOTIGER_WITH_KOKKOS)
@@ -270,8 +272,10 @@ if(OCTOTIGER_WITH_KOKKOS)
   if(OCTOTIGER_WITH_HIP)
     test_rotating_star_scenario(test_problems.gpu.am_hydro_off.rotating_star_kokkos_hip rotating_star_am_hydro_off_kokkos_hip_log.txt ${silo_scenario_filename}
       " --correct_am_hydro=0 --number_gpus=1 --executors_per_gpu=32 --max_gpu_executor_queue_length=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=KOKKOS_HIP --multipole_device_kernel_type=KOKKOS_HIP --hydro_device_kernel_type=KOKKOS_HIP --hydro_host_kernel_type=DEVICE_ONLY")
-  test_rotating_star_scenario(test_problems.gpu.am_hydro_off.rotating_star_kokkos_hip_work_aggregation rotating_star_am_hydro_off_kokkos_hip_work_aggregation_log.txt ${silo_scenario_filename}
-  " --correct_am_hydro=0 --number_gpus=1 --executors_per_gpu=32 --max_gpu_executor_queue_length=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=KOKKOS_HIP --multipole_device_kernel_type=KOKKOS_HIP --hydro_device_kernel_type=KOKKOS_HIP --hydro_host_kernel_type=DEVICE_ONLY --max_kernels_fused=8")
+    if (OCTOTIGER_WITH_GRIDDIM EQUAL 8)
+      test_rotating_star_scenario(test_problems.gpu.am_hydro_off.rotating_star_kokkos_hip_work_aggregation rotating_star_am_hydro_off_kokkos_hip_work_aggregation_log.txt ${silo_scenario_filename}
+      " --correct_am_hydro=0 --number_gpus=1 --executors_per_gpu=32 --max_gpu_executor_queue_length=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=KOKKOS_HIP --multipole_device_kernel_type=KOKKOS_HIP --hydro_device_kernel_type=KOKKOS_HIP --hydro_host_kernel_type=DEVICE_ONLY --max_kernels_fused=8")
+    endif()
   endif()
   if(Kokkos_ENABLE_SYCL)
     test_rotating_star_scenario(test_problems.gpu.am_hydro_off.rotating_star_kokkos_sycl rotating_star_am_hydro_off_kokkos_sycl_log.txt ${silo_scenario_filename}

--- a/test_problems/rotating_star/CMakeLists.txt
+++ b/test_problems/rotating_star/CMakeLists.txt
@@ -148,16 +148,16 @@ test_rotating_star_scenario(test_problems.cpu.am_hydro_on.rotating_star_legacy r
 "  --correct_am_hydro=1 --monopole_host_kernel_type=LEGACY --multipole_host_kernel_type=LEGACY --monopole_device_kernel_type=OFF --multipole_device_kernel_type=OFF --hydro_device_kernel_type=OFF --hydro_host_kernel_type=LEGACY")
 if(OCTOTIGER_WITH_CUDA)
   test_rotating_star_scenario(test_problems.gpu.am_hydro_on.rotating_star_cuda rotating_star_am_hydro_on_cuda_log.txt ${silo_scenario_filename} 
-  "  --correct_am_hydro=1 --cuda_number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=CUDA --multipole_device_kernel_type=CUDA --hydro_device_kernel_type=CUDA --hydro_host_kernel_type=DEVICE_ONLY")
+  "  --correct_am_hydro=1 --number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=CUDA --multipole_device_kernel_type=CUDA --hydro_device_kernel_type=CUDA --hydro_host_kernel_type=DEVICE_ONLY")
   if(NOT OCTOTIGER_WITH_FAST_FP_CONTRACT)
     # combined cpu+gpu
     test_rotating_star_scenario(test_problems.cpu_gpu.am_hydro_on.rotating_star_cuda rotating_star_am_hydro_on_cuda_log.txt ${silo_scenario_filename} 
-      "  --correct_am_hydro=1 --cuda_number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1 --monopole_host_kernel_type=VC --multipole_host_kernel_type=VC --monopole_device_kernel_type=CUDA --multipole_device_kernel_type=CUDA --hydro_device_kernel_type=CUDA --hydro_host_kernel_type=DEVICE_ONLY")
+      "  --correct_am_hydro=1 --number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1 --monopole_host_kernel_type=VC --multipole_host_kernel_type=VC --monopole_device_kernel_type=CUDA --multipole_device_kernel_type=CUDA --hydro_device_kernel_type=CUDA --hydro_host_kernel_type=DEVICE_ONLY")
   endif()
 endif()
 if(OCTOTIGER_WITH_HIP)
   test_rotating_star_scenario(test_problems.gpu.am_hydro_on.rotating_star_hip rotating_star_am_hydro_on_hip_log.txt ${silo_scenario_filename} 
-    "  --correct_am_hydro=1 --cuda_number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=HIP --multipole_device_kernel_type=HIP --hydro_device_kernel_type=HIP --hydro_host_kernel_type=DEVICE_ONLY ")
+    "  --correct_am_hydro=1 --number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=HIP --multipole_device_kernel_type=HIP --hydro_device_kernel_type=HIP --hydro_host_kernel_type=DEVICE_ONLY ")
 endif()
 
 if(OCTOTIGER_WITH_KOKKOS)
@@ -165,20 +165,20 @@ if(OCTOTIGER_WITH_KOKKOS)
   "  --correct_am_hydro=1 --monopole_host_kernel_type=KOKKOS --multipole_host_kernel_type=KOKKOS --monopole_device_kernel_type=OFF --multipole_device_kernel_type=OFF --hydro_device_kernel_type=OFF --hydro_host_kernel_type=KOKKOS")
   if(OCTOTIGER_WITH_CUDA)
     test_rotating_star_scenario(test_problems.gpu.am_hydro_on.rotating_star_kokkos rotating_star_am_hydro_on_kokkos_cuda_log.txt ${silo_scenario_filename} 
-    "  --correct_am_hydro=1 --cuda_number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=KOKKOS_CUDA --multipole_device_kernel_type=KOKKOS_CUDA --hydro_device_kernel_type=KOKKOS_CUDA --hydro_host_kernel_type=DEVICE_ONLY")
+    "  --correct_am_hydro=1 --number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=KOKKOS_CUDA --multipole_device_kernel_type=KOKKOS_CUDA --hydro_device_kernel_type=KOKKOS_CUDA --hydro_host_kernel_type=DEVICE_ONLY")
     if(NOT OCTOTIGER_WITH_FAST_FP_CONTRACT)
       # combined cpu+gpu
       test_rotating_star_scenario(test_problems.cpu_gpu.am_hydro_on.rotating_star_kokkos_cuda rotating_star_am_hydro_on_kokkos_cuda_log.txt ${silo_scenario_filename} 
-        "  --correct_am_hydro=1 --cuda_number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1 --monopole_host_kernel_type=KOKKOS --multipole_host_kernel_type=KOKKOS --monopole_device_kernel_type=KOKKOS_CUDA --multipole_device_kernel_type=KOKKOS_CUDA --hydro_device_kernel_type=KOKKOS_CUDA --hydro_host_kernel_type=DEVICE_ONLY")
+        "  --correct_am_hydro=1 --number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1 --monopole_host_kernel_type=KOKKOS --multipole_host_kernel_type=KOKKOS --monopole_device_kernel_type=KOKKOS_CUDA --multipole_device_kernel_type=KOKKOS_CUDA --hydro_device_kernel_type=KOKKOS_CUDA --hydro_host_kernel_type=DEVICE_ONLY")
     endif()
   endif()
   if(OCTOTIGER_WITH_HIP)
     test_rotating_star_scenario(test_problems.gpu.am_hydro_on.rotating_star_kokkos_hip rotating_star_am_hydro_on_kokkos_hip_log.txt ${silo_scenario_filename} 
-      "  --correct_am_hydro=1 --cuda_number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=KOKKOS_HIP --multipole_device_kernel_type=KOKKOS_HIP --hydro_device_kernel_type=KOKKOS_HIP --hydro_host_kernel_type=DEVICE_ONLY")
+      "  --correct_am_hydro=1 --number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=KOKKOS_HIP --multipole_device_kernel_type=KOKKOS_HIP --hydro_device_kernel_type=KOKKOS_HIP --hydro_host_kernel_type=DEVICE_ONLY")
   endif()
   if(Kokkos_ENABLE_SYCL)
     test_rotating_star_scenario(test_problems.gpu.am_hydro_on.rotating_star_kokkos_sycl rotating_star_am_hydro_on_kokkos_sycl_log.txt ${silo_scenario_filename} 
-      "  --correct_am_hydro=1 --cuda_number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=KOKKOS_SYCL --multipole_device_kernel_type=KOKKOS_SYCL --hydro_device_kernel_type=KOKKOS_SYCL --hydro_host_kernel_type=DEVICE_ONLY")
+      "  --correct_am_hydro=1 --number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=KOKKOS_SYCL --multipole_device_kernel_type=KOKKOS_SYCL --hydro_device_kernel_type=KOKKOS_SYCL --hydro_host_kernel_type=DEVICE_ONLY")
   endif()
 endif()
 
@@ -237,20 +237,20 @@ test_rotating_star_scenario(test_problems.cpu.am_hydro_off.rotating_star_legacy 
 " --correct_am_hydro=0 --monopole_host_kernel_type=LEGACY --multipole_host_kernel_type=LEGACY --monopole_device_kernel_type=OFF --multipole_device_kernel_type=OFF --hydro_device_kernel_type=OFF --hydro_host_kernel_type=LEGACY")
 if(OCTOTIGER_WITH_CUDA)
   test_rotating_star_scenario(test_problems.gpu.am_hydro_off.rotating_star_cuda rotating_star_am_hydro_off_cuda_log.txt ${silo_scenario_filename}
-  " --correct_am_hydro=0 --cuda_number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=CUDA --multipole_device_kernel_type=CUDA --hydro_device_kernel_type=CUDA --hydro_host_kernel_type=DEVICE_ONLY")
+  " --correct_am_hydro=0 --number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=CUDA --multipole_device_kernel_type=CUDA --hydro_device_kernel_type=CUDA --hydro_host_kernel_type=DEVICE_ONLY")
   test_rotating_star_scenario(test_problems.gpu.am_hydro_off.rotating_star_cuda_work_aggregation rotating_star_am_hydro_off_cuda_work_aggregation_log.txt ${silo_scenario_filename}
-  " --correct_am_hydro=0 --cuda_number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=CUDA --multipole_device_kernel_type=CUDA --hydro_device_kernel_type=CUDA --hydro_host_kernel_type=DEVICE_ONLY --max_executor_slices=8")
+  " --correct_am_hydro=0 --number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=CUDA --multipole_device_kernel_type=CUDA --hydro_device_kernel_type=CUDA --hydro_host_kernel_type=DEVICE_ONLY --max_executor_slices=8")
   if(NOT OCTOTIGER_WITH_FAST_FP_CONTRACT)
   # combined cpu+gpu
     test_rotating_star_scenario(test_problems.cpu_gpu.am_hydro_off.rotating_star_cuda rotating_star_am_hydro_off_cuda_log.txt ${silo_scenario_filename} 
-      "  --correct_am_hydro=0 --cuda_number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1 --monopole_host_kernel_type=VC --multipole_host_kernel_type=VC --monopole_device_kernel_type=CUDA --multipole_device_kernel_type=CUDA --hydro_device_kernel_type=CUDA --hydro_host_kernel_type=DEVICE_ONLY")
+      "  --correct_am_hydro=0 --number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1 --monopole_host_kernel_type=VC --multipole_host_kernel_type=VC --monopole_device_kernel_type=CUDA --multipole_device_kernel_type=CUDA --hydro_device_kernel_type=CUDA --hydro_host_kernel_type=DEVICE_ONLY")
   endif()
 endif()
 if(OCTOTIGER_WITH_HIP)
   test_rotating_star_scenario(test_problems.gpu.am_hydro_off.rotating_star_hip rotating_star_am_hydro_off_hip_log.txt ${silo_scenario_filename}
-    " --correct_am_hydro=0 --cuda_number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=HIP --multipole_device_kernel_type=HIP --hydro_device_kernel_type=HIP --hydro_host_kernel_type=DEVICE_ONLY")
+    " --correct_am_hydro=0 --number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=HIP --multipole_device_kernel_type=HIP --hydro_device_kernel_type=HIP --hydro_host_kernel_type=DEVICE_ONLY")
   test_rotating_star_scenario(test_problems.gpu.am_hydro_off.rotating_star_hip_work_aggregation rotating_star_am_hydro_off_hip_work_aggregation_log.txt ${silo_scenario_filename}
-  " --correct_am_hydro=0 --cuda_number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=HIP --multipole_device_kernel_type=HIP --hydro_device_kernel_type=HIP --hydro_host_kernel_type=DEVICE_ONLY --max_executor_slices=8")
+  " --correct_am_hydro=0 --number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=HIP --multipole_device_kernel_type=HIP --hydro_device_kernel_type=HIP --hydro_host_kernel_type=DEVICE_ONLY --max_executor_slices=8")
 endif()
 
 if(OCTOTIGER_WITH_KOKKOS)
@@ -258,26 +258,26 @@ if(OCTOTIGER_WITH_KOKKOS)
   " --correct_am_hydro=0 --monopole_host_kernel_type=KOKKOS --multipole_host_kernel_type=KOKKOS --monopole_device_kernel_type=OFF --multipole_device_kernel_type=OFF --hydro_device_kernel_type=OFF --hydro_host_kernel_type=KOKKOS")
   if(OCTOTIGER_WITH_CUDA)
     test_rotating_star_scenario(test_problems.gpu.am_hydro_off.rotating_star_kokkos_cuda rotating_star_am_hydro_off_kokkos_cuda_log.txt ${silo_scenario_filename}
-    " --correct_am_hydro=0 --cuda_number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=KOKKOS_CUDA --multipole_device_kernel_type=KOKKOS_CUDA --hydro_device_kernel_type=KOKKOS_CUDA --hydro_host_kernel_type=DEVICE_ONLY")
+    " --correct_am_hydro=0 --number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=KOKKOS_CUDA --multipole_device_kernel_type=KOKKOS_CUDA --hydro_device_kernel_type=KOKKOS_CUDA --hydro_host_kernel_type=DEVICE_ONLY")
   test_rotating_star_scenario(test_problems.gpu.am_hydro_off.rotating_star_kokkos_cuda_work_aggregation rotating_star_am_hydro_off_kokkos_cuda_work_aggregation_log.txt ${silo_scenario_filename}
-  " --correct_am_hydro=0 --cuda_number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=KOKKOS_CUDA --multipole_device_kernel_type=KOKKOS_CUDA --hydro_device_kernel_type=KOKKOS_CUDA --hydro_host_kernel_type=DEVICE_ONLY --max_executor_slices=8")
+  " --correct_am_hydro=0 --number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=KOKKOS_CUDA --multipole_device_kernel_type=KOKKOS_CUDA --hydro_device_kernel_type=KOKKOS_CUDA --hydro_host_kernel_type=DEVICE_ONLY --max_executor_slices=8")
     if(NOT OCTOTIGER_WITH_FAST_FP_CONTRACT)
       # combined cpu+gpu
       test_rotating_star_scenario(test_problems.cpu_gpu.am_hydro_off.rotating_star_kokkos_cuda rotating_star_am_hydro_off_kokkos_cuda_log.txt ${silo_scenario_filename} 
-        "  --correct_am_hydro=0 --cuda_number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1 --monopole_host_kernel_type=KOKKOS --multipole_host_kernel_type=KOKKOS --monopole_device_kernel_type=KOKKOS_CUDA --multipole_device_kernel_type=KOKKOS_CUDA --hydro_device_kernel_type=KOKKOS_CUDA --hydro_host_kernel_type=DEVICE_ONLY")
+        "  --correct_am_hydro=0 --number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1 --monopole_host_kernel_type=KOKKOS --multipole_host_kernel_type=KOKKOS --monopole_device_kernel_type=KOKKOS_CUDA --multipole_device_kernel_type=KOKKOS_CUDA --hydro_device_kernel_type=KOKKOS_CUDA --hydro_host_kernel_type=DEVICE_ONLY")
     endif()
   endif()
   if(OCTOTIGER_WITH_HIP)
     test_rotating_star_scenario(test_problems.gpu.am_hydro_off.rotating_star_kokkos_hip rotating_star_am_hydro_off_kokkos_hip_log.txt ${silo_scenario_filename}
-      " --correct_am_hydro=0 --cuda_number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=KOKKOS_HIP --multipole_device_kernel_type=KOKKOS_HIP --hydro_device_kernel_type=KOKKOS_HIP --hydro_host_kernel_type=DEVICE_ONLY")
+      " --correct_am_hydro=0 --number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=KOKKOS_HIP --multipole_device_kernel_type=KOKKOS_HIP --hydro_device_kernel_type=KOKKOS_HIP --hydro_host_kernel_type=DEVICE_ONLY")
   test_rotating_star_scenario(test_problems.gpu.am_hydro_off.rotating_star_kokkos_hip_work_aggregation rotating_star_am_hydro_off_kokkos_hip_work_aggregation_log.txt ${silo_scenario_filename}
-  " --correct_am_hydro=0 --cuda_number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=KOKKOS_HIP --multipole_device_kernel_type=KOKKOS_HIP --hydro_device_kernel_type=KOKKOS_HIP --hydro_host_kernel_type=DEVICE_ONLY --max_executor_slices=8")
+  " --correct_am_hydro=0 --number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=KOKKOS_HIP --multipole_device_kernel_type=KOKKOS_HIP --hydro_device_kernel_type=KOKKOS_HIP --hydro_host_kernel_type=DEVICE_ONLY --max_executor_slices=8")
   endif()
   if(Kokkos_ENABLE_SYCL)
     test_rotating_star_scenario(test_problems.gpu.am_hydro_off.rotating_star_kokkos_sycl rotating_star_am_hydro_off_kokkos_sycl_log.txt ${silo_scenario_filename}
-      " --correct_am_hydro=0 --cuda_number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=KOKKOS_SYCL --multipole_device_kernel_type=KOKKOS_SYCL --hydro_device_kernel_type=KOKKOS_SYCL --hydro_host_kernel_type=DEVICE_ONLY")
+      " --correct_am_hydro=0 --number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=KOKKOS_SYCL --multipole_device_kernel_type=KOKKOS_SYCL --hydro_device_kernel_type=KOKKOS_SYCL --hydro_host_kernel_type=DEVICE_ONLY")
     test_rotating_star_scenario(test_problems.gpu.am_hydro_off.rotating_star_kokkos_sycl_work_aggregation rotating_star_am_hydro_off_kokkos_sycl_work_aggregation_log.txt ${silo_scenario_filename}
-    " --correct_am_hydro=0 --cuda_number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=KOKKOS_SYCL --multipole_device_kernel_type=KOKKOS_SYCL --hydro_device_kernel_type=KOKKOS_SYCL --hydro_host_kernel_type=DEVICE_ONLY --max_executor_slices=8")
+    " --correct_am_hydro=0 --number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=KOKKOS_SYCL --multipole_device_kernel_type=KOKKOS_SYCL --hydro_device_kernel_type=KOKKOS_SYCL --hydro_host_kernel_type=DEVICE_ONLY --max_executor_slices=8")
   endif()
 endif()
 
@@ -318,11 +318,11 @@ if (OCTOTIGER_WITH_GRIDDIM EQUAL 8)
     " --correct_am_hydro=0 --eos=WD --monopole_host_kernel_type=LEGACY --multipole_host_kernel_type=LEGACY --monopole_device_kernel_type=OFF --multipole_device_kernel_type=OFF --hydro_device_kernel_type=OFF --hydro_host_kernel_type=LEGACY")
   if(OCTOTIGER_WITH_CUDA)
     test_rotating_star_scenario(test_problems.gpu.eos_wd.rotating_star_cuda rotating_star_eos_wd_cuda_log.txt ${silo_scenario_filename}
-      " --correct_am_hydro=0 --eos=WD --cuda_number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=CUDA --multipole_device_kernel_type=CUDA --hydro_device_kernel_type=CUDA --hydro_host_kernel_type=DEVICE_ONLY")
+      " --correct_am_hydro=0 --eos=WD --number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=CUDA --multipole_device_kernel_type=CUDA --hydro_device_kernel_type=CUDA --hydro_host_kernel_type=DEVICE_ONLY")
   endif()
   if(OCTOTIGER_WITH_HIP)
     test_rotating_star_scenario(test_problems.gpu.eos_wd.rotating_star_hip rotating_star_eos_wd_hip.txt ${silo_scenario_filename}
-      " --correct_am_hydro=0 --eos=WD --cuda_number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=HIP --multipole_device_kernel_type=HIP --hydro_device_kernel_type=HIP --hydro_host_kernel_type=DEVICE_ONLY")
+      " --correct_am_hydro=0 --eos=WD --number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=HIP --multipole_device_kernel_type=HIP --hydro_device_kernel_type=HIP --hydro_host_kernel_type=DEVICE_ONLY")
   endif()
   # TODO Add eos=wd CPU+GPU test
 
@@ -331,16 +331,16 @@ if (OCTOTIGER_WITH_GRIDDIM EQUAL 8)
       " --correct_am_hydro=0 --eos=WD --monopole_host_kernel_type=KOKKOS --multipole_host_kernel_type=KOKKOS --monopole_device_kernel_type=OFF --multipole_device_kernel_type=OFF --hydro_device_kernel_type=OFF --hydro_host_kernel_type=KOKKOS")
     if(OCTOTIGER_WITH_CUDA)
       test_rotating_star_scenario(test_problems.gpu.eos_wd.rotating_star_kokkos_cuda rotating_star_eos_wd_kokkos_cuda_log.txt ${silo_scenario_filename}
-        " --correct_am_hydro=0 --eos=WD --cuda_number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=KOKKOS_CUDA --multipole_device_kernel_type=KOKKOS_CUDA --hydro_device_kernel_type=KOKKOS_CUDA --hydro_host_kernel_type=DEVICE_ONLY")
+        " --correct_am_hydro=0 --eos=WD --number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=KOKKOS_CUDA --multipole_device_kernel_type=KOKKOS_CUDA --hydro_device_kernel_type=KOKKOS_CUDA --hydro_host_kernel_type=DEVICE_ONLY")
     endif()
     if(OCTOTIGER_WITH_HIP)
       test_rotating_star_scenario(test_problems.gpu.eos_wd.rotating_star_kokkos_hip rotating_star_eos_wd_kokkos_hip.txt ${silo_scenario_filename}
-        " --correct_am_hydro=0 --eos=WD --cuda_number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=KOKKOS_HIP --multipole_device_kernel_type=KOKKOS_HIP --hydro_device_kernel_type=KOKKOS_HIP --hydro_host_kernel_type=DEVICE_ONLY")
+        " --correct_am_hydro=0 --eos=WD --number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=KOKKOS_HIP --multipole_device_kernel_type=KOKKOS_HIP --hydro_device_kernel_type=KOKKOS_HIP --hydro_host_kernel_type=DEVICE_ONLY")
     endif()
   endif()
   if(Kokkos_ENABLE_SYCL)
       test_rotating_star_scenario(test_problems.gpu.eos_wd.rotating_star_kokkos_sycl rotating_star_eos_wd_kokkos_sycl.txt ${silo_scenario_filename}
-        " --correct_am_hydro=0 --eos=WD --cuda_number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=KOKKOS_SYCL --multipole_device_kernel_type=KOKKOS_SYCL --hydro_device_kernel_type=KOKKOS_SYCL --hydro_host_kernel_type=DEVICE_ONLY")
+        " --correct_am_hydro=0 --eos=WD --number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=KOKKOS_SYCL --multipole_device_kernel_type=KOKKOS_SYCL --hydro_device_kernel_type=KOKKOS_SYCL --hydro_host_kernel_type=DEVICE_ONLY")
   endif()
   # TODO Add eos=wd CPU+GPU kokkos test
 

--- a/test_problems/rotating_star/CMakeLists.txt
+++ b/test_problems/rotating_star/CMakeLists.txt
@@ -148,16 +148,16 @@ test_rotating_star_scenario(test_problems.cpu.am_hydro_on.rotating_star_legacy r
 "  --correct_am_hydro=1 --monopole_host_kernel_type=LEGACY --multipole_host_kernel_type=LEGACY --monopole_device_kernel_type=OFF --multipole_device_kernel_type=OFF --hydro_device_kernel_type=OFF --hydro_host_kernel_type=LEGACY")
 if(OCTOTIGER_WITH_CUDA)
   test_rotating_star_scenario(test_problems.gpu.am_hydro_on.rotating_star_cuda rotating_star_am_hydro_on_cuda_log.txt ${silo_scenario_filename} 
-  "  --correct_am_hydro=1 --number_gpus=1 --executors_per_gpu=32 --cuda_buffer_capacity=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=CUDA --multipole_device_kernel_type=CUDA --hydro_device_kernel_type=CUDA --hydro_host_kernel_type=DEVICE_ONLY")
+  "  --correct_am_hydro=1 --number_gpus=1 --executors_per_gpu=32 --max_gpu_executor_queue_length=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=CUDA --multipole_device_kernel_type=CUDA --hydro_device_kernel_type=CUDA --hydro_host_kernel_type=DEVICE_ONLY")
   if(NOT OCTOTIGER_WITH_FAST_FP_CONTRACT)
     # combined cpu+gpu
     test_rotating_star_scenario(test_problems.cpu_gpu.am_hydro_on.rotating_star_cuda rotating_star_am_hydro_on_cuda_log.txt ${silo_scenario_filename} 
-      "  --correct_am_hydro=1 --number_gpus=1 --executors_per_gpu=32 --cuda_buffer_capacity=1 --monopole_host_kernel_type=VC --multipole_host_kernel_type=VC --monopole_device_kernel_type=CUDA --multipole_device_kernel_type=CUDA --hydro_device_kernel_type=CUDA --hydro_host_kernel_type=DEVICE_ONLY")
+      "  --correct_am_hydro=1 --number_gpus=1 --executors_per_gpu=32 --max_gpu_executor_queue_length=1 --monopole_host_kernel_type=VC --multipole_host_kernel_type=VC --monopole_device_kernel_type=CUDA --multipole_device_kernel_type=CUDA --hydro_device_kernel_type=CUDA --hydro_host_kernel_type=DEVICE_ONLY")
   endif()
 endif()
 if(OCTOTIGER_WITH_HIP)
   test_rotating_star_scenario(test_problems.gpu.am_hydro_on.rotating_star_hip rotating_star_am_hydro_on_hip_log.txt ${silo_scenario_filename} 
-    "  --correct_am_hydro=1 --number_gpus=1 --executors_per_gpu=32 --cuda_buffer_capacity=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=HIP --multipole_device_kernel_type=HIP --hydro_device_kernel_type=HIP --hydro_host_kernel_type=DEVICE_ONLY ")
+    "  --correct_am_hydro=1 --number_gpus=1 --executors_per_gpu=32 --max_gpu_executor_queue_length=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=HIP --multipole_device_kernel_type=HIP --hydro_device_kernel_type=HIP --hydro_host_kernel_type=DEVICE_ONLY ")
 endif()
 
 if(OCTOTIGER_WITH_KOKKOS)
@@ -165,20 +165,20 @@ if(OCTOTIGER_WITH_KOKKOS)
   "  --correct_am_hydro=1 --monopole_host_kernel_type=KOKKOS --multipole_host_kernel_type=KOKKOS --monopole_device_kernel_type=OFF --multipole_device_kernel_type=OFF --hydro_device_kernel_type=OFF --hydro_host_kernel_type=KOKKOS")
   if(OCTOTIGER_WITH_CUDA)
     test_rotating_star_scenario(test_problems.gpu.am_hydro_on.rotating_star_kokkos rotating_star_am_hydro_on_kokkos_cuda_log.txt ${silo_scenario_filename} 
-    "  --correct_am_hydro=1 --number_gpus=1 --executors_per_gpu=32 --cuda_buffer_capacity=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=KOKKOS_CUDA --multipole_device_kernel_type=KOKKOS_CUDA --hydro_device_kernel_type=KOKKOS_CUDA --hydro_host_kernel_type=DEVICE_ONLY")
+    "  --correct_am_hydro=1 --number_gpus=1 --executors_per_gpu=32 --max_gpu_executor_queue_length=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=KOKKOS_CUDA --multipole_device_kernel_type=KOKKOS_CUDA --hydro_device_kernel_type=KOKKOS_CUDA --hydro_host_kernel_type=DEVICE_ONLY")
     if(NOT OCTOTIGER_WITH_FAST_FP_CONTRACT)
       # combined cpu+gpu
       test_rotating_star_scenario(test_problems.cpu_gpu.am_hydro_on.rotating_star_kokkos_cuda rotating_star_am_hydro_on_kokkos_cuda_log.txt ${silo_scenario_filename} 
-        "  --correct_am_hydro=1 --number_gpus=1 --executors_per_gpu=32 --cuda_buffer_capacity=1 --monopole_host_kernel_type=KOKKOS --multipole_host_kernel_type=KOKKOS --monopole_device_kernel_type=KOKKOS_CUDA --multipole_device_kernel_type=KOKKOS_CUDA --hydro_device_kernel_type=KOKKOS_CUDA --hydro_host_kernel_type=DEVICE_ONLY")
+        "  --correct_am_hydro=1 --number_gpus=1 --executors_per_gpu=32 --max_gpu_executor_queue_length=1 --monopole_host_kernel_type=KOKKOS --multipole_host_kernel_type=KOKKOS --monopole_device_kernel_type=KOKKOS_CUDA --multipole_device_kernel_type=KOKKOS_CUDA --hydro_device_kernel_type=KOKKOS_CUDA --hydro_host_kernel_type=DEVICE_ONLY")
     endif()
   endif()
   if(OCTOTIGER_WITH_HIP)
     test_rotating_star_scenario(test_problems.gpu.am_hydro_on.rotating_star_kokkos_hip rotating_star_am_hydro_on_kokkos_hip_log.txt ${silo_scenario_filename} 
-      "  --correct_am_hydro=1 --number_gpus=1 --executors_per_gpu=32 --cuda_buffer_capacity=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=KOKKOS_HIP --multipole_device_kernel_type=KOKKOS_HIP --hydro_device_kernel_type=KOKKOS_HIP --hydro_host_kernel_type=DEVICE_ONLY")
+      "  --correct_am_hydro=1 --number_gpus=1 --executors_per_gpu=32 --max_gpu_executor_queue_length=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=KOKKOS_HIP --multipole_device_kernel_type=KOKKOS_HIP --hydro_device_kernel_type=KOKKOS_HIP --hydro_host_kernel_type=DEVICE_ONLY")
   endif()
   if(Kokkos_ENABLE_SYCL)
     test_rotating_star_scenario(test_problems.gpu.am_hydro_on.rotating_star_kokkos_sycl rotating_star_am_hydro_on_kokkos_sycl_log.txt ${silo_scenario_filename} 
-      "  --correct_am_hydro=1 --number_gpus=1 --executors_per_gpu=32 --cuda_buffer_capacity=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=KOKKOS_SYCL --multipole_device_kernel_type=KOKKOS_SYCL --hydro_device_kernel_type=KOKKOS_SYCL --hydro_host_kernel_type=DEVICE_ONLY")
+      "  --correct_am_hydro=1 --number_gpus=1 --executors_per_gpu=32 --max_gpu_executor_queue_length=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=KOKKOS_SYCL --multipole_device_kernel_type=KOKKOS_SYCL --hydro_device_kernel_type=KOKKOS_SYCL --hydro_host_kernel_type=DEVICE_ONLY")
   endif()
 endif()
 
@@ -237,20 +237,20 @@ test_rotating_star_scenario(test_problems.cpu.am_hydro_off.rotating_star_legacy 
 " --correct_am_hydro=0 --monopole_host_kernel_type=LEGACY --multipole_host_kernel_type=LEGACY --monopole_device_kernel_type=OFF --multipole_device_kernel_type=OFF --hydro_device_kernel_type=OFF --hydro_host_kernel_type=LEGACY")
 if(OCTOTIGER_WITH_CUDA)
   test_rotating_star_scenario(test_problems.gpu.am_hydro_off.rotating_star_cuda rotating_star_am_hydro_off_cuda_log.txt ${silo_scenario_filename}
-  " --correct_am_hydro=0 --number_gpus=1 --executors_per_gpu=32 --cuda_buffer_capacity=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=CUDA --multipole_device_kernel_type=CUDA --hydro_device_kernel_type=CUDA --hydro_host_kernel_type=DEVICE_ONLY")
+  " --correct_am_hydro=0 --number_gpus=1 --executors_per_gpu=32 --max_gpu_executor_queue_length=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=CUDA --multipole_device_kernel_type=CUDA --hydro_device_kernel_type=CUDA --hydro_host_kernel_type=DEVICE_ONLY")
   test_rotating_star_scenario(test_problems.gpu.am_hydro_off.rotating_star_cuda_work_aggregation rotating_star_am_hydro_off_cuda_work_aggregation_log.txt ${silo_scenario_filename}
-  " --correct_am_hydro=0 --number_gpus=1 --executors_per_gpu=32 --cuda_buffer_capacity=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=CUDA --multipole_device_kernel_type=CUDA --hydro_device_kernel_type=CUDA --hydro_host_kernel_type=DEVICE_ONLY --max_executor_slices=8")
+  " --correct_am_hydro=0 --number_gpus=1 --executors_per_gpu=32 --max_gpu_executor_queue_length=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=CUDA --multipole_device_kernel_type=CUDA --hydro_device_kernel_type=CUDA --hydro_host_kernel_type=DEVICE_ONLY --max_executor_slices=8")
   if(NOT OCTOTIGER_WITH_FAST_FP_CONTRACT)
   # combined cpu+gpu
     test_rotating_star_scenario(test_problems.cpu_gpu.am_hydro_off.rotating_star_cuda rotating_star_am_hydro_off_cuda_log.txt ${silo_scenario_filename} 
-      "  --correct_am_hydro=0 --number_gpus=1 --executors_per_gpu=32 --cuda_buffer_capacity=1 --monopole_host_kernel_type=VC --multipole_host_kernel_type=VC --monopole_device_kernel_type=CUDA --multipole_device_kernel_type=CUDA --hydro_device_kernel_type=CUDA --hydro_host_kernel_type=DEVICE_ONLY")
+      "  --correct_am_hydro=0 --number_gpus=1 --executors_per_gpu=32 --max_gpu_executor_queue_length=1 --monopole_host_kernel_type=VC --multipole_host_kernel_type=VC --monopole_device_kernel_type=CUDA --multipole_device_kernel_type=CUDA --hydro_device_kernel_type=CUDA --hydro_host_kernel_type=DEVICE_ONLY")
   endif()
 endif()
 if(OCTOTIGER_WITH_HIP)
   test_rotating_star_scenario(test_problems.gpu.am_hydro_off.rotating_star_hip rotating_star_am_hydro_off_hip_log.txt ${silo_scenario_filename}
-    " --correct_am_hydro=0 --number_gpus=1 --executors_per_gpu=32 --cuda_buffer_capacity=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=HIP --multipole_device_kernel_type=HIP --hydro_device_kernel_type=HIP --hydro_host_kernel_type=DEVICE_ONLY")
+    " --correct_am_hydro=0 --number_gpus=1 --executors_per_gpu=32 --max_gpu_executor_queue_length=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=HIP --multipole_device_kernel_type=HIP --hydro_device_kernel_type=HIP --hydro_host_kernel_type=DEVICE_ONLY")
   test_rotating_star_scenario(test_problems.gpu.am_hydro_off.rotating_star_hip_work_aggregation rotating_star_am_hydro_off_hip_work_aggregation_log.txt ${silo_scenario_filename}
-  " --correct_am_hydro=0 --number_gpus=1 --executors_per_gpu=32 --cuda_buffer_capacity=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=HIP --multipole_device_kernel_type=HIP --hydro_device_kernel_type=HIP --hydro_host_kernel_type=DEVICE_ONLY --max_executor_slices=8")
+  " --correct_am_hydro=0 --number_gpus=1 --executors_per_gpu=32 --max_gpu_executor_queue_length=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=HIP --multipole_device_kernel_type=HIP --hydro_device_kernel_type=HIP --hydro_host_kernel_type=DEVICE_ONLY --max_executor_slices=8")
 endif()
 
 if(OCTOTIGER_WITH_KOKKOS)
@@ -258,26 +258,26 @@ if(OCTOTIGER_WITH_KOKKOS)
   " --correct_am_hydro=0 --monopole_host_kernel_type=KOKKOS --multipole_host_kernel_type=KOKKOS --monopole_device_kernel_type=OFF --multipole_device_kernel_type=OFF --hydro_device_kernel_type=OFF --hydro_host_kernel_type=KOKKOS")
   if(OCTOTIGER_WITH_CUDA)
     test_rotating_star_scenario(test_problems.gpu.am_hydro_off.rotating_star_kokkos_cuda rotating_star_am_hydro_off_kokkos_cuda_log.txt ${silo_scenario_filename}
-    " --correct_am_hydro=0 --number_gpus=1 --executors_per_gpu=32 --cuda_buffer_capacity=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=KOKKOS_CUDA --multipole_device_kernel_type=KOKKOS_CUDA --hydro_device_kernel_type=KOKKOS_CUDA --hydro_host_kernel_type=DEVICE_ONLY")
+    " --correct_am_hydro=0 --number_gpus=1 --executors_per_gpu=32 --max_gpu_executor_queue_length=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=KOKKOS_CUDA --multipole_device_kernel_type=KOKKOS_CUDA --hydro_device_kernel_type=KOKKOS_CUDA --hydro_host_kernel_type=DEVICE_ONLY")
   test_rotating_star_scenario(test_problems.gpu.am_hydro_off.rotating_star_kokkos_cuda_work_aggregation rotating_star_am_hydro_off_kokkos_cuda_work_aggregation_log.txt ${silo_scenario_filename}
-  " --correct_am_hydro=0 --number_gpus=1 --executors_per_gpu=32 --cuda_buffer_capacity=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=KOKKOS_CUDA --multipole_device_kernel_type=KOKKOS_CUDA --hydro_device_kernel_type=KOKKOS_CUDA --hydro_host_kernel_type=DEVICE_ONLY --max_executor_slices=8")
+  " --correct_am_hydro=0 --number_gpus=1 --executors_per_gpu=32 --max_gpu_executor_queue_length=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=KOKKOS_CUDA --multipole_device_kernel_type=KOKKOS_CUDA --hydro_device_kernel_type=KOKKOS_CUDA --hydro_host_kernel_type=DEVICE_ONLY --max_executor_slices=8")
     if(NOT OCTOTIGER_WITH_FAST_FP_CONTRACT)
       # combined cpu+gpu
       test_rotating_star_scenario(test_problems.cpu_gpu.am_hydro_off.rotating_star_kokkos_cuda rotating_star_am_hydro_off_kokkos_cuda_log.txt ${silo_scenario_filename} 
-        "  --correct_am_hydro=0 --number_gpus=1 --executors_per_gpu=32 --cuda_buffer_capacity=1 --monopole_host_kernel_type=KOKKOS --multipole_host_kernel_type=KOKKOS --monopole_device_kernel_type=KOKKOS_CUDA --multipole_device_kernel_type=KOKKOS_CUDA --hydro_device_kernel_type=KOKKOS_CUDA --hydro_host_kernel_type=DEVICE_ONLY")
+        "  --correct_am_hydro=0 --number_gpus=1 --executors_per_gpu=32 --max_gpu_executor_queue_length=1 --monopole_host_kernel_type=KOKKOS --multipole_host_kernel_type=KOKKOS --monopole_device_kernel_type=KOKKOS_CUDA --multipole_device_kernel_type=KOKKOS_CUDA --hydro_device_kernel_type=KOKKOS_CUDA --hydro_host_kernel_type=DEVICE_ONLY")
     endif()
   endif()
   if(OCTOTIGER_WITH_HIP)
     test_rotating_star_scenario(test_problems.gpu.am_hydro_off.rotating_star_kokkos_hip rotating_star_am_hydro_off_kokkos_hip_log.txt ${silo_scenario_filename}
-      " --correct_am_hydro=0 --number_gpus=1 --executors_per_gpu=32 --cuda_buffer_capacity=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=KOKKOS_HIP --multipole_device_kernel_type=KOKKOS_HIP --hydro_device_kernel_type=KOKKOS_HIP --hydro_host_kernel_type=DEVICE_ONLY")
+      " --correct_am_hydro=0 --number_gpus=1 --executors_per_gpu=32 --max_gpu_executor_queue_length=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=KOKKOS_HIP --multipole_device_kernel_type=KOKKOS_HIP --hydro_device_kernel_type=KOKKOS_HIP --hydro_host_kernel_type=DEVICE_ONLY")
   test_rotating_star_scenario(test_problems.gpu.am_hydro_off.rotating_star_kokkos_hip_work_aggregation rotating_star_am_hydro_off_kokkos_hip_work_aggregation_log.txt ${silo_scenario_filename}
-  " --correct_am_hydro=0 --number_gpus=1 --executors_per_gpu=32 --cuda_buffer_capacity=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=KOKKOS_HIP --multipole_device_kernel_type=KOKKOS_HIP --hydro_device_kernel_type=KOKKOS_HIP --hydro_host_kernel_type=DEVICE_ONLY --max_executor_slices=8")
+  " --correct_am_hydro=0 --number_gpus=1 --executors_per_gpu=32 --max_gpu_executor_queue_length=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=KOKKOS_HIP --multipole_device_kernel_type=KOKKOS_HIP --hydro_device_kernel_type=KOKKOS_HIP --hydro_host_kernel_type=DEVICE_ONLY --max_executor_slices=8")
   endif()
   if(Kokkos_ENABLE_SYCL)
     test_rotating_star_scenario(test_problems.gpu.am_hydro_off.rotating_star_kokkos_sycl rotating_star_am_hydro_off_kokkos_sycl_log.txt ${silo_scenario_filename}
-      " --correct_am_hydro=0 --number_gpus=1 --executors_per_gpu=32 --cuda_buffer_capacity=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=KOKKOS_SYCL --multipole_device_kernel_type=KOKKOS_SYCL --hydro_device_kernel_type=KOKKOS_SYCL --hydro_host_kernel_type=DEVICE_ONLY")
+      " --correct_am_hydro=0 --number_gpus=1 --executors_per_gpu=32 --max_gpu_executor_queue_length=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=KOKKOS_SYCL --multipole_device_kernel_type=KOKKOS_SYCL --hydro_device_kernel_type=KOKKOS_SYCL --hydro_host_kernel_type=DEVICE_ONLY")
     test_rotating_star_scenario(test_problems.gpu.am_hydro_off.rotating_star_kokkos_sycl_work_aggregation rotating_star_am_hydro_off_kokkos_sycl_work_aggregation_log.txt ${silo_scenario_filename}
-    " --correct_am_hydro=0 --number_gpus=1 --executors_per_gpu=32 --cuda_buffer_capacity=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=KOKKOS_SYCL --multipole_device_kernel_type=KOKKOS_SYCL --hydro_device_kernel_type=KOKKOS_SYCL --hydro_host_kernel_type=DEVICE_ONLY --max_executor_slices=8")
+    " --correct_am_hydro=0 --number_gpus=1 --executors_per_gpu=32 --max_gpu_executor_queue_length=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=KOKKOS_SYCL --multipole_device_kernel_type=KOKKOS_SYCL --hydro_device_kernel_type=KOKKOS_SYCL --hydro_host_kernel_type=DEVICE_ONLY --max_executor_slices=8")
   endif()
 endif()
 
@@ -318,11 +318,11 @@ if (OCTOTIGER_WITH_GRIDDIM EQUAL 8)
     " --correct_am_hydro=0 --eos=WD --monopole_host_kernel_type=LEGACY --multipole_host_kernel_type=LEGACY --monopole_device_kernel_type=OFF --multipole_device_kernel_type=OFF --hydro_device_kernel_type=OFF --hydro_host_kernel_type=LEGACY")
   if(OCTOTIGER_WITH_CUDA)
     test_rotating_star_scenario(test_problems.gpu.eos_wd.rotating_star_cuda rotating_star_eos_wd_cuda_log.txt ${silo_scenario_filename}
-      " --correct_am_hydro=0 --eos=WD --number_gpus=1 --executors_per_gpu=32 --cuda_buffer_capacity=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=CUDA --multipole_device_kernel_type=CUDA --hydro_device_kernel_type=CUDA --hydro_host_kernel_type=DEVICE_ONLY")
+      " --correct_am_hydro=0 --eos=WD --number_gpus=1 --executors_per_gpu=32 --max_gpu_executor_queue_length=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=CUDA --multipole_device_kernel_type=CUDA --hydro_device_kernel_type=CUDA --hydro_host_kernel_type=DEVICE_ONLY")
   endif()
   if(OCTOTIGER_WITH_HIP)
     test_rotating_star_scenario(test_problems.gpu.eos_wd.rotating_star_hip rotating_star_eos_wd_hip.txt ${silo_scenario_filename}
-      " --correct_am_hydro=0 --eos=WD --number_gpus=1 --executors_per_gpu=32 --cuda_buffer_capacity=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=HIP --multipole_device_kernel_type=HIP --hydro_device_kernel_type=HIP --hydro_host_kernel_type=DEVICE_ONLY")
+      " --correct_am_hydro=0 --eos=WD --number_gpus=1 --executors_per_gpu=32 --max_gpu_executor_queue_length=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=HIP --multipole_device_kernel_type=HIP --hydro_device_kernel_type=HIP --hydro_host_kernel_type=DEVICE_ONLY")
   endif()
   # TODO Add eos=wd CPU+GPU test
 
@@ -331,16 +331,16 @@ if (OCTOTIGER_WITH_GRIDDIM EQUAL 8)
       " --correct_am_hydro=0 --eos=WD --monopole_host_kernel_type=KOKKOS --multipole_host_kernel_type=KOKKOS --monopole_device_kernel_type=OFF --multipole_device_kernel_type=OFF --hydro_device_kernel_type=OFF --hydro_host_kernel_type=KOKKOS")
     if(OCTOTIGER_WITH_CUDA)
       test_rotating_star_scenario(test_problems.gpu.eos_wd.rotating_star_kokkos_cuda rotating_star_eos_wd_kokkos_cuda_log.txt ${silo_scenario_filename}
-        " --correct_am_hydro=0 --eos=WD --number_gpus=1 --executors_per_gpu=32 --cuda_buffer_capacity=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=KOKKOS_CUDA --multipole_device_kernel_type=KOKKOS_CUDA --hydro_device_kernel_type=KOKKOS_CUDA --hydro_host_kernel_type=DEVICE_ONLY")
+        " --correct_am_hydro=0 --eos=WD --number_gpus=1 --executors_per_gpu=32 --max_gpu_executor_queue_length=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=KOKKOS_CUDA --multipole_device_kernel_type=KOKKOS_CUDA --hydro_device_kernel_type=KOKKOS_CUDA --hydro_host_kernel_type=DEVICE_ONLY")
     endif()
     if(OCTOTIGER_WITH_HIP)
       test_rotating_star_scenario(test_problems.gpu.eos_wd.rotating_star_kokkos_hip rotating_star_eos_wd_kokkos_hip.txt ${silo_scenario_filename}
-        " --correct_am_hydro=0 --eos=WD --number_gpus=1 --executors_per_gpu=32 --cuda_buffer_capacity=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=KOKKOS_HIP --multipole_device_kernel_type=KOKKOS_HIP --hydro_device_kernel_type=KOKKOS_HIP --hydro_host_kernel_type=DEVICE_ONLY")
+        " --correct_am_hydro=0 --eos=WD --number_gpus=1 --executors_per_gpu=32 --max_gpu_executor_queue_length=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=KOKKOS_HIP --multipole_device_kernel_type=KOKKOS_HIP --hydro_device_kernel_type=KOKKOS_HIP --hydro_host_kernel_type=DEVICE_ONLY")
     endif()
   endif()
   if(Kokkos_ENABLE_SYCL)
       test_rotating_star_scenario(test_problems.gpu.eos_wd.rotating_star_kokkos_sycl rotating_star_eos_wd_kokkos_sycl.txt ${silo_scenario_filename}
-        " --correct_am_hydro=0 --eos=WD --number_gpus=1 --executors_per_gpu=32 --cuda_buffer_capacity=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=KOKKOS_SYCL --multipole_device_kernel_type=KOKKOS_SYCL --hydro_device_kernel_type=KOKKOS_SYCL --hydro_host_kernel_type=DEVICE_ONLY")
+        " --correct_am_hydro=0 --eos=WD --number_gpus=1 --executors_per_gpu=32 --max_gpu_executor_queue_length=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=KOKKOS_SYCL --multipole_device_kernel_type=KOKKOS_SYCL --hydro_device_kernel_type=KOKKOS_SYCL --hydro_host_kernel_type=DEVICE_ONLY")
   endif()
   # TODO Add eos=wd CPU+GPU kokkos test
 

--- a/test_problems/rotating_star/CMakeLists.txt
+++ b/test_problems/rotating_star/CMakeLists.txt
@@ -157,7 +157,7 @@ if(OCTOTIGER_WITH_CUDA)
 endif()
 if(OCTOTIGER_WITH_HIP)
   test_rotating_star_scenario(test_problems.gpu.am_hydro_on.rotating_star_hip rotating_star_am_hydro_on_hip_log.txt ${silo_scenario_filename} 
-    "  --correct_am_hydro=1 --number_gpus=1 --executors_per_gpu=32 --max_gpu_executor_queue_length=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=HIP --multipole_device_kernel_type=HIP --hydro_device_kernel_type=HIP --hydro_host_kernel_type=DEVICE_ONLY ")
+    "  --correct_am_hydro=1 --number_gpus=1 --executors_per_gpu=16 --max_gpu_executor_queue_length=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=HIP --multipole_device_kernel_type=HIP --hydro_device_kernel_type=HIP --hydro_host_kernel_type=DEVICE_ONLY ")
 endif()
 
 if(OCTOTIGER_WITH_KOKKOS)
@@ -174,7 +174,7 @@ if(OCTOTIGER_WITH_KOKKOS)
   endif()
   if(OCTOTIGER_WITH_HIP)
     test_rotating_star_scenario(test_problems.gpu.am_hydro_on.rotating_star_kokkos_hip rotating_star_am_hydro_on_kokkos_hip_log.txt ${silo_scenario_filename} 
-      "  --correct_am_hydro=1 --number_gpus=1 --executors_per_gpu=32 --max_gpu_executor_queue_length=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=KOKKOS_HIP --multipole_device_kernel_type=KOKKOS_HIP --hydro_device_kernel_type=KOKKOS_HIP --hydro_host_kernel_type=DEVICE_ONLY")
+      "  --correct_am_hydro=1 --number_gpus=1 --executors_per_gpu=16 --max_gpu_executor_queue_length=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=KOKKOS_HIP --multipole_device_kernel_type=KOKKOS_HIP --hydro_device_kernel_type=KOKKOS_HIP --hydro_host_kernel_type=DEVICE_ONLY")
   endif()
   if(Kokkos_ENABLE_SYCL)
     test_rotating_star_scenario(test_problems.gpu.am_hydro_on.rotating_star_kokkos_sycl rotating_star_am_hydro_on_kokkos_sycl_log.txt ${silo_scenario_filename} 
@@ -251,7 +251,7 @@ if(OCTOTIGER_WITH_HIP)
     " --correct_am_hydro=0 --number_gpus=1 --executors_per_gpu=32 --max_gpu_executor_queue_length=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=HIP --multipole_device_kernel_type=HIP --hydro_device_kernel_type=HIP --hydro_host_kernel_type=DEVICE_ONLY")
   if (OCTOTIGER_WITH_GRIDDIM EQUAL 8)
     test_rotating_star_scenario(test_problems.gpu.am_hydro_off.rotating_star_hip_work_aggregation rotating_star_am_hydro_off_hip_work_aggregation_log.txt ${silo_scenario_filename}
-    " --correct_am_hydro=0 --number_gpus=1 --executors_per_gpu=32 --max_gpu_executor_queue_length=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=HIP --multipole_device_kernel_type=HIP --hydro_device_kernel_type=HIP --hydro_host_kernel_type=DEVICE_ONLY --max_kernels_fused=8")
+    " --correct_am_hydro=0 --number_gpus=1 --executors_per_gpu=8 --max_gpu_executor_queue_length=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=HIP --multipole_device_kernel_type=HIP --hydro_device_kernel_type=HIP --hydro_host_kernel_type=DEVICE_ONLY --max_kernels_fused=8")
   endif()
 endif()
 
@@ -271,10 +271,10 @@ if(OCTOTIGER_WITH_KOKKOS)
   endif()
   if(OCTOTIGER_WITH_HIP)
     test_rotating_star_scenario(test_problems.gpu.am_hydro_off.rotating_star_kokkos_hip rotating_star_am_hydro_off_kokkos_hip_log.txt ${silo_scenario_filename}
-      " --correct_am_hydro=0 --number_gpus=1 --executors_per_gpu=32 --max_gpu_executor_queue_length=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=KOKKOS_HIP --multipole_device_kernel_type=KOKKOS_HIP --hydro_device_kernel_type=KOKKOS_HIP --hydro_host_kernel_type=DEVICE_ONLY")
+      " --correct_am_hydro=0 --number_gpus=1 --executors_per_gpu=16 --max_gpu_executor_queue_length=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=KOKKOS_HIP --multipole_device_kernel_type=KOKKOS_HIP --hydro_device_kernel_type=KOKKOS_HIP --hydro_host_kernel_type=DEVICE_ONLY")
     if (OCTOTIGER_WITH_GRIDDIM EQUAL 8)
       test_rotating_star_scenario(test_problems.gpu.am_hydro_off.rotating_star_kokkos_hip_work_aggregation rotating_star_am_hydro_off_kokkos_hip_work_aggregation_log.txt ${silo_scenario_filename}
-      " --correct_am_hydro=0 --number_gpus=1 --executors_per_gpu=32 --max_gpu_executor_queue_length=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=KOKKOS_HIP --multipole_device_kernel_type=KOKKOS_HIP --hydro_device_kernel_type=KOKKOS_HIP --hydro_host_kernel_type=DEVICE_ONLY --max_kernels_fused=8")
+      " --correct_am_hydro=0 --number_gpus=1 --executors_per_gpu=8 --max_gpu_executor_queue_length=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=KOKKOS_HIP --multipole_device_kernel_type=KOKKOS_HIP --hydro_device_kernel_type=KOKKOS_HIP --hydro_host_kernel_type=DEVICE_ONLY --max_kernels_fused=8")
     endif()
   endif()
   if(Kokkos_ENABLE_SYCL)
@@ -326,7 +326,7 @@ if (OCTOTIGER_WITH_GRIDDIM EQUAL 8)
   endif()
   if(OCTOTIGER_WITH_HIP)
     test_rotating_star_scenario(test_problems.gpu.eos_wd.rotating_star_hip rotating_star_eos_wd_hip.txt ${silo_scenario_filename}
-      " --correct_am_hydro=0 --eos=WD --number_gpus=1 --executors_per_gpu=32 --max_gpu_executor_queue_length=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=HIP --multipole_device_kernel_type=HIP --hydro_device_kernel_type=HIP --hydro_host_kernel_type=DEVICE_ONLY")
+      " --correct_am_hydro=0 --eos=WD --number_gpus=1 --executors_per_gpu=16 --max_gpu_executor_queue_length=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=HIP --multipole_device_kernel_type=HIP --hydro_device_kernel_type=HIP --hydro_host_kernel_type=DEVICE_ONLY")
   endif()
   # TODO Add eos=wd CPU+GPU test
 
@@ -339,7 +339,7 @@ if (OCTOTIGER_WITH_GRIDDIM EQUAL 8)
     endif()
     if(OCTOTIGER_WITH_HIP)
       test_rotating_star_scenario(test_problems.gpu.eos_wd.rotating_star_kokkos_hip rotating_star_eos_wd_kokkos_hip.txt ${silo_scenario_filename}
-        " --correct_am_hydro=0 --eos=WD --number_gpus=1 --executors_per_gpu=32 --max_gpu_executor_queue_length=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=KOKKOS_HIP --multipole_device_kernel_type=KOKKOS_HIP --hydro_device_kernel_type=KOKKOS_HIP --hydro_host_kernel_type=DEVICE_ONLY")
+        " --correct_am_hydro=0 --eos=WD --number_gpus=1 --executors_per_gpu=16 --max_gpu_executor_queue_length=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=KOKKOS_HIP --multipole_device_kernel_type=KOKKOS_HIP --hydro_device_kernel_type=KOKKOS_HIP --hydro_host_kernel_type=DEVICE_ONLY")
     endif()
   endif()
   if(Kokkos_ENABLE_SYCL)

--- a/test_problems/rotating_star/CMakeLists.txt
+++ b/test_problems/rotating_star/CMakeLists.txt
@@ -169,7 +169,7 @@ if(OCTOTIGER_WITH_KOKKOS)
     if(NOT OCTOTIGER_WITH_FAST_FP_CONTRACT)
       # combined cpu+gpu
       test_rotating_star_scenario(test_problems.cpu_gpu.am_hydro_on.rotating_star_kokkos_cuda rotating_star_am_hydro_on_kokkos_cuda_log.txt ${silo_scenario_filename} 
-      "  --correct_am_hydro=1 --cuda_number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1 --monopole_host_kernel_type=KOKKOS --multipole_host_kernel_type=KOKKOS --monopole_device_kernel_type=KOKKOS_CUDA --multipole_device_kernel_type=KOKKOS_CUDA --hydro_device_kernel_type=KOKKOS_CUDA --hydro_host_kernel_type=KOKKOS")
+        "  --correct_am_hydro=1 --cuda_number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1 --monopole_host_kernel_type=KOKKOS --multipole_host_kernel_type=KOKKOS --monopole_device_kernel_type=KOKKOS_CUDA --multipole_device_kernel_type=KOKKOS_CUDA --hydro_device_kernel_type=KOKKOS_CUDA --hydro_host_kernel_type=DEVICE_ONLY")
     endif()
   endif()
   if(OCTOTIGER_WITH_HIP)
@@ -243,7 +243,7 @@ if(OCTOTIGER_WITH_CUDA)
   if(NOT OCTOTIGER_WITH_FAST_FP_CONTRACT)
   # combined cpu+gpu
     test_rotating_star_scenario(test_problems.cpu_gpu.am_hydro_off.rotating_star_cuda rotating_star_am_hydro_off_cuda_log.txt ${silo_scenario_filename} 
-    "  --correct_am_hydro=0 --cuda_number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1 --monopole_host_kernel_type=VC --multipole_host_kernel_type=VC --monopole_device_kernel_type=CUDA --multipole_device_kernel_type=CUDA --hydro_device_kernel_type=CUDA --hydro_host_kernel_type=LEGACY")
+      "  --correct_am_hydro=0 --cuda_number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1 --monopole_host_kernel_type=VC --multipole_host_kernel_type=VC --monopole_device_kernel_type=CUDA --multipole_device_kernel_type=CUDA --hydro_device_kernel_type=CUDA --hydro_host_kernel_type=DEVICE_ONLY")
   endif()
 endif()
 if(OCTOTIGER_WITH_HIP)
@@ -264,7 +264,7 @@ if(OCTOTIGER_WITH_KOKKOS)
     if(NOT OCTOTIGER_WITH_FAST_FP_CONTRACT)
       # combined cpu+gpu
       test_rotating_star_scenario(test_problems.cpu_gpu.am_hydro_off.rotating_star_kokkos_cuda rotating_star_am_hydro_off_kokkos_cuda_log.txt ${silo_scenario_filename} 
-      "  --correct_am_hydro=0 --cuda_number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1 --monopole_host_kernel_type=KOKKOS --multipole_host_kernel_type=KOKKOS --monopole_device_kernel_type=KOKKOS_CUDA --multipole_device_kernel_type=KOKKOS_CUDA --hydro_device_kernel_type=KOKKOS_CUDA --hydro_host_kernel_type=KOKKOS")
+        "  --correct_am_hydro=0 --cuda_number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1 --monopole_host_kernel_type=KOKKOS --multipole_host_kernel_type=KOKKOS --monopole_device_kernel_type=KOKKOS_CUDA --multipole_device_kernel_type=KOKKOS_CUDA --hydro_device_kernel_type=KOKKOS_CUDA --hydro_host_kernel_type=DEVICE_ONLY")
     endif()
   endif()
   if(OCTOTIGER_WITH_HIP)

--- a/test_problems/sod/CMakeLists.txt
+++ b/test_problems/sod/CMakeLists.txt
@@ -153,7 +153,7 @@ if(OCTOTIGER_WITH_CUDA)
 endif()
 if(OCTOTIGER_WITH_HIP)
 	test_sod_scenario(test_problems.gpu.am_hydro_off.sod_hip sod_hip_log.txt ${ini_scenario_filename} ${silo_reference_filename} OFF
-    "--correct_am_hydro=off --number_gpus=1 --executors_per_gpu=32 --max_gpu_executor_queue_length=1024 --hydro_device_kernel_type=HIP --hydro_host_kernel_type=DEVICE_ONLY")
+    "--correct_am_hydro=off --number_gpus=1 --executors_per_gpu=8 --max_gpu_executor_queue_length=1024 --hydro_device_kernel_type=HIP --hydro_host_kernel_type=DEVICE_ONLY")
 endif()
 
 if(OCTOTIGER_WITH_KOKKOS)
@@ -165,7 +165,7 @@ if(OCTOTIGER_WITH_KOKKOS)
   endif()
   if(OCTOTIGER_WITH_HIP)
 	  test_sod_scenario(test_problems.gpu.am_hydro_off.sod_kokkos sod_kokkos_cuda_log.txt ${ini_scenario_filename} ${silo_reference_filename} OFF
-      "--correct_am_hydro=off --number_gpus=1 --executors_per_gpu=32 --max_gpu_executor_queue_length=1024 --hydro_device_kernel_type=KOKKOS_HIP --hydro_host_kernel_type=DEVICE_ONLY")
+      "--correct_am_hydro=off --number_gpus=1 --executors_per_gpu=8 --max_gpu_executor_queue_length=1024 --hydro_device_kernel_type=KOKKOS_HIP --hydro_host_kernel_type=DEVICE_ONLY")
   endif()
 endif()
 

--- a/test_problems/sod/CMakeLists.txt
+++ b/test_problems/sod/CMakeLists.txt
@@ -149,11 +149,11 @@ test_sod_scenario(test_problems.cpu.am_hydro_on.sod_legacy sod_old_log.txt ${ini
 "--correct_am_hydro=1 --hydro_device_kernel_type=OFF --hydro_host_kernel_type=LEGACY")
 if(OCTOTIGER_WITH_CUDA)
   test_sod_scenario(test_problems.gpu.am_hydro_on.sod_cuda sod_cuda_log.txt ${ini_scenario_filename} ${silo_reference_filename} OFF
-  "--correct_am_hydro=1 --number_gpus=1 --executors_per_gpu=32 --cuda_buffer_capacity=1024 --hydro_device_kernel_type=CUDA --hydro_host_kernel_type=DEVICE_ONLY")
+  "--correct_am_hydro=1 --number_gpus=1 --executors_per_gpu=32 --max_gpu_executor_queue_length=1024 --hydro_device_kernel_type=CUDA --hydro_host_kernel_type=DEVICE_ONLY")
 endif()
 if(OCTOTIGER_WITH_HIP)
 	test_sod_scenario(test_problems.gpu.am_hydro_off.sod_hip sod_hip_log.txt ${ini_scenario_filename} ${silo_reference_filename} OFF
-    "--correct_am_hydro=off --number_gpus=1 --executors_per_gpu=32 --cuda_buffer_capacity=1024 --hydro_device_kernel_type=HIP --hydro_host_kernel_type=DEVICE_ONLY")
+    "--correct_am_hydro=off --number_gpus=1 --executors_per_gpu=32 --max_gpu_executor_queue_length=1024 --hydro_device_kernel_type=HIP --hydro_host_kernel_type=DEVICE_ONLY")
 endif()
 
 if(OCTOTIGER_WITH_KOKKOS)
@@ -161,11 +161,11 @@ if(OCTOTIGER_WITH_KOKKOS)
   "--correct_am_hydro=1 --hydro_device_kernel_type=OFF --hydro_host_kernel_type=KOKKOS")
   if(OCTOTIGER_WITH_CUDA)
     test_sod_scenario(test_problems.gpu.am_hydro_on.sod_kokkos sod_kokkos_cuda_log.txt ${ini_scenario_filename} ${silo_reference_filename} OFF
-    "--correct_am_hydro=1 --number_gpus=1 --executors_per_gpu=32 --cuda_buffer_capacity=1024 --hydro_device_kernel_type=KOKKOS_CUDA --hydro_host_kernel_type=DEVICE_ONLY")
+    "--correct_am_hydro=1 --number_gpus=1 --executors_per_gpu=32 --max_gpu_executor_queue_length=1024 --hydro_device_kernel_type=KOKKOS_CUDA --hydro_host_kernel_type=DEVICE_ONLY")
   endif()
   if(OCTOTIGER_WITH_HIP)
 	  test_sod_scenario(test_problems.gpu.am_hydro_off.sod_kokkos sod_kokkos_cuda_log.txt ${ini_scenario_filename} ${silo_reference_filename} OFF
-      "--correct_am_hydro=off --number_gpus=1 --executors_per_gpu=32 --cuda_buffer_capacity=1024 --hydro_device_kernel_type=KOKKOS_HIP --hydro_host_kernel_type=DEVICE_ONLY")
+      "--correct_am_hydro=off --number_gpus=1 --executors_per_gpu=32 --max_gpu_executor_queue_length=1024 --hydro_device_kernel_type=KOKKOS_HIP --hydro_host_kernel_type=DEVICE_ONLY")
   endif()
 endif()
 
@@ -217,7 +217,7 @@ test_sod_scenario(test_problems.cpu.am_hydro_off.sod_legacy sod_old_log.txt ${in
 "--correct_am_hydro=0 --hydro_device_kernel_type=OFF --hydro_host_kernel_type=LEGACY")
 if(OCTOTIGER_WITH_CUDA)
   test_sod_scenario(test_problems.gpu.am_hydro_off.sod_cuda sod_cuda_log.txt ${ini_scenario_filename} ${silo_reference_filename} ON
-  "--correct_am_hydro=0 --number_gpus=1 --executors_per_gpu=32 --cuda_buffer_capacity=1024 --hydro_device_kernel_type=CUDA --hydro_host_kernel_type=DEVICE_ONLY")
+  "--correct_am_hydro=0 --number_gpus=1 --executors_per_gpu=32 --max_gpu_executor_queue_length=1024 --hydro_device_kernel_type=CUDA --hydro_host_kernel_type=DEVICE_ONLY")
 endif()
 
 if(OCTOTIGER_WITH_KOKKOS)
@@ -225,11 +225,11 @@ if(OCTOTIGER_WITH_KOKKOS)
   "--correct_am_hydro=0 --hydro_device_kernel_type=OFF --hydro_host_kernel_type=KOKKOS")
   if(OCTOTIGER_WITH_CUDA)
     test_sod_scenario(test_problems.gpu.am_hydro_off.sod_kokkos_cuda sod_kokkos_cuda_log.txt ${ini_scenario_filename} ${silo_reference_filename} ON
-    "--correct_am_hydro=0 --number_gpus=1 --executors_per_gpu=32 --cuda_buffer_capacity=1024 --hydro_device_kernel_type=KOKKOS_CUDA --hydro_host_kernel_type=DEVICE_ONLY")
+    "--correct_am_hydro=0 --number_gpus=1 --executors_per_gpu=32 --max_gpu_executor_queue_length=1024 --hydro_device_kernel_type=KOKKOS_CUDA --hydro_host_kernel_type=DEVICE_ONLY")
   endif()
   if(Kokkos_ENABLE_SYCL)
     test_sod_scenario(test_problems.gpu.am_hydro_off.sod_kokkos_sycl sod_kokkos_sycl_log.txt ${ini_scenario_filename} ${silo_reference_filename} ON
-      "--correct_am_hydro=0 --number_gpus=1 --executors_per_gpu=32 --cuda_buffer_capacity=1024 --hydro_device_kernel_type=KOKKOS_SYCL --hydro_host_kernel_type=DEVICE_ONLY")
+      "--correct_am_hydro=0 --number_gpus=1 --executors_per_gpu=32 --max_gpu_executor_queue_length=1024 --hydro_device_kernel_type=KOKKOS_SYCL --hydro_host_kernel_type=DEVICE_ONLY")
   endif()
 endif()
 
@@ -256,11 +256,11 @@ if (OCTOTIGER_WITH_GRIDDIM EQUAL 8)
   "--correct_am_hydro=0 --hydro_device_kernel_type=OFF --hydro_host_kernel_type=LEGACY")
   if(OCTOTIGER_WITH_CUDA)
     test_sod_scenario(test_problems.gpu.am_hydro_off.sod_big_cuda sod_cuda_log.txt ${ini_scenario_filename} ${silo_reference_filename} ON
-    "--correct_am_hydro=0 --number_gpus=1 --executors_per_gpu=32 --cuda_buffer_capacity=1024 --hydro_device_kernel_type=CUDA --hydro_host_kernel_type=DEVICE_ONLY")
+    "--correct_am_hydro=0 --number_gpus=1 --executors_per_gpu=32 --max_gpu_executor_queue_length=1024 --hydro_device_kernel_type=CUDA --hydro_host_kernel_type=DEVICE_ONLY")
       # Test combined cpu + gpu execution: Only makes sense when kernels use the same FP_Contract (otherwise there'll be an ~ 1e-20 error due to interactions between kernels executed on different devices)
     # if(NOT OCTOTIGER_WITH_FAST_FP_CONTRACT)
     #   test_sod_scenario(test_problems.cpu_gpu.am_hydro_off.sod_big_cuda sod_cuda_log.txt ${ini_scenario_filename} ${silo_reference_filename} ON
-    #   "--correct_am_hydro=0 --number_gpus=1 --executors_per_gpu=4 --cuda_buffer_capacity=1 --hydro_device_kernel_type=CUDA --hydro_host_kernel_type=LEGACY")
+    #   "--correct_am_hydro=0 --number_gpus=1 --executors_per_gpu=4 --max_gpu_executor_queue_length=1 --hydro_device_kernel_type=CUDA --hydro_host_kernel_type=LEGACY")
     # endif()
   endif()
 
@@ -269,16 +269,16 @@ if (OCTOTIGER_WITH_GRIDDIM EQUAL 8)
     "--correct_am_hydro=0 --hydro_device_kernel_type=OFF --hydro_host_kernel_type=KOKKOS")
     if(OCTOTIGER_WITH_CUDA)
       test_sod_scenario(test_problems.gpu.am_hydro_off.sod_big_kokkos_cuda sod_kokkos_cuda_log.txt ${ini_scenario_filename} ${silo_reference_filename} ON
-      "--correct_am_hydro=0 --number_gpus=1 --executors_per_gpu=32 --cuda_buffer_capacity=1024 --hydro_device_kernel_type=KOKKOS_CUDA --hydro_host_kernel_type=DEVICE_ONLY")
+      "--correct_am_hydro=0 --number_gpus=1 --executors_per_gpu=32 --max_gpu_executor_queue_length=1024 --hydro_device_kernel_type=KOKKOS_CUDA --hydro_host_kernel_type=DEVICE_ONLY")
       # Test combined cpu + gpu execution: Only makes sense when kernels use the same FP_Contract (otherwise there'll be an ~ 1e-20 error due to interactions between kernels executed on different devices)
       # if(NOT OCTOTIGER_WITH_FAST_FP_CONTRACT)
       #   test_sod_scenario(test_problems.cpu_gpu.am_hydro_off.sod_big_kokkos sod_kokkos_cuda_log.txt ${ini_scenario_filename} ${silo_reference_filename} ON
-      #   "--correct_am_hydro=0 --number_gpus=1 --executors_per_gpu=4 --cuda_buffer_capacity=1 --hydro_device_kernel_type=KOKKOS_CUDA --hydro_host_kernel_type=KOKKOS")
+      #   "--correct_am_hydro=0 --number_gpus=1 --executors_per_gpu=4 --max_gpu_executor_queue_length=1 --hydro_device_kernel_type=KOKKOS_CUDA --hydro_host_kernel_type=KOKKOS")
       # endif()
     endif()
     if(Kokkos_ENABLE_SYCL)
       test_sod_scenario(test_problems.gpu.am_hydro_off.sod_big_kokkos_sycl sod_kokkos_sycl_log.txt ${ini_scenario_filename} ${silo_reference_filename} ON
-        "--correct_am_hydro=0 --number_gpus=1 --executors_per_gpu=32 --cuda_buffer_capacity=1024 --hydro_device_kernel_type=KOKKOS_SYCL --hydro_host_kernel_type=DEVICE_ONLY")
+        "--correct_am_hydro=0 --number_gpus=1 --executors_per_gpu=32 --max_gpu_executor_queue_length=1024 --hydro_device_kernel_type=KOKKOS_SYCL --hydro_host_kernel_type=DEVICE_ONLY")
     endif()
   endif()
 

--- a/test_problems/sod/CMakeLists.txt
+++ b/test_problems/sod/CMakeLists.txt
@@ -149,11 +149,11 @@ test_sod_scenario(test_problems.cpu.am_hydro_on.sod_legacy sod_old_log.txt ${ini
 "--correct_am_hydro=1 --hydro_device_kernel_type=OFF --hydro_host_kernel_type=LEGACY")
 if(OCTOTIGER_WITH_CUDA)
   test_sod_scenario(test_problems.gpu.am_hydro_on.sod_cuda sod_cuda_log.txt ${ini_scenario_filename} ${silo_reference_filename} OFF
-  "--correct_am_hydro=1 --cuda_number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1024 --hydro_device_kernel_type=CUDA --hydro_host_kernel_type=DEVICE_ONLY")
+  "--correct_am_hydro=1 --number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1024 --hydro_device_kernel_type=CUDA --hydro_host_kernel_type=DEVICE_ONLY")
 endif()
 if(OCTOTIGER_WITH_HIP)
 	test_sod_scenario(test_problems.gpu.am_hydro_off.sod_hip sod_hip_log.txt ${ini_scenario_filename} ${silo_reference_filename} OFF
-    "--correct_am_hydro=off --cuda_number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1024 --hydro_device_kernel_type=HIP --hydro_host_kernel_type=DEVICE_ONLY")
+    "--correct_am_hydro=off --number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1024 --hydro_device_kernel_type=HIP --hydro_host_kernel_type=DEVICE_ONLY")
 endif()
 
 if(OCTOTIGER_WITH_KOKKOS)
@@ -161,11 +161,11 @@ if(OCTOTIGER_WITH_KOKKOS)
   "--correct_am_hydro=1 --hydro_device_kernel_type=OFF --hydro_host_kernel_type=KOKKOS")
   if(OCTOTIGER_WITH_CUDA)
     test_sod_scenario(test_problems.gpu.am_hydro_on.sod_kokkos sod_kokkos_cuda_log.txt ${ini_scenario_filename} ${silo_reference_filename} OFF
-    "--correct_am_hydro=1 --cuda_number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1024 --hydro_device_kernel_type=KOKKOS_CUDA --hydro_host_kernel_type=DEVICE_ONLY")
+    "--correct_am_hydro=1 --number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1024 --hydro_device_kernel_type=KOKKOS_CUDA --hydro_host_kernel_type=DEVICE_ONLY")
   endif()
   if(OCTOTIGER_WITH_HIP)
 	  test_sod_scenario(test_problems.gpu.am_hydro_off.sod_kokkos sod_kokkos_cuda_log.txt ${ini_scenario_filename} ${silo_reference_filename} OFF
-      "--correct_am_hydro=off --cuda_number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1024 --hydro_device_kernel_type=KOKKOS_HIP --hydro_host_kernel_type=DEVICE_ONLY")
+      "--correct_am_hydro=off --number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1024 --hydro_device_kernel_type=KOKKOS_HIP --hydro_host_kernel_type=DEVICE_ONLY")
   endif()
 endif()
 
@@ -217,7 +217,7 @@ test_sod_scenario(test_problems.cpu.am_hydro_off.sod_legacy sod_old_log.txt ${in
 "--correct_am_hydro=0 --hydro_device_kernel_type=OFF --hydro_host_kernel_type=LEGACY")
 if(OCTOTIGER_WITH_CUDA)
   test_sod_scenario(test_problems.gpu.am_hydro_off.sod_cuda sod_cuda_log.txt ${ini_scenario_filename} ${silo_reference_filename} ON
-  "--correct_am_hydro=0 --cuda_number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1024 --hydro_device_kernel_type=CUDA --hydro_host_kernel_type=DEVICE_ONLY")
+  "--correct_am_hydro=0 --number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1024 --hydro_device_kernel_type=CUDA --hydro_host_kernel_type=DEVICE_ONLY")
 endif()
 
 if(OCTOTIGER_WITH_KOKKOS)
@@ -225,11 +225,11 @@ if(OCTOTIGER_WITH_KOKKOS)
   "--correct_am_hydro=0 --hydro_device_kernel_type=OFF --hydro_host_kernel_type=KOKKOS")
   if(OCTOTIGER_WITH_CUDA)
     test_sod_scenario(test_problems.gpu.am_hydro_off.sod_kokkos_cuda sod_kokkos_cuda_log.txt ${ini_scenario_filename} ${silo_reference_filename} ON
-    "--correct_am_hydro=0 --cuda_number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1024 --hydro_device_kernel_type=KOKKOS_CUDA --hydro_host_kernel_type=DEVICE_ONLY")
+    "--correct_am_hydro=0 --number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1024 --hydro_device_kernel_type=KOKKOS_CUDA --hydro_host_kernel_type=DEVICE_ONLY")
   endif()
   if(Kokkos_ENABLE_SYCL)
     test_sod_scenario(test_problems.gpu.am_hydro_off.sod_kokkos_sycl sod_kokkos_sycl_log.txt ${ini_scenario_filename} ${silo_reference_filename} ON
-      "--correct_am_hydro=0 --cuda_number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1024 --hydro_device_kernel_type=KOKKOS_SYCL --hydro_host_kernel_type=DEVICE_ONLY")
+      "--correct_am_hydro=0 --number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1024 --hydro_device_kernel_type=KOKKOS_SYCL --hydro_host_kernel_type=DEVICE_ONLY")
   endif()
 endif()
 
@@ -256,11 +256,11 @@ if (OCTOTIGER_WITH_GRIDDIM EQUAL 8)
   "--correct_am_hydro=0 --hydro_device_kernel_type=OFF --hydro_host_kernel_type=LEGACY")
   if(OCTOTIGER_WITH_CUDA)
     test_sod_scenario(test_problems.gpu.am_hydro_off.sod_big_cuda sod_cuda_log.txt ${ini_scenario_filename} ${silo_reference_filename} ON
-    "--correct_am_hydro=0 --cuda_number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1024 --hydro_device_kernel_type=CUDA --hydro_host_kernel_type=DEVICE_ONLY")
+    "--correct_am_hydro=0 --number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1024 --hydro_device_kernel_type=CUDA --hydro_host_kernel_type=DEVICE_ONLY")
       # Test combined cpu + gpu execution: Only makes sense when kernels use the same FP_Contract (otherwise there'll be an ~ 1e-20 error due to interactions between kernels executed on different devices)
     # if(NOT OCTOTIGER_WITH_FAST_FP_CONTRACT)
     #   test_sod_scenario(test_problems.cpu_gpu.am_hydro_off.sod_big_cuda sod_cuda_log.txt ${ini_scenario_filename} ${silo_reference_filename} ON
-    #   "--correct_am_hydro=0 --cuda_number_gpus=1 --cuda_streams_per_gpu=4 --cuda_buffer_capacity=1 --hydro_device_kernel_type=CUDA --hydro_host_kernel_type=LEGACY")
+    #   "--correct_am_hydro=0 --number_gpus=1 --cuda_streams_per_gpu=4 --cuda_buffer_capacity=1 --hydro_device_kernel_type=CUDA --hydro_host_kernel_type=LEGACY")
     # endif()
   endif()
 
@@ -269,16 +269,16 @@ if (OCTOTIGER_WITH_GRIDDIM EQUAL 8)
     "--correct_am_hydro=0 --hydro_device_kernel_type=OFF --hydro_host_kernel_type=KOKKOS")
     if(OCTOTIGER_WITH_CUDA)
       test_sod_scenario(test_problems.gpu.am_hydro_off.sod_big_kokkos_cuda sod_kokkos_cuda_log.txt ${ini_scenario_filename} ${silo_reference_filename} ON
-      "--correct_am_hydro=0 --cuda_number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1024 --hydro_device_kernel_type=KOKKOS_CUDA --hydro_host_kernel_type=DEVICE_ONLY")
+      "--correct_am_hydro=0 --number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1024 --hydro_device_kernel_type=KOKKOS_CUDA --hydro_host_kernel_type=DEVICE_ONLY")
       # Test combined cpu + gpu execution: Only makes sense when kernels use the same FP_Contract (otherwise there'll be an ~ 1e-20 error due to interactions between kernels executed on different devices)
       # if(NOT OCTOTIGER_WITH_FAST_FP_CONTRACT)
       #   test_sod_scenario(test_problems.cpu_gpu.am_hydro_off.sod_big_kokkos sod_kokkos_cuda_log.txt ${ini_scenario_filename} ${silo_reference_filename} ON
-      #   "--correct_am_hydro=0 --cuda_number_gpus=1 --cuda_streams_per_gpu=4 --cuda_buffer_capacity=1 --hydro_device_kernel_type=KOKKOS_CUDA --hydro_host_kernel_type=KOKKOS")
+      #   "--correct_am_hydro=0 --number_gpus=1 --cuda_streams_per_gpu=4 --cuda_buffer_capacity=1 --hydro_device_kernel_type=KOKKOS_CUDA --hydro_host_kernel_type=KOKKOS")
       # endif()
     endif()
     if(Kokkos_ENABLE_SYCL)
       test_sod_scenario(test_problems.gpu.am_hydro_off.sod_big_kokkos_sycl sod_kokkos_sycl_log.txt ${ini_scenario_filename} ${silo_reference_filename} ON
-        "--correct_am_hydro=0 --cuda_number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1024 --hydro_device_kernel_type=KOKKOS_SYCL --hydro_host_kernel_type=DEVICE_ONLY")
+        "--correct_am_hydro=0 --number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1024 --hydro_device_kernel_type=KOKKOS_SYCL --hydro_host_kernel_type=DEVICE_ONLY")
     endif()
   endif()
 

--- a/test_problems/sod/CMakeLists.txt
+++ b/test_problems/sod/CMakeLists.txt
@@ -149,11 +149,11 @@ test_sod_scenario(test_problems.cpu.am_hydro_on.sod_legacy sod_old_log.txt ${ini
 "--correct_am_hydro=1 --hydro_device_kernel_type=OFF --hydro_host_kernel_type=LEGACY")
 if(OCTOTIGER_WITH_CUDA)
   test_sod_scenario(test_problems.gpu.am_hydro_on.sod_cuda sod_cuda_log.txt ${ini_scenario_filename} ${silo_reference_filename} OFF
-  "--correct_am_hydro=1 --number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1024 --hydro_device_kernel_type=CUDA --hydro_host_kernel_type=DEVICE_ONLY")
+  "--correct_am_hydro=1 --number_gpus=1 --executors_per_gpu=32 --cuda_buffer_capacity=1024 --hydro_device_kernel_type=CUDA --hydro_host_kernel_type=DEVICE_ONLY")
 endif()
 if(OCTOTIGER_WITH_HIP)
 	test_sod_scenario(test_problems.gpu.am_hydro_off.sod_hip sod_hip_log.txt ${ini_scenario_filename} ${silo_reference_filename} OFF
-    "--correct_am_hydro=off --number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1024 --hydro_device_kernel_type=HIP --hydro_host_kernel_type=DEVICE_ONLY")
+    "--correct_am_hydro=off --number_gpus=1 --executors_per_gpu=32 --cuda_buffer_capacity=1024 --hydro_device_kernel_type=HIP --hydro_host_kernel_type=DEVICE_ONLY")
 endif()
 
 if(OCTOTIGER_WITH_KOKKOS)
@@ -161,11 +161,11 @@ if(OCTOTIGER_WITH_KOKKOS)
   "--correct_am_hydro=1 --hydro_device_kernel_type=OFF --hydro_host_kernel_type=KOKKOS")
   if(OCTOTIGER_WITH_CUDA)
     test_sod_scenario(test_problems.gpu.am_hydro_on.sod_kokkos sod_kokkos_cuda_log.txt ${ini_scenario_filename} ${silo_reference_filename} OFF
-    "--correct_am_hydro=1 --number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1024 --hydro_device_kernel_type=KOKKOS_CUDA --hydro_host_kernel_type=DEVICE_ONLY")
+    "--correct_am_hydro=1 --number_gpus=1 --executors_per_gpu=32 --cuda_buffer_capacity=1024 --hydro_device_kernel_type=KOKKOS_CUDA --hydro_host_kernel_type=DEVICE_ONLY")
   endif()
   if(OCTOTIGER_WITH_HIP)
 	  test_sod_scenario(test_problems.gpu.am_hydro_off.sod_kokkos sod_kokkos_cuda_log.txt ${ini_scenario_filename} ${silo_reference_filename} OFF
-      "--correct_am_hydro=off --number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1024 --hydro_device_kernel_type=KOKKOS_HIP --hydro_host_kernel_type=DEVICE_ONLY")
+      "--correct_am_hydro=off --number_gpus=1 --executors_per_gpu=32 --cuda_buffer_capacity=1024 --hydro_device_kernel_type=KOKKOS_HIP --hydro_host_kernel_type=DEVICE_ONLY")
   endif()
 endif()
 
@@ -217,7 +217,7 @@ test_sod_scenario(test_problems.cpu.am_hydro_off.sod_legacy sod_old_log.txt ${in
 "--correct_am_hydro=0 --hydro_device_kernel_type=OFF --hydro_host_kernel_type=LEGACY")
 if(OCTOTIGER_WITH_CUDA)
   test_sod_scenario(test_problems.gpu.am_hydro_off.sod_cuda sod_cuda_log.txt ${ini_scenario_filename} ${silo_reference_filename} ON
-  "--correct_am_hydro=0 --number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1024 --hydro_device_kernel_type=CUDA --hydro_host_kernel_type=DEVICE_ONLY")
+  "--correct_am_hydro=0 --number_gpus=1 --executors_per_gpu=32 --cuda_buffer_capacity=1024 --hydro_device_kernel_type=CUDA --hydro_host_kernel_type=DEVICE_ONLY")
 endif()
 
 if(OCTOTIGER_WITH_KOKKOS)
@@ -225,11 +225,11 @@ if(OCTOTIGER_WITH_KOKKOS)
   "--correct_am_hydro=0 --hydro_device_kernel_type=OFF --hydro_host_kernel_type=KOKKOS")
   if(OCTOTIGER_WITH_CUDA)
     test_sod_scenario(test_problems.gpu.am_hydro_off.sod_kokkos_cuda sod_kokkos_cuda_log.txt ${ini_scenario_filename} ${silo_reference_filename} ON
-    "--correct_am_hydro=0 --number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1024 --hydro_device_kernel_type=KOKKOS_CUDA --hydro_host_kernel_type=DEVICE_ONLY")
+    "--correct_am_hydro=0 --number_gpus=1 --executors_per_gpu=32 --cuda_buffer_capacity=1024 --hydro_device_kernel_type=KOKKOS_CUDA --hydro_host_kernel_type=DEVICE_ONLY")
   endif()
   if(Kokkos_ENABLE_SYCL)
     test_sod_scenario(test_problems.gpu.am_hydro_off.sod_kokkos_sycl sod_kokkos_sycl_log.txt ${ini_scenario_filename} ${silo_reference_filename} ON
-      "--correct_am_hydro=0 --number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1024 --hydro_device_kernel_type=KOKKOS_SYCL --hydro_host_kernel_type=DEVICE_ONLY")
+      "--correct_am_hydro=0 --number_gpus=1 --executors_per_gpu=32 --cuda_buffer_capacity=1024 --hydro_device_kernel_type=KOKKOS_SYCL --hydro_host_kernel_type=DEVICE_ONLY")
   endif()
 endif()
 
@@ -256,11 +256,11 @@ if (OCTOTIGER_WITH_GRIDDIM EQUAL 8)
   "--correct_am_hydro=0 --hydro_device_kernel_type=OFF --hydro_host_kernel_type=LEGACY")
   if(OCTOTIGER_WITH_CUDA)
     test_sod_scenario(test_problems.gpu.am_hydro_off.sod_big_cuda sod_cuda_log.txt ${ini_scenario_filename} ${silo_reference_filename} ON
-    "--correct_am_hydro=0 --number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1024 --hydro_device_kernel_type=CUDA --hydro_host_kernel_type=DEVICE_ONLY")
+    "--correct_am_hydro=0 --number_gpus=1 --executors_per_gpu=32 --cuda_buffer_capacity=1024 --hydro_device_kernel_type=CUDA --hydro_host_kernel_type=DEVICE_ONLY")
       # Test combined cpu + gpu execution: Only makes sense when kernels use the same FP_Contract (otherwise there'll be an ~ 1e-20 error due to interactions between kernels executed on different devices)
     # if(NOT OCTOTIGER_WITH_FAST_FP_CONTRACT)
     #   test_sod_scenario(test_problems.cpu_gpu.am_hydro_off.sod_big_cuda sod_cuda_log.txt ${ini_scenario_filename} ${silo_reference_filename} ON
-    #   "--correct_am_hydro=0 --number_gpus=1 --cuda_streams_per_gpu=4 --cuda_buffer_capacity=1 --hydro_device_kernel_type=CUDA --hydro_host_kernel_type=LEGACY")
+    #   "--correct_am_hydro=0 --number_gpus=1 --executors_per_gpu=4 --cuda_buffer_capacity=1 --hydro_device_kernel_type=CUDA --hydro_host_kernel_type=LEGACY")
     # endif()
   endif()
 
@@ -269,16 +269,16 @@ if (OCTOTIGER_WITH_GRIDDIM EQUAL 8)
     "--correct_am_hydro=0 --hydro_device_kernel_type=OFF --hydro_host_kernel_type=KOKKOS")
     if(OCTOTIGER_WITH_CUDA)
       test_sod_scenario(test_problems.gpu.am_hydro_off.sod_big_kokkos_cuda sod_kokkos_cuda_log.txt ${ini_scenario_filename} ${silo_reference_filename} ON
-      "--correct_am_hydro=0 --number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1024 --hydro_device_kernel_type=KOKKOS_CUDA --hydro_host_kernel_type=DEVICE_ONLY")
+      "--correct_am_hydro=0 --number_gpus=1 --executors_per_gpu=32 --cuda_buffer_capacity=1024 --hydro_device_kernel_type=KOKKOS_CUDA --hydro_host_kernel_type=DEVICE_ONLY")
       # Test combined cpu + gpu execution: Only makes sense when kernels use the same FP_Contract (otherwise there'll be an ~ 1e-20 error due to interactions between kernels executed on different devices)
       # if(NOT OCTOTIGER_WITH_FAST_FP_CONTRACT)
       #   test_sod_scenario(test_problems.cpu_gpu.am_hydro_off.sod_big_kokkos sod_kokkos_cuda_log.txt ${ini_scenario_filename} ${silo_reference_filename} ON
-      #   "--correct_am_hydro=0 --number_gpus=1 --cuda_streams_per_gpu=4 --cuda_buffer_capacity=1 --hydro_device_kernel_type=KOKKOS_CUDA --hydro_host_kernel_type=KOKKOS")
+      #   "--correct_am_hydro=0 --number_gpus=1 --executors_per_gpu=4 --cuda_buffer_capacity=1 --hydro_device_kernel_type=KOKKOS_CUDA --hydro_host_kernel_type=KOKKOS")
       # endif()
     endif()
     if(Kokkos_ENABLE_SYCL)
       test_sod_scenario(test_problems.gpu.am_hydro_off.sod_big_kokkos_sycl sod_kokkos_sycl_log.txt ${ini_scenario_filename} ${silo_reference_filename} ON
-        "--correct_am_hydro=0 --number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1024 --hydro_device_kernel_type=KOKKOS_SYCL --hydro_host_kernel_type=DEVICE_ONLY")
+        "--correct_am_hydro=0 --number_gpus=1 --executors_per_gpu=32 --cuda_buffer_capacity=1024 --hydro_device_kernel_type=KOKKOS_SYCL --hydro_host_kernel_type=DEVICE_ONLY")
     endif()
   endif()
 

--- a/test_problems/sod/CMakeLists.txt
+++ b/test_problems/sod/CMakeLists.txt
@@ -258,10 +258,10 @@ if (OCTOTIGER_WITH_GRIDDIM EQUAL 8)
     test_sod_scenario(test_problems.gpu.am_hydro_off.sod_big_cuda sod_cuda_log.txt ${ini_scenario_filename} ${silo_reference_filename} ON
     "--correct_am_hydro=0 --cuda_number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1024 --hydro_device_kernel_type=CUDA --hydro_host_kernel_type=DEVICE_ONLY")
       # Test combined cpu + gpu execution: Only makes sense when kernels use the same FP_Contract (otherwise there'll be an ~ 1e-20 error due to interactions between kernels executed on different devices)
-    if(NOT OCTOTIGER_WITH_FAST_FP_CONTRACT)
-      test_sod_scenario(test_problems.cpu_gpu.am_hydro_off.sod_big_cuda sod_cuda_log.txt ${ini_scenario_filename} ${silo_reference_filename} ON
-      "--correct_am_hydro=0 --cuda_number_gpus=1 --cuda_streams_per_gpu=4 --cuda_buffer_capacity=1 --hydro_device_kernel_type=CUDA --hydro_host_kernel_type=LEGACY")
-    endif()
+    # if(NOT OCTOTIGER_WITH_FAST_FP_CONTRACT)
+    #   test_sod_scenario(test_problems.cpu_gpu.am_hydro_off.sod_big_cuda sod_cuda_log.txt ${ini_scenario_filename} ${silo_reference_filename} ON
+    #   "--correct_am_hydro=0 --cuda_number_gpus=1 --cuda_streams_per_gpu=4 --cuda_buffer_capacity=1 --hydro_device_kernel_type=CUDA --hydro_host_kernel_type=LEGACY")
+    # endif()
   endif()
 
   if(OCTOTIGER_WITH_KOKKOS)
@@ -271,10 +271,10 @@ if (OCTOTIGER_WITH_GRIDDIM EQUAL 8)
       test_sod_scenario(test_problems.gpu.am_hydro_off.sod_big_kokkos_cuda sod_kokkos_cuda_log.txt ${ini_scenario_filename} ${silo_reference_filename} ON
       "--correct_am_hydro=0 --cuda_number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1024 --hydro_device_kernel_type=KOKKOS_CUDA --hydro_host_kernel_type=DEVICE_ONLY")
       # Test combined cpu + gpu execution: Only makes sense when kernels use the same FP_Contract (otherwise there'll be an ~ 1e-20 error due to interactions between kernels executed on different devices)
-      if(NOT OCTOTIGER_WITH_FAST_FP_CONTRACT)
-        test_sod_scenario(test_problems.cpu_gpu.am_hydro_off.sod_big_kokkos sod_kokkos_cuda_log.txt ${ini_scenario_filename} ${silo_reference_filename} ON
-        "--correct_am_hydro=0 --cuda_number_gpus=1 --cuda_streams_per_gpu=4 --cuda_buffer_capacity=1 --hydro_device_kernel_type=KOKKOS_CUDA --hydro_host_kernel_type=KOKKOS")
-      endif()
+      # if(NOT OCTOTIGER_WITH_FAST_FP_CONTRACT)
+      #   test_sod_scenario(test_problems.cpu_gpu.am_hydro_off.sod_big_kokkos sod_kokkos_cuda_log.txt ${ini_scenario_filename} ${silo_reference_filename} ON
+      #   "--correct_am_hydro=0 --cuda_number_gpus=1 --cuda_streams_per_gpu=4 --cuda_buffer_capacity=1 --hydro_device_kernel_type=KOKKOS_CUDA --hydro_host_kernel_type=KOKKOS")
+      # endif()
     endif()
     if(Kokkos_ENABLE_SYCL)
       test_sod_scenario(test_problems.gpu.am_hydro_off.sod_big_kokkos_sycl sod_kokkos_sycl_log.txt ${ini_scenario_filename} ${silo_reference_filename} ON

--- a/test_problems/sphere/CMakeLists.txt
+++ b/test_problems/sphere/CMakeLists.txt
@@ -143,12 +143,12 @@ test_sphere_scenario(test_problems.cpu.sphere_legacy  sphere_old_log.txt ${silo_
 # Sphere - GPU plain CUDA
 if(OCTOTIGER_WITH_CUDA)
   test_sphere_scenario(test_problems.gpu.sphere_cuda  sphere_cuda_log.txt ${silo_scenario_filename}
-    " --number_gpus=1 --executors_per_gpu=32 --cuda_buffer_capacity=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=CUDA --multipole_device_kernel_type=CUDA ")
+    " --number_gpus=1 --executors_per_gpu=32 --max_gpu_executor_queue_length=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=CUDA --multipole_device_kernel_type=CUDA ")
 endif()
 # Sphere - GPU plain HIP
 if(OCTOTIGER_WITH_HIP)
   test_sphere_scenario(test_problems.gpu.sphere_hip  sphere_hip_log.txt ${silo_scenario_filename}
-    " --number_gpus=1 --executors_per_gpu=32 --cuda_buffer_capacity=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=HIP --multipole_device_kernel_type=HIP ")
+    " --number_gpus=1 --executors_per_gpu=32 --max_gpu_executor_queue_length=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=HIP --multipole_device_kernel_type=HIP ")
 endif()
 
 # Sphere - Kokkos Host / Device tests
@@ -157,15 +157,15 @@ if(OCTOTIGER_WITH_KOKKOS)
   " --monopole_host_kernel_type=KOKKOS --multipole_host_kernel_type=KOKKOS --monopole_device_kernel_type=OFF --multipole_device_kernel_type=OFF ")
   if(OCTOTIGER_WITH_CUDA)
     test_sphere_scenario(test_problems.gpu.sphere_kokkos_cuda  sphere_kokkos_cuda_log.txt ${silo_scenario_filename}
-      " --number_gpus=1 --executors_per_gpu=32 --cuda_buffer_capacity=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=KOKKOS_CUDA --multipole_device_kernel_type=KOKKOS_CUDA ")
+      " --number_gpus=1 --executors_per_gpu=32 --max_gpu_executor_queue_length=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=KOKKOS_CUDA --multipole_device_kernel_type=KOKKOS_CUDA ")
   endif()
   if(OCTOTIGER_WITH_HIP)
     test_sphere_scenario(test_problems.gpu.sphere_kokkos_hip  sphere_kokkos_hip_log.txt ${silo_scenario_filename}
-      " --number_gpus=1 --executors_per_gpu=32 --cuda_buffer_capacity=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=KOKKOS_HIP --multipole_device_kernel_type=KOKKOS_HIP ")
+      " --number_gpus=1 --executors_per_gpu=32 --max_gpu_executor_queue_length=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=KOKKOS_HIP --multipole_device_kernel_type=KOKKOS_HIP ")
   endif()
   if(Kokkos_ENABLE_SYCL)
     test_sphere_scenario(test_problems.gpu.sphere_kokkos_sycl  sphere_kokkos_sycl_log.txt ${silo_scenario_filename}
-      " --number_gpus=1 --executors_per_gpu=32 --cuda_buffer_capacity=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=KOKKOS_SYCL --multipole_device_kernel_type=KOKKOS_SYCL ")
+      " --number_gpus=1 --executors_per_gpu=32 --max_gpu_executor_queue_length=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=KOKKOS_SYCL --multipole_device_kernel_type=KOKKOS_SYCL ")
   endif()
 endif()
 # TODO CPU+GPU tests?

--- a/test_problems/sphere/CMakeLists.txt
+++ b/test_problems/sphere/CMakeLists.txt
@@ -143,12 +143,12 @@ test_sphere_scenario(test_problems.cpu.sphere_legacy  sphere_old_log.txt ${silo_
 # Sphere - GPU plain CUDA
 if(OCTOTIGER_WITH_CUDA)
   test_sphere_scenario(test_problems.gpu.sphere_cuda  sphere_cuda_log.txt ${silo_scenario_filename}
-    " --number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=CUDA --multipole_device_kernel_type=CUDA ")
+    " --number_gpus=1 --executors_per_gpu=32 --cuda_buffer_capacity=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=CUDA --multipole_device_kernel_type=CUDA ")
 endif()
 # Sphere - GPU plain HIP
 if(OCTOTIGER_WITH_HIP)
   test_sphere_scenario(test_problems.gpu.sphere_hip  sphere_hip_log.txt ${silo_scenario_filename}
-    " --number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=HIP --multipole_device_kernel_type=HIP ")
+    " --number_gpus=1 --executors_per_gpu=32 --cuda_buffer_capacity=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=HIP --multipole_device_kernel_type=HIP ")
 endif()
 
 # Sphere - Kokkos Host / Device tests
@@ -157,15 +157,15 @@ if(OCTOTIGER_WITH_KOKKOS)
   " --monopole_host_kernel_type=KOKKOS --multipole_host_kernel_type=KOKKOS --monopole_device_kernel_type=OFF --multipole_device_kernel_type=OFF ")
   if(OCTOTIGER_WITH_CUDA)
     test_sphere_scenario(test_problems.gpu.sphere_kokkos_cuda  sphere_kokkos_cuda_log.txt ${silo_scenario_filename}
-      " --number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=KOKKOS_CUDA --multipole_device_kernel_type=KOKKOS_CUDA ")
+      " --number_gpus=1 --executors_per_gpu=32 --cuda_buffer_capacity=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=KOKKOS_CUDA --multipole_device_kernel_type=KOKKOS_CUDA ")
   endif()
   if(OCTOTIGER_WITH_HIP)
     test_sphere_scenario(test_problems.gpu.sphere_kokkos_hip  sphere_kokkos_hip_log.txt ${silo_scenario_filename}
-      " --number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=KOKKOS_HIP --multipole_device_kernel_type=KOKKOS_HIP ")
+      " --number_gpus=1 --executors_per_gpu=32 --cuda_buffer_capacity=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=KOKKOS_HIP --multipole_device_kernel_type=KOKKOS_HIP ")
   endif()
   if(Kokkos_ENABLE_SYCL)
     test_sphere_scenario(test_problems.gpu.sphere_kokkos_sycl  sphere_kokkos_sycl_log.txt ${silo_scenario_filename}
-      " --number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=KOKKOS_SYCL --multipole_device_kernel_type=KOKKOS_SYCL ")
+      " --number_gpus=1 --executors_per_gpu=32 --cuda_buffer_capacity=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=KOKKOS_SYCL --multipole_device_kernel_type=KOKKOS_SYCL ")
   endif()
 endif()
 # TODO CPU+GPU tests?

--- a/test_problems/sphere/CMakeLists.txt
+++ b/test_problems/sphere/CMakeLists.txt
@@ -143,12 +143,12 @@ test_sphere_scenario(test_problems.cpu.sphere_legacy  sphere_old_log.txt ${silo_
 # Sphere - GPU plain CUDA
 if(OCTOTIGER_WITH_CUDA)
   test_sphere_scenario(test_problems.gpu.sphere_cuda  sphere_cuda_log.txt ${silo_scenario_filename}
-    " --cuda_number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=CUDA --multipole_device_kernel_type=CUDA ")
+    " --number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=CUDA --multipole_device_kernel_type=CUDA ")
 endif()
 # Sphere - GPU plain HIP
 if(OCTOTIGER_WITH_HIP)
   test_sphere_scenario(test_problems.gpu.sphere_hip  sphere_hip_log.txt ${silo_scenario_filename}
-    " --cuda_number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=HIP --multipole_device_kernel_type=HIP ")
+    " --number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=HIP --multipole_device_kernel_type=HIP ")
 endif()
 
 # Sphere - Kokkos Host / Device tests
@@ -157,15 +157,15 @@ if(OCTOTIGER_WITH_KOKKOS)
   " --monopole_host_kernel_type=KOKKOS --multipole_host_kernel_type=KOKKOS --monopole_device_kernel_type=OFF --multipole_device_kernel_type=OFF ")
   if(OCTOTIGER_WITH_CUDA)
     test_sphere_scenario(test_problems.gpu.sphere_kokkos_cuda  sphere_kokkos_cuda_log.txt ${silo_scenario_filename}
-      " --cuda_number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=KOKKOS_CUDA --multipole_device_kernel_type=KOKKOS_CUDA ")
+      " --number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=KOKKOS_CUDA --multipole_device_kernel_type=KOKKOS_CUDA ")
   endif()
   if(OCTOTIGER_WITH_HIP)
     test_sphere_scenario(test_problems.gpu.sphere_kokkos_hip  sphere_kokkos_hip_log.txt ${silo_scenario_filename}
-      " --cuda_number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=KOKKOS_HIP --multipole_device_kernel_type=KOKKOS_HIP ")
+      " --number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=KOKKOS_HIP --multipole_device_kernel_type=KOKKOS_HIP ")
   endif()
   if(Kokkos_ENABLE_SYCL)
     test_sphere_scenario(test_problems.gpu.sphere_kokkos_sycl  sphere_kokkos_sycl_log.txt ${silo_scenario_filename}
-      " --cuda_number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=KOKKOS_SYCL --multipole_device_kernel_type=KOKKOS_SYCL ")
+      " --number_gpus=1 --cuda_streams_per_gpu=32 --cuda_buffer_capacity=1024 --monopole_host_kernel_type=DEVICE_ONLY --multipole_host_kernel_type=DEVICE_ONLY --monopole_device_kernel_type=KOKKOS_SYCL --multipole_device_kernel_type=KOKKOS_SYCL ")
   endif()
 endif()
 # TODO CPU+GPU tests?

--- a/test_problems/star/CMakeLists.txt
+++ b/test_problems/star/CMakeLists.txt
@@ -20,38 +20,38 @@ function(test_star_scenario test_name test_log_file kernel_parameters)
     FIXTURES_SETUP ${test_name})
 
   # Analyze test log file: Timestep output needs to match
-  add_test(NAME ${test_name}.TS10_dt_regex COMMAND cat ${test_log_file})
-  set_tests_properties(${test_name}.TS10_dt_regex PROPERTIES
+  add_test(NAME ${test_name}.TS11_dt_regex COMMAND cat ${test_log_file})
+  set_tests_properties(${test_name}.TS11_dt_regex PROPERTIES
   FIXTURES_REQUIRED ${test_name}
-  PASS_REGULAR_EXPRESSION "TS 10:: t: 7.352407e.00, dt: 6.715325e-01")
+  PASS_REGULAR_EXPRESSION "TS 1.:: t: 7.352407e.00, dt: 6.715325e-01")
 
-  add_test(NAME ${test_name}.TS10_a_regex COMMAND cat ${test_log_file})
-  set_tests_properties(${test_name}.TS10_a_regex PROPERTIES
+  add_test(NAME ${test_name}.TS11_a_regex COMMAND cat ${test_log_file})
+  set_tests_properties(${test_name}.TS11_a_regex PROPERTIES
   FIXTURES_REQUIRED ${test_name}
   PASS_REGULAR_EXPRESSION "a: 9.307070e-01")
 
-  add_test(NAME ${test_name}.TS10_ur_regex COMMAND cat ${test_log_file})
-  set_tests_properties(${test_name}.TS10_ur_regex PROPERTIES
+  add_test(NAME ${test_name}.TS11_ur_regex COMMAND cat ${test_log_file})
+  set_tests_properties(${test_name}.TS11_ur_regex PROPERTIES
   FIXTURES_REQUIRED ${test_name}
   PASS_REGULAR_EXPRESSION "ur: 1.680614e-02")
 
-  add_test(NAME ${test_name}.TS10_ul_regex COMMAND cat ${test_log_file})
-  set_tests_properties(${test_name}.TS10_ul_regex PROPERTIES
+  add_test(NAME ${test_name}.TS11_ul_regex COMMAND cat ${test_log_file})
+  set_tests_properties(${test_name}.TS11_ul_regex PROPERTIES
   FIXTURES_REQUIRED ${test_name}
   PASS_REGULAR_EXPRESSION "ul: 1.365091e-02")
 
-  add_test(NAME ${test_name}.TS10_vr_regex COMMAND cat ${test_log_file})
-  set_tests_properties(${test_name}.TS10_vr_regex PROPERTIES
+  add_test(NAME ${test_name}.TS11_vr_regex COMMAND cat ${test_log_file})
+  set_tests_properties(${test_name}.TS11_vr_regex PROPERTIES
   FIXTURES_REQUIRED ${test_name}
   PASS_REGULAR_EXPRESSION "vr: 6.075061e-02")
 
-  add_test(NAME ${test_name}.TS10_vl_regex COMMAND cat ${test_log_file})
-  set_tests_properties(${test_name}.TS10_vl_regex PROPERTIES
+  add_test(NAME ${test_name}.TS11_vl_regex COMMAND cat ${test_log_file})
+  set_tests_properties(${test_name}.TS11_vl_regex PROPERTIES
   FIXTURES_REQUIRED ${test_name}
   PASS_REGULAR_EXPRESSION "vl: 2.912973e-02")
 
-  add_test(NAME ${test_name}.TS10_boundaries_regex COMMAND cat ${test_log_file})
-  set_tests_properties(${test_name}.TS10_boundaries_regex PROPERTIES
+  add_test(NAME ${test_name}.TS11_boundaries_regex COMMAND cat ${test_log_file})
+  set_tests_properties(${test_name}.TS11_boundaries_regex PROPERTIES
   FIXTURES_REQUIRED ${test_name}
   PASS_REGULAR_EXPRESSION "amr_boundaries: 312")
 

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -107,3 +107,7 @@ set_property(TARGET silo_counter PROPERTY FOLDER "Tools")
 if(MSVC)
   target_compile_options(silo_counter PRIVATE /EHsc)
 endif()
+
+# non-hpx targets need this to be intalled
+install(TARGETS silo_planes silo_counter gen_rotating_star_init RUNTIME DESTINATION bin)
+


### PR DESCRIPTION
This PR adds experimental multi-GPU support for all CUDA/KOKKOS kernels in Octo-Tiger.

To do so, it mostly uses the additions in STEllAR-GROUP/hpx/pull/6284 and SC-SGS/CPPuddle/pull/22. 
Accordingly, this PR uses the new functionality defined in those PRs. To work correctly, it also
- ensures that the required constant data is initialized on all GPUs.
- sets the correct device before all Kokkos calls.
- and, of course, the PR adapts to all API changes, necessary to initialize the executors on all devices.

Overall, it seems to work well on the machines I tested it on. I will probably re-structure the MultiGPU part of the gravity solver a bit in the future, but I think that is a subject for another PR. This one gives us the basic functionality for now!