### PR TITLE
Add missing serialize code for polling_threads

### DIFF
--- a/octotiger/options.hpp
+++ b/octotiger/options.hpp
@@ -274,6 +274,7 @@ public:
 		arc & max_kernels_fused;
 	  arc & root_node_on_device;
 	  arc & optimize_local_communication;
+    arc & polling_threads;
     arc & detected_intel_compiler;
     arc & print_times_per_timestep;
 		arc & atomic_mass;


### PR DESCRIPTION
The ```polling_threads``` flag was not being serialized. This PR fixes this.

Might resolve #485.
@JiakunYan Can you check if this PR already helps with this issue?