### PR TITLE
Work around segfaults on Intel GPUs

### DIFF
--- a/octotiger/sycl_initialization_guard.hpp
+++ b/octotiger/sycl_initialization_guard.hpp
@@ -1,0 +1,54 @@
+//  Copyright (c) 2024 Gregor Daiß
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#pragma once
+
+#if defined(OCTOTIGER_HAVE_KOKKOS) && defined(KOKKOS_ENABLE_SYCL)
+#include <CL/sycl.hpp>
+#include <iostream>
+
+namespace octotiger {
+namespace sycl_util {
+#include <CL/sycl.hpp>
+  // We encounter segfaults on Intel GPUs when running the normal kernels for the first time after
+  // the program starts. This seems to be some initialization issue as we can simply fix it by
+  // (non-concurrently) run simple dummy kernel first right after starting octotiger
+  // (presumably initializes something within the intel gpu runtime).
+  // Curiousely we have to do this not once per program, but once per lib (octolib and hydrolib).
+  //
+  // Somewhat of an ugly workaround but it does the trick and allows us to target Intel GPUs as
+  // Octo-Tiger runs as expected after applying this workaround.
+
+  // TODO(daissgr) Check again in the future to see if the runtime has matured and we don't need this anymore. 
+  // (last check was 02/2024)
+
+  /// Utility function working around segfault on Intel GPU. Initializes something within the runtime by runnning
+  ///a dummy kernel
+  template<const char *modulename> // modulename must be unique within octotiger for this to work
+  int touch_sycl_device_by_running_a_dummy_kernel(void) {
+      try {
+          cl::sycl::queue q(cl::sycl::default_selector_v, cl::sycl::property::queue::in_order{});
+          cl::sycl::event my_kernel_event = q.submit(
+              [&](cl::sycl::handler& h) {
+                  h.parallel_for(512, [=](auto i) {});
+              },
+              cl::sycl::detail::code_location{});
+          my_kernel_event.wait();
+          std::cout << "SYCL runtime has been initialized for " << modulename << " !" << std::endl;
+      } catch (sycl::exception const& e) {
+          std::cerr << "(NON-FATAL) ERROR: Caught sycl::exception during SYCL dummy kernel!\n";
+          std::cerr << " {what}: " << e.what() << "\n ";
+          std::cerr << "Continuing for now as error only occured in the dummy kernel...\n";
+          return 2;
+
+      }
+      return 1;
+  }
+
+}    // namespace sycl_util
+}    // namespace octotiger
+
+#endif

--- a/octotiger/sycl_initialization_guard.hpp
+++ b/octotiger/sycl_initialization_guard.hpp
@@ -37,11 +37,12 @@ namespace sycl_util {
               },
               cl::sycl::detail::code_location{});
           my_kernel_event.wait();
-          std::cout << "SYCL runtime has been initialized for " << modulename << " !" << std::endl;
+          std::cout << "SYCL runtime has been initialized for " << modulename << "!" << std::endl;
       } catch (sycl::exception const& e) {
           std::cerr << "(NON-FATAL) ERROR: Caught sycl::exception during SYCL dummy kernel!\n";
           std::cerr << " {what}: " << e.what() << "\n ";
-          std::cerr << "Continuing for now as error only occured in the dummy kernel...\n";
+          std::cerr << "Continuing for now as error only occured in the dummy kernel meant to "
+		    << "initialize the device by first touch...\n";
           return 2;
 
       }

--- a/src/monopole_interactions/monopole_kernel_interface.cpp
+++ b/src/monopole_interactions/monopole_kernel_interface.cpp
@@ -30,41 +30,10 @@
 #include "octotiger/options.hpp"
 
 #if defined(OCTOTIGER_HAVE_KOKKOS) && defined(KOKKOS_ENABLE_SYCL)
