### PR TITLE
Fix Octo-Tiger segfaults when using HPX master - V2

### DIFF
--- a/frontend/frontend-helper.cpp
+++ b/frontend/frontend-helper.cpp
@@ -149,7 +149,7 @@ void start_octotiger(int argc, char* argv[]) {
 
             hpx::id_type root_id = hpx::new_<node_server>(hpx::find_here()).get();
             node_client root_client(root_id);
-            node_server* root = root_client.get_ptr().get();
+            auto root = root_client.get_ptr().get();
             std::cerr << "Found root" << std::endl;
 
             node_count_type ngrids;
@@ -200,7 +200,7 @@ void start_octotiger(int argc, char* argv[]) {
                 auto e = root->amr_error();
                 std::cerr << "Finished AMR test" << std::endl;
                 printf("AMR Error: %e %e %e\n", e.first, e.second, e.first / e.second);
-                output_all(root, "X", 0, true);
+                output_all(root.get(), "X", 0, true);
             }
             std::cerr << "Start timings report..." << std::endl;
             root->report_timing();

--- a/octotiger/io/silo.hpp
+++ b/octotiger/io/silo.hpp
@@ -86,7 +86,7 @@ void output_all(node_server* root_ptr, std::string fname, int cycle, bool);
 
 void load_options_from_silo(std::string fname, DBfile* = nullptr);
 
-OCTOTIGER_EXPORT void load_data_from_silo(std::string fname, node_server*, hpx::id_type);
+OCTOTIGER_EXPORT void load_data_from_silo(std::string fname, std::shared_ptr<node_server>, hpx::id_type);
 
 
 template<class T>

--- a/octotiger/node_client.hpp
+++ b/octotiger/node_client.hpp
@@ -93,7 +93,7 @@ public:
     future<set_child_aunt_type> set_child_aunt(
         const hpx::id_type&, const geo::face&) const;
     future<void> set_aunt(const hpx::id_type&, const geo::face&) const;
-    OCTOTIGER_EXPORT future<node_server*> get_ptr() const;
+    OCTOTIGER_EXPORT future<std::shared_ptr<node_server>> get_ptr() const;
     future<int> form_tree(
         hpx::id_type&&, hpx::id_type&&, std::vector<hpx::id_type>&&);
     future<hpx::id_type> get_child_client(

--- a/octotiger/node_server.hpp
+++ b/octotiger/node_server.hpp
@@ -255,9 +255,6 @@ public:
 	int form_tree(hpx::id_type, hpx::id_type=hpx::invalid_id, std::vector<hpx::id_type> = std::vector<hpx::id_type>(geo::direction::count()));/**/
 	HPX_DEFINE_COMPONENT_ACTION(node_server, form_tree, form_tree_action);
 
-	std::uintptr_t get_ptr();/**/
-	HPX_DEFINE_COMPONENT_DIRECT_ACTION(node_server, get_ptr, get_ptr_action);
-
 	analytic_t compare_analytic();/**/
 	HPX_DEFINE_COMPONENT_ACTION(node_server, compare_analytic, compare_analytic_action);
 

--- a/octotiger/node_server.hpp
+++ b/octotiger/node_server.hpp
@@ -377,7 +377,6 @@ HPX_REGISTER_ACTION_DECLARATION(node_server::solve_gravity_action);
 HPX_REGISTER_ACTION_DECLARATION(node_server::copy_to_locality_action);
 HPX_REGISTER_ACTION_DECLARATION(node_server::get_child_client_action);
 HPX_REGISTER_ACTION_DECLARATION(node_server::form_tree_action);
-HPX_REGISTER_ACTION_DECLARATION(node_server::get_ptr_action);
 HPX_REGISTER_ACTION_DECLARATION(node_server::diagnostics_action);
 HPX_REGISTER_ACTION_DECLARATION(node_server::timestep_driver_ascend_action);
 HPX_REGISTER_ACTION_DECLARATION(node_server::scf_params_action);

--- a/src/io/silo_in.cpp
+++ b/src/io/silo_in.cpp
@@ -257,7 +257,7 @@ auto split_mesh_id(const std::string id) {
 	return rc;
 }
 
-void load_data_from_silo(std::string fname, node_server *root_ptr, hpx::id_type root) {
+void load_data_from_silo(std::string fname, std::shared_ptr<node_server> root_ptr, hpx::id_type root) {
 	timings::scope ts(root_ptr->timings_, timings::time_io);
 	printf( "Reading %s\n", fname.c_str());
 	const auto tstart = time(NULL);

--- a/src/io/silo_out.cpp
+++ b/src/io/silo_out.cpp
@@ -97,14 +97,14 @@ void output_stage1(std::string fname, int cycle) {
   }
 	std::vector<node_location::node_id> ids;
 	futs_.clear();
-	const auto *node_ptr_ = node_registry::begin()->second.get_ptr().get();
+	const auto node_ptr_ = node_registry::begin()->second.get_ptr().get();
 	silo_output_time() = node_ptr_->get_time() * opts().code_to_s;
 	silo_output_rotation_time() = node_ptr_->get_rotation_count();
 	for (auto i = node_registry::begin(); i != node_registry::end(); ++i) {
-		const auto *node_ptr_ = GET(i->second.get_ptr());
+		const auto node_ptr_ = GET(i->second.get_ptr());
 		if (!node_ptr_->refined()) {
 			futs_.push_back(hpx::async(hpx::launch::async_policy(hpx::threads::thread_priority::boost), [](node_location loc, node_registry::node_ptr ptr) {
-				const auto *this_ptr = ptr.get_ptr().get();
+				const auto this_ptr = ptr.get_ptr().get();
 				assert(this_ptr);
 				const real dx = TWO / real(1 << loc.level()) / real(INX);
 				mesh_vars_t rc(loc);

--- a/src/node_server_actions_2.cpp
+++ b/src/node_server_actions_2.cpp
@@ -629,20 +629,8 @@ set_child_aunt_type node_server::set_child_aunt(const hpx::id_type &aunt, const 
 #endif
 }
 
-using get_ptr_action_type = node_server::get_ptr_action;
-HPX_REGISTER_ACTION(get_ptr_action_type);
-
-std::uintptr_t node_server::get_ptr() {
-	return reinterpret_cast<std::uintptr_t>(this);
+future<std::shared_ptr<node_server>> node_client::get_ptr() const {
+    return hpx::get_ptr<node_server>(get_unmanaged_gid());
 }
 
-future<node_server*> node_client::get_ptr() const {
-	return hpx::async<typename node_server::get_ptr_action>(get_unmanaged_gid()).then(hpx::annotated_function([this](future<std::uintptr_t> &&fut) {
-		if (hpx::find_here() != hpx::get_colocation_id(get_gid()).get()) {
-			printf("get_ptr called non-locally\n");
-			abort();
-		}
-		return reinterpret_cast<node_server*>(GET(fut));
-	}, "node_client::get_ptr"));
-}
 #endif

--- a/src/node_server_actions_3.cpp
+++ b/src/node_server_actions_3.cpp
@@ -329,7 +329,7 @@ void node_server::execute_solver(bool scf, node_count_type ngrids) {
 	}
 	printf("Starting run...\n");
 	auto fut_ptr = me.get_ptr();
-	node_server *root_ptr = GET(fut_ptr);
+	auto root_ptr = GET(fut_ptr);
 	if (!opts().output_filename.empty()) {
 		diagnostics();
 		solve_gravity(false, false);


### PR DESCRIPTION
Using HPX master uncovered an issue within Octo-Tiger causing segfaults during the initialization (as outlined in the original HPX issue https://github.com/STEllAR-GROUP/hpx/issues/6414 and the PR https://github.com/STEllAR-GROUP/hpx/pull/6415).

This PR fixes this issue!

The original hotfix #477 would have already fixed this issue as well, however, a proper fix (like this PR) using ```hpx::get_ptr``` and ```shared_ptr```s was easier to add than I initially thought. Hence I closed #477 in favor of this one!
