### PR TITLE
Fix Octo-Tiger segfaults when using HPX master

### DIFF
--- a/src/node_server_actions_2.cpp
+++ b/src/node_server_actions_2.cpp
@@ -638,7 +638,7 @@ std::uintptr_t node_server::get_ptr() {
 
 future<node_server*> node_client::get_ptr() const {
 	return hpx::async<typename node_server::get_ptr_action>(get_unmanaged_gid()).then(hpx::annotated_function([this](future<std::uintptr_t> &&fut) {
-		if (hpx::find_here() != hpx::get_colocation_id(get_gid()).get()) {
+		if (hpx::get_locality_id() != hpx::naming::get_locality_id_from_id(get_unmanaged_gid())) {
 			printf("get_ptr called non-locally\n");
 			abort();
 		}


### PR DESCRIPTION
Using HPX master uncovered an issue within Octo-Tiger causing segfaults during the initialization (as outlined in the original HPX issue STEllAR-GROUP/hpx#6414 and the PR STEllAR-GROUP/hpx#6415)

This should hotfix the issue for now (at least the local tests pass again)!
However, in the future we will want to remove this part of the code and use shared_ptr instead via
```c++
future<std::shared_ptr<node_server>> node_client::get_ptr() const {
    return hpx::get_ptr<node_server>(get_unmanaged_gid());
}
```
to properly fix this.