-#include <CL/sycl.hpp>
-// We encounter segfaults on Intel GPUs when running the normal kernels for the first time after
-// the program starts. This seems to be some initialization issue as we can simply fix it by
-// (non-concurrently) run simple dummy kernel first right after starting octotiger
-// (presumably initializes something within the intel gpu runtime).
-// Curiousely we have to do this not once per program, but once per lib (octolib and hydrolib).
-//
-// Somewhat of an ugly workaround but it does the trick and allows us to target Intel GPUs as
-// Octo-Tiger runs as expected after applying this workaround.
-
-// TODO(daissgr) Check again in the future to see if the runtime has matured and we don't need this anymore. 
-// (last check was 02/2024)
-
-/// Utility function working around segfault on Intel GPU. Initializes something within the runtime by runnning
-///a dummy kernel
-int touch_sycl_device_by_running_a_dummy_kernel(void) {
-    try {
-        cl::sycl::queue q(cl::sycl::default_selector_v, cl::sycl::property::queue::in_order{});
-        cl::sycl::event my_kernel_event = q.submit(
-            [&](cl::sycl::handler& h) {
-                h.parallel_for(512, [=](auto i) {});
-            },
-            cl::sycl::detail::code_location{});
-        my_kernel_event.wait();
-    } catch (sycl::exception const& e) {
-        std::cerr << "(NON-FATAL) ERROR: Caught sycl::exception during SYCL dummy kernel!\n";
-        std::cerr << " {what}: " << e.what() << "\n ";
-        std::cerr << "Continuing for now as error only occured in the dummy kernel...\n";
-        return 2;
-
-    }
-    return 1;
-}
+#include "octotiger/sycl_initialization_guard.hpp"
 /// Dummy variable to ensure the touch_sycl_device_by_running_a_dummy_kernel is being run
-const int init_sycl_device = touch_sycl_device_by_running_a_dummy_kernel();
+const int init_sycl_device_monopoles =
+    octotiger::sycl_util::touch_sycl_device_by_running_a_dummy_kernel<"gravity_solver_monopoles">();
 #endif
 
 #if defined(OCTOTIGER_HAVE_KOKKOS)

--- a/src/monopole_interactions/monopole_kernel_interface.cpp
+++ b/src/monopole_interactions/monopole_kernel_interface.cpp
@@ -29,6 +29,44 @@
 
 #include "octotiger/options.hpp"
 
+#if defined(OCTOTIGER_HAVE_KOKKOS) && defined(KOKKOS_ENABLE_SYCL)
+#include <CL/sycl.hpp>
+// We encounter segfaults on Intel GPUs when running the normal kernels for the first time after
+// the program starts. This seems to be some initialization issue as we can simply fix it by
+// (non-concurrently) run simple dummy kernel first right after starting octotiger
+// (presumably initializes something within the intel gpu runtime).
+// Curiousely we have to do this not once per program, but once per lib (octolib and hydrolib).
+//
+// Somewhat of an ugly workaround but it does the trick and allows us to target Intel GPUs as
+// Octo-Tiger runs as expected after applying this workaround.
+
+// TODO(daissgr) Check again in the future to see if the runtime has matured and we don't need this anymore. 
+// (last check was 02/2024)
+
+/// Utility function working around segfault on Intel GPU. Initializes something within the runtime by runnning
+///a dummy kernel
+int touch_sycl_device_by_running_a_dummy_kernel(void) {
+    try {
+        cl::sycl::queue q(cl::sycl::default_selector_v, cl::sycl::property::queue::in_order{});
+        cl::sycl::event my_kernel_event = q.submit(
+            [&](cl::sycl::handler& h) {
+                h.parallel_for(512, [=](auto i) {});
+            },
+            cl::sycl::detail::code_location{});
+        my_kernel_event.wait();
+    } catch (sycl::exception const& e) {
+        std::cerr << "(NON-FATAL) ERROR: Caught sycl::exception during SYCL dummy kernel!\n";
+        std::cerr << " {what}: " << e.what() << "\n ";
+        std::cerr << "Continuing for now as error only occured in the dummy kernel...\n";
+        return 2;
+
+    }
+    return 1;
+}
+/// Dummy variable to ensure the touch_sycl_device_by_running_a_dummy_kernel is being run
+const int init_sycl_device = touch_sycl_device_by_running_a_dummy_kernel();
+#endif
+
 #if defined(OCTOTIGER_HAVE_KOKKOS)
 #if defined(KOKKOS_ENABLE_CUDA)
 using device_executor = hpx::kokkos::cuda_executor;

--- a/src/monopole_interactions/monopole_kernel_interface.cpp
+++ b/src/monopole_interactions/monopole_kernel_interface.cpp
@@ -31,9 +31,10 @@
 
 #if defined(OCTOTIGER_HAVE_KOKKOS) && defined(KOKKOS_ENABLE_SYCL)
 #include "octotiger/sycl_initialization_guard.hpp"
+static const char module_identifier_monopoles[] = "gravity_solver_monopoles";
 /// Dummy variable to ensure the touch_sycl_device_by_running_a_dummy_kernel is being run
 const int init_sycl_device_monopoles =
