### PR TITLE
Fix octotiger performance tests

### DIFF
--- a/.jenkins-performance-tests/lsu/hip-aggregation-test.sbatch
+++ b/.jenkins-performance-tests/lsu/hip-aggregation-test.sbatch
@@ -10,7 +10,7 @@
 
 echo "Aggregation Test running on $(hostname):"
 echo "Loading modules..."
-module load llvm/14 rocm/5 hwloc cmake
+module load rocm/5.4 hwloc llvm/14
 module list
 echo "Building Octo-Tiger and toolchain..."
 echo ""


### PR DESCRIPTION
I noticed that the automated GPU aggregation performance tests were failing (which are usually only running when we merge PRs into master). The CI scripts were still using the old CLI parameter names, causing this problem.

This PR resolves this issue (by updating the test submodule version and thus said scripts). 
It further fixes a build issue for the aggregation tests on the MI100 node (by loading the correct modules).
