### PR TITLE
Move run_as_os_thread from hpx::threads to hpx::

### DIFF
--- a/octotiger/radiation/kernel_interface.hpp
+++ b/octotiger/radiation/kernel_interface.hpp
@@ -163,7 +163,7 @@ namespace octotiger { namespace radiation {
         static std::atomic_size_t next_index(0);
         std::size_t index = next_index++;
 
-        hpx::threads::run_as_os_thread([&]() {
+        hpx::run_as_os_thread([&]() {
             dumper::save_case_args(index, opts().eos, opts().problem,
                 opts().dual_energy_sw1, opts().dual_energy_sw2, physcon().A,
                 physcon().B, physcon().c, fgamma, dt, clightinv, er_i, fx_i,
@@ -176,7 +176,7 @@ namespace octotiger { namespace radiation {
             tau, fgamma, U, mmw, X_spc, Z_spc, dt, clightinv);
 
 #if defined(OCTOTIGER_DUMP_RADIATION_CASES)
-        hpx::threads::run_as_os_thread([&]() {
+        hpx::run_as_os_thread([&]() {
             dumper::save_case_outs(index, sx, sy, sz, egas, tau, U);
         }).get();
 #endif

--- a/octotiger/util.hpp
+++ b/octotiger/util.hpp
@@ -42,7 +42,7 @@ int file_copy(const char* fin, const char* fout);
 template<class... Args>
 int lprint( const char* log, const char* str, Args&&...args) {
     // run output on separate thread
-    auto f = hpx::threads::run_as_os_thread([&]() -> int
+    auto f = hpx::run_as_os_thread([&]() -> int
     {
         if(!opts().disable_output) {
             FILE* fp = fopen (log, "at");

--- a/src/io/silo_out.cpp
+++ b/src/io/silo_out.cpp
@@ -168,7 +168,7 @@ void output_stage3(std::string fname, int cycle, int gn, int gb, int ge) {
 	const auto dir = opts().data_dir;
 	std::string this_fname = dir  + fname + ".silo.data/" + std::to_string(gn) + std::string(".silo");
 	double dtime = silo_output_rotation_time();
-	hpx::threads::run_as_os_thread([&this_fname, this_id, &dtime, gb, gn, ge](integer cycle) {
+	hpx::run_as_os_thread([&this_fname, this_id, &dtime, gb, gn, ge](integer cycle) {
 		DBfile *db;
 		if (this_id == gb) {
 //			printf( "Create %s %i %i %i %i\n", this_fname.c_str(), this_id, gn, gb, ge);
@@ -259,7 +259,7 @@ void output_stage4(std::string fname, int cycle) {
 	std::string this_fname = opts().data_dir + "/" + fname + std::string(".silo");
 	double dtime = silo_output_rotation_time();
 	double rtime = silo_output_rotation_time();
-	hpx::threads::run_as_os_thread([&this_fname, fname, nfields, &rtime](int cycle) {
+	hpx::run_as_os_thread([&this_fname, fname, nfields, &rtime](int cycle) {
 		auto *db = DBCreateReal(this_fname.c_str(), DB_CLOBBER, DB_LOCAL, "Octo-tiger", SILO_DRIVER);
 		double dtime = silo_output_time();
 		float ftime = dtime;
@@ -518,7 +518,7 @@ void output_all(node_server *root_ptr, std::string fname, int cycle, bool block)
 	}
 
 	std::string dir = opts().data_dir + "/" + fname + ".silo.data";
-	hpx::threads::run_as_os_thread([&]() {
+	hpx::run_as_os_thread([&]() {
 		auto rc = mkdir(dir.c_str(), S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH);
 		if (rc != 0 && errno != EEXIST) {
 			printf("Could not create directory for SILO file. mkdir failed with error. code: %i name: %s", errno, std::strerror(errno));

--- a/src/node_server_actions_3.cpp
+++ b/src/node_server_actions_3.cpp
@@ -417,7 +417,7 @@ void node_server::execute_solver(bool scf, node_count_type ngrids) {
 
 		// run output on separate thread
 		if (!opts().disable_output) {
-			hpx::threads::run_as_os_thread([=]() {
+			hpx::run_as_os_thread([=]() {
 				FILE *fp = fopen((opts().data_dir + "step.dat").c_str(), "at");
 				if (fp == NULL) {
 					printf( "Unable to open step.dat for writing %s\n", std::strerror(errno));
@@ -430,7 +430,7 @@ void node_server::execute_solver(bool scf, node_count_type ngrids) {
 			});     // do not wait for it to finish
 		}
 
-		/* hpx::threads::run_as_os_thread( */
+		/* hpx::run_as_os_thread( */
 		/* 		[=]() { */
     {
 					const auto vr = sqrt(sqr(dt_.ur[sx_i]) + sqr(dt_.ur[sy_i]) + sqr(dt_.ur[sz_i])) / dt_.ur[0];
@@ -457,7 +457,7 @@ void node_server::execute_solver(bool scf, node_count_type ngrids) {
 			ngrids = regrid(me.get_gid(), omega, new_floor, false);
 
 			// run output on separate thread
-			auto need_break = hpx::threads::run_as_os_thread([&]() {
+			auto need_break = hpx::run_as_os_thread([&]() {
 				//		set_omega_and_pivot();
 				bench_stop = hpx::chrono::high_resolution_clock::now() / 1e9;
 				if (scf || opts().bench) {
@@ -502,7 +502,7 @@ void node_server::execute_solver(bool scf, node_count_type ngrids) {
 	}
 
 	if (opts().bench && !opts().disable_output) {
-		hpx::threads::run_as_os_thread([&]() {
+		hpx::run_as_os_thread([&]() {
 
 			FILE *fp = fopen((opts().data_dir + "scaling.dat").c_str(), "at");
 			const auto nproc = options::all_localities.size();
@@ -678,7 +678,7 @@ future<real> node_server::local_step(integer steps) {
         if (opts().print_times_per_timestep)
           timestep_util::add_time_per_timestep(time_elapsed);
 
-				hpx::threads::run_as_os_thread([=]() {
+				hpx::run_as_os_thread([=]() {
 					printf("%i %e %e %e %e\n", local_step_num, double(current_time), double(dt_.dt), time_elapsed, rotational_time);
 				});  // do not wait for output to finish
 			}

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -43,7 +43,7 @@ real LambertW(real z) {
 
 int file_copy(const char* fin, const char* fout) {
     // run output on separate thread
-    auto f = hpx::threads::run_as_os_thread([&]()
+    auto f = hpx::run_as_os_thread([&]()
     {
 	    constexpr size_t chunk_size = BUFSIZ;
 	    char buffer[chunk_size];


### PR DESCRIPTION
run_as_os_thread was moved to a different namespace within HPX. This caused some deprecation warnings (and in the case of hipcc actually some compilation errors). This PR should fix that by using the updated namespace.