-    octotiger::sycl_util::touch_sycl_device_by_running_a_dummy_kernel<"gravity_solver_monopoles">();
+    octotiger::sycl_util::touch_sycl_device_by_running_a_dummy_kernel<module_identifier_monopoles>();
 #endif
 
 #if defined(OCTOTIGER_HAVE_KOKKOS)

--- a/src/multipole_interactions/multipole_kernel_interface.cpp
+++ b/src/multipole_interactions/multipole_kernel_interface.cpp
@@ -29,6 +29,14 @@
 
 #include "octotiger/options.hpp"
 
+#if defined(OCTOTIGER_HAVE_KOKKOS) && defined(KOKKOS_ENABLE_SYCL)
+#include "octotiger/sycl_initialization_guard.hpp"
+/// Dummy variable to ensure the touch_sycl_device_by_running_a_dummy_kernel is being run
+const int init_sycl_device_multipoles =
+    octotiger::sycl_util::touch_sycl_device_by_running_a_dummy_kernel<
+        "gravity_solver_multipoles">();
+#endif
+
 #ifdef OCTOTIGER_HAVE_KOKKOS
 #if defined(KOKKOS_ENABLE_CUDA)
 using device_executor = hpx::kokkos::cuda_executor;

--- a/src/multipole_interactions/multipole_kernel_interface.cpp
+++ b/src/multipole_interactions/multipole_kernel_interface.cpp
@@ -31,10 +31,11 @@
 
 #if defined(OCTOTIGER_HAVE_KOKKOS) && defined(KOKKOS_ENABLE_SYCL)
 #include "octotiger/sycl_initialization_guard.hpp"
+static const char module_identifier_multipoles[] = "gravity_solver_multipoles";
 /// Dummy variable to ensure the touch_sycl_device_by_running_a_dummy_kernel is being run
 const int init_sycl_device_multipoles =
     octotiger::sycl_util::touch_sycl_device_by_running_a_dummy_kernel<
-        "gravity_solver_multipoles">();
+        module_identifier_multipoles>();
 #endif
 
 #ifdef OCTOTIGER_HAVE_KOKKOS

--- a/src/unitiger/hydro_impl/hydro_kernel_interface.cpp
+++ b/src/unitiger/hydro_impl/hydro_kernel_interface.cpp
@@ -17,9 +17,10 @@
 #endif
 #if defined(OCTOTIGER_HAVE_KOKKOS) && defined(KOKKOS_ENABLE_SYCL)
 #include "octotiger/sycl_initialization_guard.hpp"
+static const char module_identifier_hydro[] = "hydro_solver";
 /// Dummy variable to ensure the touch_sycl_device_by_running_a_dummy_kernel is being run
 const int init_sycl_device_hydro =
-    octotiger::sycl_util::touch_sycl_device_by_running_a_dummy_kernel<"hydro_solver">();
+    octotiger::sycl_util::touch_sycl_device_by_running_a_dummy_kernel<module_identifier_hydro>();
 #endif
 #if defined(OCTOTIGER_HAVE_KOKKOS)
 hpx::once_flag init_hydro_kokkos_pool_flag;

--- a/src/unitiger/hydro_impl/hydro_kernel_interface.cpp
+++ b/src/unitiger/hydro_impl/hydro_kernel_interface.cpp
@@ -16,41 +16,10 @@
 #include "octotiger/unitiger/hydro_impl/hydro_kokkos_kernel.hpp"
 #endif
 #if defined(OCTOTIGER_HAVE_KOKKOS) && defined(KOKKOS_ENABLE_SYCL)
-#include <CL/sycl.hpp>
-// We encounter segfaults on Intel GPUs when running the normal kernels for the first time after
-// the program starts. This seems to be some initialization issue as we can simply fix it by
-// (non-concurrently) run simple dummy kernel first right after starting octotiger
-// (presumably initializes something within the intel gpu runtime).
-// Curiousely we have to do this not once per program, but once per lib (octolib and hydrolib).
-//
-// Somewhat of an ugly workaround but it does the trick and allows us to target Intel GPUs as
-// Octo-Tiger runs as expected after applying this workaround.
-
-// TODO(daissgr) Check again in the future to see if the runtime has matured and we don't need this anymore. 
-// (last check was 02/2024)
-
-/// Utility function working around segfault on Intel GPU. Initializes something within the runtime by runnning
-///a dummy kernel
-int touch_sycl_device_by_running_a_dummy_kernel(void) {
-    try {
-        cl::sycl::queue q(cl::sycl::default_selector_v, cl::sycl::property::queue::in_order{});
-        cl::sycl::event my_kernel_event = q.submit(
-            [&](cl::sycl::handler& h) {
-                h.parallel_for(512, [=](auto i) {});
-            },
-            cl::sycl::detail::code_location{});
-        my_kernel_event.wait();
-    } catch (sycl::exception const& e) {
-        std::cerr << "(NON-FATAL) ERROR: Caught sycl::exception during SYCL dummy kernel!\n";
-        std::cerr << " {what}: " << e.what() << "\n ";
-        std::cerr << "Continuing for now as error only occured in the dummy kernel...\n";
-        return 2;
-
-    }
-    return 1;
-}
+#include "octotiger/sycl_initialization_guard.hpp"
 /// Dummy variable to ensure the touch_sycl_device_by_running_a_dummy_kernel is being run
