### PR TITLE
Fix SYCL build and other typos

### DIFF
--- a/frontend/init_methods.cpp
+++ b/frontend/init_methods.cpp
@@ -179,35 +179,41 @@ void init_executors(void) {
 #if HPX_KOKKOS_CUDA_FUTURE_TYPE == 0
 #if (defined(OCTOTIGER_HAVE_CUDA) || defined(OCTOTIGER_HAVE_HIP) || defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP))  
     if (opts().polling_threads>0) {
-      std::cerr << "Registering HPX CUDA polling on polling pool..." << std::endl;
+      std::cout << "Registering HPX CUDA polling on polling pool..." << std::endl;
       hpx::cuda::experimental::detail::register_polling(hpx::resource::get_thread_pool("polling"));
     } else {
-      std::cerr << "Registering HPX CUDA polling..." << std::endl;
+      std::cout << "Registering HPX CUDA polling..." << std::endl;
       hpx::cuda::experimental::detail::register_polling(hpx::resource::get_thread_pool(0));
     }
-    std::cerr << "Registered HPX CUDA polling!" << std::endl;
+    std::cout << "Registered HPX CUDA polling!" << std::endl;
 #endif
 #endif
 #if defined(OCTOTIGER_HAVE_KOKKOS) && defined(KOKKOS_ENABLE_SYCL)
     if (opts().polling_threads>0) {
-      std::cerr << "Registering HPX SYCL polling on polling pool..." << std::endl;
+      std::cout << "Registering HPX SYCL polling on polling pool..." << std::endl;
       hpx::sycl::experimental::detail::register_polling(hpx::resource::get_thread_pool("polling"));
     } else {
-      std::cerr << "Registering HPX SYCL polling..." << std::endl;
+      std::cout << "Registering HPX SYCL polling..." << std::endl;
       hpx::sycl::experimental::detail::register_polling(hpx::resource::get_thread_pool(0));
     }
-    std::cerr << "Registered HPX SYCL polling!" << std::endl;
+    std::cout << "Registered HPX SYCL polling!" << std::endl;
+#if HPX_KOKKOS_SYCL_FUTURE_TYPE == 0 
+    std::cout << "Using HPX SYCL futures with polling!" << std::endl;
+#endif
+#if HPX_KOKKOS_SYCL_FUTURE_TYPE == 1 
+    std::cout << "Using HPX SYCL futures with host_tasks!" << std::endl;
+#endif
 #endif
 
 #if defined(OCTOTIGER_HAVE_KOKKOS)
-    std::cerr << "Initializing Kokkos host executors..." << std::endl;
+    std::cout << "Initializing Kokkos host executors..." << std::endl;
     stream_pool::init_all_executor_pools<hpx::kokkos::serial_executor, round_robin_pool<hpx::kokkos::serial_executor>>(
         256, hpx::kokkos::execution_space_mode::independent);
     stream_pool::init_all_executor_pools<hpx::kokkos::hpx_executor, round_robin_pool<hpx::kokkos::hpx_executor>>(
         256, hpx::kokkos::execution_space_mode::independent);
-    std::cerr << "Initializing Kokkos device executors..." << std::endl;
-    std::cerr << "CPPuddle config: Using " << recycler::max_number_gpus << " devices!" << std::endl;
-    std::cerr << "CPPuddle config: Using " << recycler::number_instances << " internal pool instances!"
+    std::cout << "Initializing Kokkos device executors..." << std::endl;
+    std::cout << "CPPuddle config: Max number GPUs: " << recycler::max_number_gpus << " devices!" << std::endl;
+    std::cout << "CPPuddle config: Using " << recycler::number_instances << " internal buffer buckets!"
               << std::endl;
 #if defined(KOKKOS_ENABLE_CUDA)
     stream_pool::set_device_selector<hpx::kokkos::cuda_executor,
@@ -256,9 +262,9 @@ void init_executors(void) {
         kokkos_device_executor>(mover);
     Kokkos::fence();
 #if HPX_KOKKOS_CUDA_FUTURE_TYPE == 0 
-    std::cerr << "KOKKOS with polling futures enabled!" << std::endl;
+    std::cout << "KOKKOS with polling futures enabled!" << std::endl;
 #else
-    std::cerr << "KOKKOS with callback futures enabled!" << std::endl;
+    std::cout << "KOKKOS with callback futures enabled!" << std::endl;
 #endif
 #endif
 #endif

--- a/frontend/init_methods.cpp
+++ b/frontend/init_methods.cpp
@@ -195,7 +195,7 @@ void init_executors(void) {
     } else {
       std::cerr << "Registering HPX SYCL polling..." << std::endl;
       hpx::sycl::experimental::detail::register_polling(hpx::resource::get_thread_pool(0));
-    }/
+    }
     std::cerr << "Registered HPX SYCL polling!" << std::endl;
 #endif
 

--- a/src/options_processing.cpp
+++ b/src/options_processing.cpp
@@ -487,8 +487,8 @@ bool options::process_options(int argc, char *argv[]) {
     if (opts().executors_per_gpu < 1 && (opts().monopole_device_kernel_type != OFF ||
           opts().multipole_device_kernel_type != OFF || opts().hydro_device_kernel_type != OFF)) {
         std::cerr << std::endl << "ERROR: "; 
-        std::cerr << "You have chosen an GPU kernel, however, you did not specify --executor_per_gpu > 0" << std::endl
-        << " Choose a different kernel or add at least one or more executors via --executor_per_gpu=X" << std::endl;
+        std::cerr << "You have chosen an GPU kernel, however, you did not specify --executors_per_gpu > 0" << std::endl
+        << " Choose a different kernel or add at least one or more executors via --executors_per_gpu=X" << std::endl;
         abort();
     }
     if (opts().max_kernels_fused < 1 && (opts().monopole_device_kernel_type != OFF ||


### PR DESCRIPTION
A stray " / " managed to make it into the code, causing the SYCL builds to fail (we really need a SYCL Jenkins pipeline to catch errors like these, but I leave that for a future PR). Alongside removing the " / ", I also fixed a few other typos in error messages and added some information regarding the SYCL future type printed during the octotiger initialization.

Lastly, I began replacing cerr with cout where appropriate (partially addressing #454 ).