-const int init_sycl_device = touch_sycl_device_by_running_a_dummy_kernel();
+const int init_sycl_device_hydro =
+    octotiger::sycl_util::touch_sycl_device_by_running_a_dummy_kernel<"hydro_solver">();
 #endif
 #if defined(OCTOTIGER_HAVE_KOKKOS)
 hpx::once_flag init_hydro_kokkos_pool_flag;

--- a/src/unitiger/hydro_impl/hydro_kernel_interface.cpp
+++ b/src/unitiger/hydro_impl/hydro_kernel_interface.cpp
@@ -15,6 +15,43 @@
 #ifdef OCTOTIGER_HAVE_KOKKOS
 #include "octotiger/unitiger/hydro_impl/hydro_kokkos_kernel.hpp"
 #endif
+#if defined(OCTOTIGER_HAVE_KOKKOS) && defined(KOKKOS_ENABLE_SYCL)
+#include <CL/sycl.hpp>
+// We encounter segfaults on Intel GPUs when running the normal kernels for the first time after
+// the program starts. This seems to be some initialization issue as we can simply fix it by
+// (non-concurrently) run simple dummy kernel first right after starting octotiger
+// (presumably initializes something within the intel gpu runtime).
+// Curiousely we have to do this not once per program, but once per lib (octolib and hydrolib).
+//
+// Somewhat of an ugly workaround but it does the trick and allows us to target Intel GPUs as
+// Octo-Tiger runs as expected after applying this workaround.
+
+// TODO(daissgr) Check again in the future to see if the runtime has matured and we don't need this anymore. 
+// (last check was 02/2024)
+
+/// Utility function working around segfault on Intel GPU. Initializes something within the runtime by runnning
+///a dummy kernel
+int touch_sycl_device_by_running_a_dummy_kernel(void) {
+    try {
+        cl::sycl::queue q(cl::sycl::default_selector_v, cl::sycl::property::queue::in_order{});
+        cl::sycl::event my_kernel_event = q.submit(
+            [&](cl::sycl::handler& h) {
+                h.parallel_for(512, [=](auto i) {});
+            },
+            cl::sycl::detail::code_location{});
+        my_kernel_event.wait();
+    } catch (sycl::exception const& e) {
+        std::cerr << "(NON-FATAL) ERROR: Caught sycl::exception during SYCL dummy kernel!\n";
+        std::cerr << " {what}: " << e.what() << "\n ";
+        std::cerr << "Continuing for now as error only occured in the dummy kernel...\n";
+        return 2;
+
+    }
+    return 1;
+}
+/// Dummy variable to ensure the touch_sycl_device_by_running_a_dummy_kernel is being run
+const int init_sycl_device = touch_sycl_device_by_running_a_dummy_kernel();
+#endif
 #if defined(OCTOTIGER_HAVE_KOKKOS)
 hpx::once_flag init_hydro_kokkos_pool_flag;
 #if defined(KOKKOS_ENABLE_CUDA)


### PR DESCRIPTION
I encountered segfaults within the OneAPI runtime when trying to run Octo-Tiger on an Intel GPU Max 1100.  This seems to happen when we call too many kernels asynchronously (or in parallel) when the first kernel is not yet finished (which is basically normal behavior for Octo-Tiger as it launches a massive amount of compute kernels). My best guess is that something gets initialized within the runtime and needs to be done by the time more kernels are being called. 

An easy workaround is to simply call some empty (and synchronous) dummy kernels right at the beginning of Octo-Tiger. Curiously, this is required once per library (hydrolib and octolib) -- however, this workaround resolves the issue entirely, and we can finally run Octo-Tiger properly on the Intel GPUs! Similar workarounds might be required for other HPX applications trying to use OneAPI though (i.e. have one synchronous kernel at the start).